### PR TITLE
Add package doc comments to all builtins

### DIFF
--- a/interp/builtins/break/break.go
+++ b/interp/builtins/break/break.go
@@ -3,6 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package breakcmd implements the break builtin command.
+//
+// break — exit from a for, while, or until loop
+//
+// Usage: break [N]
+//
+// Exit from the innermost enclosing loop. If N is specified,
+// break out of N enclosing loops.
+//
+// Exit codes:
+//
+//	0  Loop exited successfully.
+//	1  Not inside a loop, or invalid argument.
 package breakcmd
 
 import (

--- a/interp/builtins/cat/cat.go
+++ b/interp/builtins/cat/cat.go
@@ -3,6 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package cat implements the cat builtin command.
+//
+// cat — concatenate and print files
+//
+// Usage: cat [FILE]...
+//
+// Concatenate FILE(s) to standard output.
+// With no FILE, or when FILE is -, read standard input.
+//
+// Exit codes:
+//
+//	0  All files processed successfully.
+//	1  At least one error occurred (missing file, permission denied, etc.).
 package cat
 
 import (

--- a/interp/builtins/continue/continue.go
+++ b/interp/builtins/continue/continue.go
@@ -3,6 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package continuecmd implements the continue builtin command.
+//
+// continue — resume the next iteration of a for, while, or until loop
+//
+// Usage: continue [N]
+//
+// Resume the next iteration of the innermost enclosing loop. If N is
+// specified, resume the Nth enclosing loop.
+//
+// Exit codes:
+//
+//	0  Iteration resumed successfully.
+//	1  Not inside a loop, or invalid argument.
 package continuecmd
 
 import (

--- a/interp/builtins/echo/echo.go
+++ b/interp/builtins/echo/echo.go
@@ -3,6 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package echo implements the echo builtin command.
+//
+// echo — write arguments to standard output
+//
+// Usage: echo [ARG]...
+//
+// Write each ARG to standard output, separated by a single space,
+// followed by a newline.
+//
+// Exit codes:
+//
+//	0  Always succeeds.
 package echo
 
 import (

--- a/interp/builtins/exit/exit.go
+++ b/interp/builtins/exit/exit.go
@@ -3,6 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package exit implements the exit builtin command.
+//
+// exit — cause the shell to exit
+//
+// Usage: exit [N]
+//
+// Exit the shell with status N. If N is omitted, the exit status is
+// that of the last command executed. If N is not a valid integer, the
+// shell prints an error and exits with status 2.
+//
+// Exit codes:
+//
+//	N    The supplied exit status (truncated to uint8).
+//	2    Invalid (non-numeric) argument.
+//	1    Too many arguments.
 package exit
 
 import (

--- a/interp/builtins/false/false.go
+++ b/interp/builtins/false/false.go
@@ -3,6 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package falsecmd implements the false builtin command.
+//
+// false — return an unsuccessful exit status
+//
+// Usage: false
+//
+// Do nothing and return an exit status of 1. All arguments are ignored.
+//
+// Exit codes:
+//
+//	1  Always fails.
 package falsecmd
 
 import (

--- a/interp/builtins/true/true.go
+++ b/interp/builtins/true/true.go
@@ -3,6 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+// Package truecmd implements the true builtin command.
+//
+// true — return a successful exit status
+//
+// Usage: true
+//
+// Do nothing and return an exit status of 0. All arguments are ignored.
+//
+// Exit codes:
+//
+//	0  Always succeeds.
 package truecmd
 
 import (


### PR DESCRIPTION
<!-- dd-meta {"pullId":"75fcb39d-6544-4ca1-8bf0-d081dbe0de5e","source":"chat","resourceId":"432985c8-935f-4a8b-bc32-1fcc40a79259","workflowId":"d67b4a36-fb67-4733-a46e-da2bef3eb6a5","codeChangeId":"d67b4a36-fb67-4733-a46e-da2bef3eb6a5","sourceType":"chat"} -->
### What does this PR do?

Adds package-level doc comments describing each builtin command to all builtin `.go` files, matching the style already used in `head.go`.

### Motivation

`head.go` already has a comprehensive package doc comment describing the command's purpose, usage, flags, and exit codes. The remaining builtins (cat, echo, break, continue, exit, false, true) were missing these descriptions.

### Testing

- `go build ./interp/builtins/...` passes.

### Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/432985c8-935f-4a8b-bc32-1fcc40a79259)

Comment @datadog to request changes