### PR TITLE
Remove duplicate noExecHandler assignment in Reset

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -277,9 +277,6 @@ func (r *Runner) Reset() {
 		r.origStdout = r.stdout
 		r.origStderr = r.stderr
 
-		if r.execHandler == nil {
-			r.execHandler = noExecHandler()
-		}
 		// Open os.Root handles and wrap handlers for path restriction.
 		// Default: block all file access (nil sandbox).
 		if r.openHandler == nil {
@@ -289,8 +286,9 @@ func (r *Runner) Reset() {
 			}
 			r.openHandler = r.sandbox.open
 			r.readDirHandler = r.sandbox.readDir
-			// execHandler will be implementer in the future to handle host commands execution
-			// additional safeguard will be needed like Landlock sandbox
+			r.execHandler = noExecHandler()
+		}
+		if r.execHandler == nil {
 			r.execHandler = noExecHandler()
 		}
 	}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"530d700b-01a8-4e0c-84d2-7f17f740515e","source":"chat","resourceId":"80d0cf92-1a14-4f4e-9e27-3221beba132b","workflowId":"ea2a9025-ea7c-4bf7-89f1-7c857a7351e7","codeChangeId":"ea2a9025-ea7c-4bf7-89f1-7c857a7351e7","sourceType":"chat"} -->
## Summary
The `Reset()` function in `interp/api.go` assigned `r.execHandler = noExecHandler()` twice when `r.openHandler == nil` — once before the nil-openHandler block and again inside it, with the second silently overwriting the first.

## Changes
- Removed the first (redundant) `r.execHandler = noExecHandler()` assignment that preceded the `openHandler == nil` block.
- Moved the `execHandler == nil` guard **after** the sandbox block so it only fires when neither the caller nor the sandbox path has set an exec handler.
- Removed the stale TODO comment about future exec-handler work.

## Testing
- `go build ./interp/...` passes.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/80d0cf92-1a14-4f4e-9e27-3221beba132b)

Comment @datadog to request changes