### PR TITLE
Switch bash comparison test image to debian:bookworm-slim

### DIFF
--- a/tests/scenarios_test.go
+++ b/tests/scenarios_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/DataDog/rshell/interp"
 )
 
-const dockerBashImage = "bash:5.2"
+const dockerBashImage = "debian:bookworm-slim"
 
 // scenario represents a single test scenario.
 type scenario struct {


### PR DESCRIPTION
bash:5.2 uses Alpine/BusyBox head which lacks GNU long-form flags (--lines=N, --bytes=N, --silent). debian:bookworm-slim is an official Docker image (1B+ pulls) with GNU bash 5.2 and GNU coreutils 9.1, giving byte-for-byte GNU compatibility without BusyBox limitations.