### PR TITLE
Pin AllowedPaths roots during New

### DIFF
--- a/interp/allowed_paths.go
+++ b/interp/allowed_paths.go
@@ -29,8 +29,9 @@ type pathSandbox struct {
 	roots []allowedRoot
 }
 
-// newPathSandbox validates paths and creates a pathSandbox without opening
-// os.Root handles. Call [pathSandbox.openRoots] to activate the sandbox.
+// newPathSandbox validates paths and eagerly opens os.Root handles so the
+// allowed directories are pinned before the caller can modify them between
+// construction and the first run.
 func newPathSandbox(paths []string) (*pathSandbox, error) {
 	roots := make([]allowedRoot, len(paths))
 	for i, p := range paths {
@@ -38,35 +39,23 @@ func newPathSandbox(paths []string) (*pathSandbox, error) {
 		if err != nil {
 			return nil, fmt.Errorf("AllowedPaths: cannot resolve %q: %w", p, err)
 		}
-		info, err := os.Stat(abs)
+		root, err := os.OpenRoot(abs)
 		if err != nil {
-			return nil, fmt.Errorf("AllowedPaths: cannot stat %q: %w", abs, err)
+			for _, prev := range roots[:i] {
+				if prev.root != nil {
+					prev.root.Close()
+				}
+			}
+
+			info, statErr := os.Stat(abs)
+			if statErr == nil && !info.IsDir() {
+				return nil, fmt.Errorf("AllowedPaths: %q is not a directory", abs)
+			}
+			return nil, fmt.Errorf("AllowedPaths: cannot open root %q: %w", abs, err)
 		}
-		if !info.IsDir() {
-			return nil, fmt.Errorf("AllowedPaths: %q is not a directory", abs)
-		}
-		roots[i] = allowedRoot{absPath: abs}
+		roots[i] = allowedRoot{absPath: abs, root: root}
 	}
 	return &pathSandbox{roots: roots}, nil
-}
-
-// openRoots opens os.Root handles for every allowed path. It is a no-op if
-// the handles are already open.
-func (s *pathSandbox) openRoots() error {
-	if s == nil || len(s.roots) == 0 || s.roots[0].root != nil {
-		return nil
-	}
-	for i := range s.roots {
-		root, err := os.OpenRoot(s.roots[i].absPath)
-		if err != nil {
-			for _, prev := range s.roots[:i] {
-				prev.root.Close()
-			}
-			return fmt.Errorf("AllowedPaths: cannot open root %q: %w", s.roots[i].absPath, err)
-		}
-		s.roots[i].root = root
-	}
-	return nil
 }
 
 // resolve returns the matching os.Root and the path relative to it for the
@@ -169,4 +158,3 @@ func AllowedPaths(paths []string) RunnerOption {
 		return nil
 	}
 }
-

--- a/interp/allowed_paths_test.go
+++ b/interp/allowed_paths_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -178,6 +179,41 @@ func TestAllowedPathsDoubleDotFilename(t *testing.T) {
 	assert.Equal(t, "dotdot content\n", stdout)
 }
 
+func TestAllowedPathsPinsRootBeforeRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not applicable on Windows")
+	}
+
+	parent := t.TempDir()
+	allowed := filepath.Join(parent, "allowed")
+	secret := filepath.Join(parent, "secret")
+	require.NoError(t, os.MkdirAll(allowed, 0755))
+	require.NoError(t, os.MkdirAll(secret, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(allowed, "data.txt"), []byte("safe\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(secret, "data.txt"), []byte("secret\n"), 0644))
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader("cat "+filepath.ToSlash(filepath.Join(allowed, "data.txt"))), "")
+	require.NoError(t, err)
+
+	var outBuf, errBuf bytes.Buffer
+	runner, err := interp.New(
+		interp.StdIO(nil, &outBuf, &errBuf),
+		interp.AllowedPaths([]string{allowed}),
+	)
+	require.NoError(t, err)
+	defer runner.Close()
+
+	movedAllowed := filepath.Join(parent, "allowed-moved")
+	require.NoError(t, os.Rename(allowed, movedAllowed))
+	require.NoError(t, os.Symlink(secret, allowed))
+
+	err = runner.Run(context.Background(), prog)
+	require.NoError(t, err)
+	assert.Equal(t, "safe\n", outBuf.String())
+	assert.Empty(t, errBuf.String())
+}
+
 func TestAllowedPathsEmptyBlocksAll(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("test"), 0644))
@@ -199,7 +235,6 @@ func TestAllowedPathsDefaultBlocksAll(t *testing.T) {
 	assert.Contains(t, stderr, "permission denied")
 }
 
-
 func TestAllowedPathsClose(t *testing.T) {
 	dir := t.TempDir()
 	runner, err := interp.New(
@@ -207,7 +242,7 @@ func TestAllowedPathsClose(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Trigger Reset to open roots
+	// Run once so Close is exercised after execution as well as before it.
 	parser := syntax.NewParser()
 	prog, _ := parser.Parse(strings.NewReader("true"), "")
 	_ = runner.Run(context.Background(), prog)

--- a/interp/api.go
+++ b/interp/api.go
@@ -177,6 +177,7 @@ func New(opts ...RunnerOption) (*Runner, error) {
 	}
 	for _, opt := range opts {
 		if err := opt(r); err != nil {
+			_ = r.Close()
 			return nil, err
 		}
 	}
@@ -282,13 +283,10 @@ func (r *Runner) Reset() {
 		r.origStdout = r.stdout
 		r.origStderr = r.stderr
 
-		// Open os.Root handles and wrap handlers for path restriction.
+		// Install sandbox-backed handlers. AllowedPaths opens os.Root handles
+		// eagerly during construction, so there is no filesystem race here.
 		// Default: block all file access (nil sandbox).
 		if r.openHandler == nil {
-			if err := r.sandbox.openRoots(); err != nil {
-				r.exit.fatal(err)
-				return
-			}
 			r.openHandler = r.sandbox.open
 			r.readDirHandler = r.sandbox.readDir
 			r.execHandler = noExecHandler()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3a6a9b2d-bf0f-49ab-ba97-a52acc9b2037","source":"chat","resourceId":"15bcb12f-aec4-4832-8ff7-c1366a8aae92","workflowId":"e3063cde-181d-4a6f-b5cd-a49c32d8af3e","codeChangeId":"e3063cde-181d-4a6f-b5cd-a49c32d8af3e","sourceType":"chat"} -->
### What does this PR do?

Pins `AllowedPaths` roots during sandbox construction instead of first `Run`/`Reset`, closing a TOCTOU window where an allowed directory could be swapped before execution. It also adds a regression test that swaps an allowed directory with a symlink after `interp.New` and verifies the runner stays pinned to the original root.

### Motivation

`AllowedPaths` previously validated directories during `interp.New` but only opened `os.Root` handles later during `Reset`. That left a gap where an attacker could replace an allowed directory path before the first execution and redirect the sandbox to a different tree. This change makes the sandbox pin the root immediately and cleans up opened roots if runner construction fails partway through.

### Testing

- `go test ./interp`
- `go test ./tests`
- `go test ./...`

### Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/15bcb12f-aec4-4832-8ff7-c1366a8aae92)

Comment @datadog to request changes