### PR TITLE
Use strings.Compare in readDir sort

### DIFF
--- a/interp/allowed_paths.go
+++ b/interp/allowed_paths.go
@@ -129,13 +129,7 @@ func (s *pathSandbox) readDir(ctx context.Context, path string) ([]fs.DirEntry, 
 	// os.Root's ReadDir does not guarantee sorted order like os.ReadDir.
 	// Sort to match POSIX glob expansion expectations.
 	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
-		if a.Name() < b.Name() {
-			return -1
-		}
-		if a.Name() > b.Name() {
-			return 1
-		}
-		return 0
+		return strings.Compare(a.Name(), b.Name())
 	})
 	return entries, nil
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4acc8db0-5214-4910-949e-31564e06e1e2","source":"chat","resourceId":"89708a14-f87e-44a1-b4c6-f61bf23abecb","workflowId":"e8802891-7040-4518-9853-a578f1141281","codeChangeId":"e8802891-7040-4518-9853-a578f1141281","sourceType":"chat"} -->
## Summary
Simplify the sort comparator in `readDir` by replacing manual `-1/0/1` branching with `strings.Compare`.

## Changes
- Replaced two-`if`-branch comparator in `interp/allowed_paths.go` with a single `strings.Compare(a.Name(), b.Name())` call.

## Testing
- `go build ./interp/...` passes.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/89708a14-f87e-44a1-b4c6-f61bf23abecb)

Comment @datadog to request changes