### PR TITLE
Implement find builtin with all safe flags

### DIFF
--- a/interp/allowed_paths.go
+++ b/interp/allowed_paths.go
@@ -107,6 +107,18 @@ func (s *pathSandbox) open(ctx context.Context, path string, flag int, perm os.F
 	return f, nil
 }
 
+// stat implements the restricted file-stat policy.
+func (s *pathSandbox) stat(ctx context.Context, path string) (fs.FileInfo, error) {
+	absPath := toAbs(path, HandlerCtx(ctx).Dir)
+
+	root, relPath, ok := s.resolve(absPath)
+	if !ok {
+		return nil, &os.PathError{Op: "stat", Path: path, Err: os.ErrPermission}
+	}
+
+	return root.Stat(relPath)
+}
+
 // readDir implements the restricted directory-read policy.
 func (s *pathSandbox) readDir(ctx context.Context, path string) ([]fs.DirEntry, error) {
 	absPath := toAbs(path, HandlerCtx(ctx).Dir)

--- a/interp/builtins/builtins.go
+++ b/interp/builtins/builtins.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 )
 
@@ -30,6 +31,12 @@ type CallContext struct {
 
 	// OpenFile opens a file within the shell's path restrictions.
 	OpenFile func(ctx context.Context, path string, flags int, mode os.FileMode) (io.ReadWriteCloser, error)
+
+	// ReadDir reads directory entries within the shell's path restrictions.
+	ReadDir func(ctx context.Context, path string) ([]fs.DirEntry, error)
+
+	// Stat returns file info within the shell's path restrictions.
+	Stat func(ctx context.Context, path string) (fs.FileInfo, error)
 
 	// PortableErr normalizes an OS error to a POSIX-style message.
 	PortableErr func(err error) string
@@ -88,4 +95,3 @@ func Lookup(name string) (HandlerFunc, bool) {
 	fn, ok := registry[name]
 	return fn, ok
 }
-

--- a/interp/builtins/find/find.go
+++ b/interp/builtins/find/find.go
@@ -1,0 +1,951 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package find implements the find builtin command.
+//
+// find — search for files in a directory hierarchy
+//
+// Usage: find [path...] [expression]
+//
+// Recursively descend directory trees rooted at each given path, evaluating
+// the given expression for each file found. With no path, search the current
+// directory. With no expression, -print is implied.
+//
+// Accepted primaries (tests):
+//
+//	-name pattern
+//	    True if the filename (basename) matches the shell glob pattern.
+//
+//	-iname pattern
+//	    Like -name but case-insensitive.
+//
+//	-path pattern / -wholename pattern
+//	    True if the full path matches the shell glob pattern.
+//
+//	-ipath pattern / -iwholename pattern
+//	    Like -path but case-insensitive.
+//
+//	-type c
+//	    True if the file is of type c: f (regular file), d (directory),
+//	    l (symbolic link), p (named pipe), s (socket), b (block device),
+//	    c (character device).
+//
+//	-empty
+//	    True if the file is empty (zero-length regular file or directory
+//	    with no entries).
+//
+//	-size n[cwbkMG]
+//	    True if the file uses n units of space. Suffixes: c (bytes),
+//	    w (2-byte words), b (512-byte blocks, default), k (KiB), M (MiB),
+//	    G (GiB). Prefix + for greater than, - for less than.
+//
+//	-newer file
+//	    True if the file was modified more recently than file.
+//
+//	-mtime n
+//	    True if the file was modified n*24 hours ago. +n means more than,
+//	    -n means less than, n means exactly.
+//
+//	-perm mode / -perm -mode / -perm /mode
+//	    True if file permission bits match. Plain mode is exact match,
+//	    -mode means all bits set, /mode means any bit set.
+//
+//	-links n
+//	    True if the file has n hard links. +n for more, -n for fewer.
+//
+//	-true
+//	    Always true.
+//
+//	-false
+//	    Always false.
+//
+// Depth control:
+//
+//	-maxdepth n
+//	    Descend at most n directory levels.
+//
+//	-mindepth n
+//	    Do not apply tests or actions at levels less than n.
+//
+// Actions:
+//
+//	-print
+//	    Print the full pathname followed by a newline. This is the default
+//	    action if no action is specified.
+//
+//	-print0
+//	    Print the full pathname followed by a null character.
+//
+//	-prune
+//	    If the file is a directory, do not descend into it. Always true.
+//
+//	-quit
+//	    Exit immediately with status 0.
+//
+// Global options:
+//
+//	-depth
+//	    Process directory contents before the directory itself.
+//
+//	-h, --help
+//	    Print usage and exit.
+//
+// Operators:
+//
+//	( expr )    Grouping.
+//	! expr      Logical NOT (also -not).
+//	expr -a expr   Logical AND (also -and; implicit between primaries).
+//	expr -o expr   Logical OR (also -or).
+//
+// Rejected actions (unsafe):
+//
+//	-exec, -execdir, -ok, -okdir  — execute external commands
+//	-delete                       — delete files
+//	-fprintf, -fprint, -fprint0, -fls — write to files
+//
+// Exit codes:
+//
+//	0  All paths processed successfully.
+//	1  At least one error occurred (missing path, permission denied, etc.).
+//
+// Memory safety:
+//
+//	The walk is streaming — each entry is evaluated and printed immediately
+//	without accumulating results. Recursion depth is bounded to MaxDepth
+//	(200 levels). Total entries visited are bounded to MaxEntries (1M).
+//	All loops check ctx.Err() at each iteration to honour the shell's
+//	execution timeout and to support graceful cancellation.
+package find
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/rshell/interp/builtins"
+)
+
+// Cmd is the find builtin command descriptor.
+var Cmd = builtins.Command{Name: "find", Run: run}
+
+// MaxDepth is the hard limit on directory recursion depth.
+const MaxDepth = 200
+
+// MaxEntries is the hard limit on total entries visited.
+const MaxEntries = 1_000_000
+
+const secondsPerDay = 86400
+
+// maxGlobRecursion limits pathGlobMatch recursion to prevent DoS from
+// pathological patterns like *a*a*a*a*b.
+const maxGlobRecursion = 1000
+
+// unsafeActions are find actions that violate the safety rules (execute, delete, write).
+var unsafeActions = map[string]bool{
+	"-exec":    true,
+	"-execdir": true,
+	"-ok":      true,
+	"-okdir":   true,
+	"-delete":  true,
+	"-fprintf": true,
+	"-fprint":  true,
+	"-fprint0": true,
+	"-fls":     true,
+	"-printf":  true,
+}
+
+type exprKind int
+
+const (
+	kindTest exprKind = iota
+	kindAction
+	kindAnd
+	kindOr
+	kindNot
+	kindPrune
+)
+
+type expr struct {
+	kind  exprKind
+	test  func(path string, info fs.FileInfo, depth int) bool
+	left  *expr
+	right *expr
+	// For actions
+	action func(path string) (quit bool)
+}
+
+type walkState struct {
+	callCtx  *builtins.CallContext
+	ctx      context.Context
+	failed   bool
+	quit     bool
+	prune    bool
+	visited  int
+	depth    bool // -depth option
+	maxdepth int
+	mindepth int
+	root     *expr
+}
+
+func run(ctx context.Context, callCtx *builtins.CallContext, args []string) builtins.Result {
+	if callCtx.ReadDir == nil || callCtx.Stat == nil {
+		callCtx.Errf("find: filesystem access not available\n")
+		return builtins.Result{Code: 1}
+	}
+
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		printHelp(callCtx)
+		return builtins.Result{}
+	}
+
+	for _, arg := range args {
+		if unsafeActions[arg] {
+			callCtx.Errf("find: %s: action not permitted (unsafe)\n", arg)
+			return builtins.Result{Code: 1}
+		}
+	}
+
+	paths, exprArgs := splitPathsAndExpr(args)
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	state := &walkState{
+		callCtx:  callCtx,
+		ctx:      ctx,
+		maxdepth: MaxDepth,
+		mindepth: 0,
+	}
+
+	remaining, err := parseGlobalOptions(state, exprArgs)
+	if err != nil {
+		callCtx.Errf("find: %s\n", err)
+		return builtins.Result{Code: 1}
+	}
+
+	root, parseErr := parseExpr(callCtx, remaining, state)
+	if parseErr != "" {
+		callCtx.Errf("find: %s\n", parseErr)
+		return builtins.Result{Code: 1}
+	}
+	state.root = root
+
+	for _, p := range paths {
+		if ctx.Err() != nil || state.quit {
+			break
+		}
+		info, statErr := callCtx.Stat(ctx, p)
+		if statErr != nil {
+			callCtx.Errf("find: %s: %s\n", p, callCtx.PortableErr(statErr))
+			state.failed = true
+			continue
+		}
+		state.walk(p, info, 0)
+	}
+
+	if state.failed {
+		return builtins.Result{Code: 1}
+	}
+	return builtins.Result{}
+}
+
+func (s *walkState) walk(path string, info fs.FileInfo, depth int) {
+	if s.ctx.Err() != nil || s.quit {
+		return
+	}
+	s.visited++
+	if s.visited > MaxEntries {
+		s.callCtx.Errf("find: entry limit exceeded (%d)\n", MaxEntries)
+		s.failed = true
+		s.quit = true
+		return
+	}
+	if depth > s.maxdepth {
+		return
+	}
+
+	isDir := info.IsDir()
+
+	if !s.depth {
+		s.prune = false
+		if depth >= s.mindepth {
+			s.evalExpr(s.root, path, info, depth)
+		}
+		if s.quit {
+			return
+		}
+		if isDir && !s.prune && depth < s.maxdepth {
+			s.walkDir(path, depth)
+		}
+	} else {
+		if isDir && depth < s.maxdepth {
+			s.walkDir(path, depth)
+		}
+		if s.quit {
+			return
+		}
+		if depth >= s.mindepth {
+			s.evalExpr(s.root, path, info, depth)
+		}
+	}
+}
+
+func (s *walkState) walkDir(path string, depth int) {
+	entries, err := s.callCtx.ReadDir(s.ctx, path)
+	if err != nil {
+		s.callCtx.Errf("find: %s: %s\n", path, s.callCtx.PortableErr(err))
+		s.failed = true
+		return
+	}
+	for _, e := range entries {
+		if s.ctx.Err() != nil || s.quit {
+			return
+		}
+		childPath := path + string(filepath.Separator) + e.Name()
+		childInfo, err := e.Info()
+		if err != nil {
+			s.callCtx.Errf("find: %s: %s\n", childPath, s.callCtx.PortableErr(err))
+			s.failed = true
+			continue
+		}
+		s.walk(childPath, childInfo, depth+1)
+	}
+}
+
+// evalExpr evaluates the expression tree for a file.
+func (s *walkState) evalExpr(e *expr, path string, info fs.FileInfo, depth int) bool {
+	if e == nil {
+		return true
+	}
+	switch e.kind {
+	case kindTest:
+		return e.test(path, info, depth)
+	case kindAction:
+		quit := e.action(path)
+		if quit {
+			s.quit = true
+		}
+		return true
+	case kindPrune:
+		s.prune = true
+		return true
+	case kindAnd:
+		if !s.evalExpr(e.left, path, info, depth) {
+			return false
+		}
+		if s.quit {
+			return true
+		}
+		return s.evalExpr(e.right, path, info, depth)
+	case kindOr:
+		if s.evalExpr(e.left, path, info, depth) {
+			return true
+		}
+		if s.quit {
+			return true
+		}
+		return s.evalExpr(e.right, path, info, depth)
+	case kindNot:
+		return !s.evalExpr(e.left, path, info, depth)
+	}
+	return true
+}
+
+func splitPathsAndExpr(args []string) (paths []string, exprArgs []string) {
+	exprStarts := map[string]bool{
+		"-name": true, "-iname": true,
+		"-path": true, "-ipath": true,
+		"-wholename": true, "-iwholename": true,
+		"-type": true, "-empty": true,
+		"-size": true, "-newer": true,
+		"-mtime": true, "-perm": true,
+		"-links": true, "-true": true, "-false": true,
+		"-maxdepth": true, "-mindepth": true,
+		"-depth": true,
+		"-print": true, "-print0": true,
+		"-prune": true, "-quit": true,
+		"-and": true, "-a": true,
+		"-or": true, "-o": true,
+		"-not": true, "!": true,
+		"(": true, ")": true,
+	}
+	for i, arg := range args {
+		if exprStarts[arg] || unsafeActions[arg] {
+			return args[:i], args[i:]
+		}
+	}
+	return args, nil
+}
+
+func parseGlobalOptions(state *walkState, args []string) (remaining []string, err error) {
+	remaining = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-depth":
+			state.depth = true
+		case "-maxdepth":
+			if i+1 >= len(args) {
+				return nil, errMissingArg("-maxdepth")
+			}
+			i++
+			n, e := strconv.Atoi(args[i])
+			if e != nil || n < 0 {
+				return nil, errInvalidArg{"-maxdepth", args[i]}
+			}
+			if n > MaxDepth {
+				n = MaxDepth
+			}
+			state.maxdepth = n
+		case "-mindepth":
+			if i+1 >= len(args) {
+				return nil, errMissingArg("-mindepth")
+			}
+			i++
+			n, e := strconv.Atoi(args[i])
+			if e != nil || n < 0 {
+				return nil, errInvalidArg{"-mindepth", args[i]}
+			}
+			state.mindepth = n
+		default:
+			remaining = append(remaining, args[i])
+		}
+	}
+	return remaining, nil
+}
+
+func parseExpr(callCtx *builtins.CallContext, args []string, state *walkState) (*expr, string) {
+	if len(args) == 0 {
+		return defaultPrintExpr(callCtx), ""
+	}
+
+	hasAction := false
+	for _, a := range args {
+		if a == "-print" || a == "-print0" || a == "-prune" || a == "-quit" {
+			hasAction = true
+			break
+		}
+	}
+
+	tokens := &tokenStream{args: args}
+	e, errMsg := parseOr(callCtx, tokens, state)
+	if errMsg != "" {
+		return nil, errMsg
+	}
+	if tokens.pos < len(tokens.args) {
+		return nil, "unexpected argument: " + tokens.args[tokens.pos]
+	}
+
+	if !hasAction {
+		printExpr := defaultPrintExpr(callCtx)
+		e = &expr{kind: kindAnd, left: e, right: printExpr}
+	}
+
+	return e, ""
+}
+
+type tokenStream struct {
+	args []string
+	pos  int
+}
+
+func (t *tokenStream) peek() string {
+	if t.pos >= len(t.args) {
+		return ""
+	}
+	return t.args[t.pos]
+}
+
+func (t *tokenStream) next() string {
+	if t.pos >= len(t.args) {
+		return ""
+	}
+	s := t.args[t.pos]
+	t.pos++
+	return s
+}
+
+func parseOr(callCtx *builtins.CallContext, tokens *tokenStream, state *walkState) (*expr, string) {
+	left, errMsg := parseAnd(callCtx, tokens, state)
+	if errMsg != "" {
+		return nil, errMsg
+	}
+	for tokens.peek() == "-o" || tokens.peek() == "-or" {
+		tokens.next()
+		right, errMsg := parseAnd(callCtx, tokens, state)
+		if errMsg != "" {
+			return nil, errMsg
+		}
+		left = &expr{kind: kindOr, left: left, right: right}
+	}
+	return left, ""
+}
+
+func parseAnd(callCtx *builtins.CallContext, tokens *tokenStream, state *walkState) (*expr, string) {
+	left, errMsg := parseUnary(callCtx, tokens, state)
+	if errMsg != "" {
+		return nil, errMsg
+	}
+	for {
+		pk := tokens.peek()
+		if pk == "-a" || pk == "-and" {
+			tokens.next()
+		} else if pk == "" || pk == "-o" || pk == "-or" || pk == ")" {
+			break
+		} else {
+			// implicit AND
+		}
+		right, errMsg := parseUnary(callCtx, tokens, state)
+		if errMsg != "" {
+			return nil, errMsg
+		}
+		left = &expr{kind: kindAnd, left: left, right: right}
+	}
+	return left, ""
+}
+
+func parseUnary(callCtx *builtins.CallContext, tokens *tokenStream, state *walkState) (*expr, string) {
+	pk := tokens.peek()
+	if pk == "!" || pk == "-not" {
+		tokens.next()
+		operand, errMsg := parseUnary(callCtx, tokens, state)
+		if errMsg != "" {
+			return nil, errMsg
+		}
+		return &expr{kind: kindNot, left: operand}, ""
+	}
+	return parsePrimary(callCtx, tokens, state)
+}
+
+func parsePrimary(callCtx *builtins.CallContext, tokens *tokenStream, state *walkState) (*expr, string) {
+	tok := tokens.peek()
+	if tok == "" {
+		return nil, "expected expression"
+	}
+
+	if tok == "(" {
+		tokens.next()
+		e, errMsg := parseOr(callCtx, tokens, state)
+		if errMsg != "" {
+			return nil, errMsg
+		}
+		if tokens.next() != ")" {
+			return nil, "missing closing ')'"
+		}
+		return e, ""
+	}
+
+	tokens.next()
+	switch tok {
+	case "-name":
+		return parseName(tokens, false)
+	case "-iname":
+		return parseName(tokens, true)
+	case "-path", "-wholename":
+		return parsePath(tokens, false)
+	case "-ipath", "-iwholename":
+		return parsePath(tokens, true)
+	case "-type":
+		return parseType(tokens)
+	case "-empty":
+		return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+			if info.Mode().IsRegular() {
+				return info.Size() == 0
+			}
+			if info.IsDir() {
+				entries, err := callCtx.ReadDir(state.ctx, path)
+				return err == nil && len(entries) == 0
+			}
+			return false
+		}}, ""
+	case "-size":
+		return parseSize(tokens)
+	case "-newer":
+		return parseNewer(callCtx, tokens, state)
+	case "-mtime":
+		return parseMtime(tokens)
+	case "-perm":
+		return parsePerm(tokens)
+	case "-links":
+		return parseLinks(tokens)
+	case "-true":
+		return &expr{kind: kindTest, test: func(string, fs.FileInfo, int) bool { return true }}, ""
+	case "-false":
+		return &expr{kind: kindTest, test: func(string, fs.FileInfo, int) bool { return false }}, ""
+	case "-print":
+		return defaultPrintExpr(callCtx), ""
+	case "-print0":
+		return &expr{kind: kindAction, action: func(path string) bool {
+			callCtx.Outf("%s\x00", path)
+			return false
+		}}, ""
+	case "-prune":
+		return &expr{kind: kindPrune}, ""
+	case "-quit":
+		return &expr{kind: kindAction, action: func(string) bool { return true }}, ""
+	default:
+		if unsafeActions[tok] {
+			return nil, tok + ": action not permitted (unsafe)"
+		}
+		return nil, "unknown primary: " + tok
+	}
+}
+
+func parseName(tokens *tokenStream, caseInsensitive bool) (*expr, string) {
+	pattern := tokens.next()
+	if pattern == "" {
+		return nil, "missing argument to -name"
+	}
+	matchPattern := pattern
+	if caseInsensitive {
+		matchPattern = strings.ToLower(pattern)
+	}
+	if _, err := filepath.Match(matchPattern, ""); err != nil {
+		return nil, "invalid pattern: " + pattern
+	}
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		name := info.Name()
+		if caseInsensitive {
+			name = strings.ToLower(name)
+		}
+		matched, _ := filepath.Match(matchPattern, name)
+		return matched
+	}}, ""
+}
+
+func parsePath(tokens *tokenStream, caseInsensitive bool) (*expr, string) {
+	pattern := tokens.next()
+	if pattern == "" {
+		return nil, "missing argument to -path"
+	}
+	matchPattern := pattern
+	if caseInsensitive {
+		matchPattern = strings.ToLower(pattern)
+	}
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		p := filepath.ToSlash(path)
+		if caseInsensitive {
+			p = strings.ToLower(p)
+		}
+		return pathGlobMatch(matchPattern, p)
+	}}, ""
+}
+
+func parseType(tokens *tokenStream) (*expr, string) {
+	typeArg := tokens.next()
+	if typeArg == "" {
+		return nil, "missing argument to -type"
+	}
+	types := make(map[byte]bool)
+	for _, part := range strings.Split(typeArg, ",") {
+		if len(part) != 1 {
+			return nil, "invalid type: " + typeArg
+		}
+		c := part[0]
+		switch c {
+		case 'f', 'd', 'l', 'p', 's', 'b', 'c':
+			types[c] = true
+		default:
+			return nil, "invalid type: " + typeArg
+		}
+	}
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		mode := info.Mode()
+		switch {
+		case mode.IsRegular():
+			return types['f']
+		case mode.IsDir():
+			return types['d']
+		case mode&os.ModeSymlink != 0:
+			return types['l']
+		case mode&os.ModeNamedPipe != 0:
+			return types['p']
+		case mode&os.ModeSocket != 0:
+			return types['s']
+		case mode&os.ModeDevice != 0 && mode&os.ModeCharDevice == 0:
+			return types['b']
+		case mode&os.ModeCharDevice != 0:
+			return types['c']
+		}
+		return false
+	}}, ""
+}
+
+func parseSize(tokens *tokenStream) (*expr, string) {
+	sizeArg := tokens.next()
+	if sizeArg == "" {
+		return nil, "missing argument to -size"
+	}
+	cmp, rest := parseNumericPrefix(sizeArg)
+
+	var unitBytes int64 = 512 // default: 512-byte blocks
+	if len(rest) > 0 {
+		lastChar := rest[len(rest)-1]
+		switch lastChar {
+		case 'c':
+			unitBytes = 1
+			rest = rest[:len(rest)-1]
+		case 'w':
+			unitBytes = 2
+			rest = rest[:len(rest)-1]
+		case 'b':
+			unitBytes = 512
+			rest = rest[:len(rest)-1]
+		case 'k':
+			unitBytes = 1024
+			rest = rest[:len(rest)-1]
+		case 'M':
+			unitBytes = 1024 * 1024
+			rest = rest[:len(rest)-1]
+		case 'G':
+			unitBytes = 1024 * 1024 * 1024
+			rest = rest[:len(rest)-1]
+		default:
+			if lastChar < '0' || lastChar > '9' {
+				return nil, "invalid size: " + sizeArg
+			}
+		}
+	}
+
+	n, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || n < 0 {
+		return nil, "invalid size: " + sizeArg
+	}
+
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		size := info.Size()
+		var fileUnits int64
+		if unitBytes == 1 {
+			fileUnits = size
+		} else {
+			fileUnits = size/unitBytes + boolToInt64(size%unitBytes != 0)
+		}
+		return compareNumeric(cmp, fileUnits, n)
+	}}, ""
+}
+
+func parseNewer(callCtx *builtins.CallContext, tokens *tokenStream, state *walkState) (*expr, string) {
+	refFile := tokens.next()
+	if refFile == "" {
+		return nil, "missing argument to -newer"
+	}
+	refInfo, err := callCtx.Stat(state.ctx, refFile)
+	if err != nil {
+		return nil, "cannot stat " + refFile + ": " + callCtx.PortableErr(err)
+	}
+	refTime := refInfo.ModTime()
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		return info.ModTime().After(refTime)
+	}}, ""
+}
+
+func parseMtime(tokens *tokenStream) (*expr, string) {
+	mtimeArg := tokens.next()
+	if mtimeArg == "" {
+		return nil, "missing argument to -mtime"
+	}
+	cmp, rest := parseNumericPrefix(mtimeArg)
+	n, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || n < 0 {
+		return nil, "invalid argument to -mtime: " + mtimeArg
+	}
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		// Age in days (fractional days rounded down, GNU find style)
+		ageSec := currentTime().Sub(info.ModTime()).Seconds()
+		ageDays := int64(ageSec / secondsPerDay)
+		return compareNumeric(cmp, ageDays, n)
+	}}, ""
+}
+
+func parsePerm(tokens *tokenStream) (*expr, string) {
+	permArg := tokens.next()
+	if permArg == "" {
+		return nil, "missing argument to -perm"
+	}
+
+	mode := permArg
+	matchAny := false
+	matchAll := false
+	if strings.HasPrefix(mode, "/") {
+		matchAny = true
+		mode = mode[1:]
+	} else if strings.HasPrefix(mode, "-") {
+		matchAll = true
+		mode = mode[1:]
+	}
+
+	perm, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return nil, "invalid mode: " + permArg
+	}
+	permBits := os.FileMode(perm)
+
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		filePerm := info.Mode().Perm()
+		if matchAll {
+			return filePerm&permBits == permBits
+		}
+		if matchAny {
+			if permBits == 0 {
+				return true
+			}
+			return filePerm&permBits != 0
+		}
+		return filePerm == permBits
+	}}, ""
+}
+
+func parseLinks(tokens *tokenStream) (*expr, string) {
+	linksArg := tokens.next()
+	if linksArg == "" {
+		return nil, "missing argument to -links"
+	}
+	cmp, rest := parseNumericPrefix(linksArg)
+	n, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || n < 0 {
+		return nil, "invalid argument to -links: " + linksArg
+	}
+	return &expr{kind: kindTest, test: func(path string, info fs.FileInfo, depth int) bool {
+		return compareNumeric(cmp, nlinks(info), n)
+	}}, ""
+}
+
+type numericComparison int
+
+const (
+	cmpExact numericComparison = iota
+	cmpGreater
+	cmpLess
+)
+
+func parseNumericPrefix(s string) (numericComparison, string) {
+	if len(s) > 0 {
+		switch s[0] {
+		case '+':
+			return cmpGreater, s[1:]
+		case '-':
+			return cmpLess, s[1:]
+		}
+	}
+	return cmpExact, s
+}
+
+func compareNumeric(cmp numericComparison, actual, expected int64) bool {
+	switch cmp {
+	case cmpGreater:
+		return actual > expected
+	case cmpLess:
+		return actual < expected
+	default:
+		return actual == expected
+	}
+}
+
+func boolToInt64(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func defaultPrintExpr(callCtx *builtins.CallContext) *expr {
+	return &expr{kind: kindAction, action: func(path string) bool {
+		callCtx.Outf("%s\n", path)
+		return false
+	}}
+}
+
+func printHelp(callCtx *builtins.CallContext) {
+	callCtx.Out("Usage: find [path...] [expression]\n")
+	callCtx.Out("Search for files in a directory hierarchy.\n\n")
+	callCtx.Out("Tests: -name, -iname, -path, -ipath, -wholename, -iwholename,\n")
+	callCtx.Out("       -type, -empty, -size, -newer, -mtime, -perm, -links,\n")
+	callCtx.Out("       -true, -false\n")
+	callCtx.Out("Actions: -print, -print0, -prune, -quit\n")
+	callCtx.Out("Options: -maxdepth N, -mindepth N, -depth\n")
+	callCtx.Out("Operators: ( ), !, -not, -a, -and, -o, -or\n\n")
+	callCtx.Out("  -h, --help   print usage and exit\n")
+}
+
+// pathGlobMatch matches a path against a glob pattern where '*' matches any
+// character including path separators (unlike filepath.Match).
+func pathGlobMatch(pattern, name string) bool {
+	return pathGlobMatchDepth(pattern, name, 0)
+}
+
+func pathGlobMatchDepth(pattern, name string, depth int) bool {
+	if depth > maxGlobRecursion {
+		return false
+	}
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			pattern = pattern[1:]
+			if len(pattern) == 0 {
+				return true
+			}
+			for i := 0; i <= len(name); i++ {
+				if pathGlobMatchDepth(pattern, name[i:], depth+1) {
+					return true
+				}
+			}
+			return false
+		case '?':
+			if len(name) == 0 {
+				return false
+			}
+			pattern = pattern[1:]
+			name = name[1:]
+		case '\\':
+			pattern = pattern[1:]
+			if len(pattern) == 0 {
+				return false
+			}
+			if len(name) == 0 || pattern[0] != name[0] {
+				return false
+			}
+			pattern = pattern[1:]
+			name = name[1:]
+		case '[':
+			if len(name) == 0 {
+				return false
+			}
+			end := strings.IndexByte(pattern, ']')
+			if end < 0 {
+				return false
+			}
+			matched, _ := filepath.Match(pattern[:end+1], string(name[0]))
+			if !matched {
+				return false
+			}
+			pattern = pattern[end+1:]
+			name = name[1:]
+		default:
+			if len(name) == 0 || pattern[0] != name[0] {
+				return false
+			}
+			pattern = pattern[1:]
+			name = name[1:]
+		}
+	}
+	return len(name) == 0
+}
+
+type errMissingArg string
+
+func (e errMissingArg) Error() string {
+	return "missing argument to " + string(e)
+}
+
+type errInvalidArg struct {
+	flag string
+	val  string
+}
+
+func (e errInvalidArg) Error() string {
+	return "invalid argument " + e.val + " to " + e.flag
+}

--- a/interp/builtins/find/find_gnu_compat_test.go
+++ b/interp/builtins/find/find_gnu_compat_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// GNU compatibility tests for the find builtin.
+//
+// Expected outputs were captured from GNU findutils find 4.10.0
+// (Debian bookworm) and are embedded as string literals so the tests
+// run without any GNU tooling present on CI.
+
+package find_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGNUCompatFindDefaultPrintsDot — find with no arguments prints "." and all entries.
+//
+// GNU command: find  (in a directory with one file)
+// Expected:    ".\n./file.txt\n"
+func TestGNUCompatFindDefaultPrintsDot(t *testing.T) {
+	dir := setupDir(t, map[string]string{"file.txt": "hello\n"})
+	stdout, _, code := cmdRun(t, "find", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, ".\n./file.txt\n", stdout)
+}
+
+// TestGNUCompatFindNameGlob — -name "*.txt" filters by extension.
+//
+// GNU command: find . -name "*.txt"  (dir has a.txt, b.log)
+// Expected:    "./a.txt\n"
+func TestGNUCompatFindNameGlob(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+		"b.log": "b",
+	})
+	stdout, _, code := cmdRun(t, `find . -name "*.txt"`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "./a.txt\n", stdout)
+}
+
+// TestGNUCompatFindTypeF — -type f lists only regular files.
+//
+// GNU command: find . -type f  (dir has a.txt and subdir)
+// Expected:    "./a.txt\n"
+func TestGNUCompatFindTypeF(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -type f", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "./a.txt\n", stdout)
+}
+
+// TestGNUCompatFindTypeD — -type d lists only directories.
+//
+// GNU command: find . -type d  (dir has a.txt and sub/)
+// Expected:    ".\n./sub\n"
+func TestGNUCompatFindTypeD(t *testing.T) {
+	dir := setupDir(t, map[string]string{"sub/a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -type d", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, ".\n./sub\n", stdout)
+}
+
+// TestGNUCompatFindMaxdepthZero — -maxdepth 0 prints only starting point.
+//
+// GNU command: find . -maxdepth 0
+// Expected:    ".\n"
+func TestGNUCompatFindMaxdepthZero(t *testing.T) {
+	dir := setupDir(t, map[string]string{"file.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -maxdepth 0", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, ".\n", stdout)
+}
+
+// TestGNUCompatFindMaxdepthOne — -maxdepth 1 lists starting point and direct children.
+//
+// GNU command: find . -maxdepth 1  (with file.txt and sub/deep.txt)
+// Expected:    ".\n./file.txt\n./sub\n"
+func TestGNUCompatFindMaxdepthOne(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":     "a",
+		"sub/deep.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find . -maxdepth 1", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, ".\n./file.txt\n./sub\n", stdout)
+}
+
+// TestGNUCompatFindPrint0 — -print0 separates with null byte.
+//
+// GNU command: find . -name "a.txt" -print0
+// Expected:    "./a.txt\x00"
+func TestGNUCompatFindPrint0(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, `find . -name "a.txt" -print0`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "./a.txt\x00", stdout)
+}
+
+// TestGNUCompatFindFalse — -false produces no output.
+//
+// GNU command: find . -false
+// Expected:    ""
+func TestGNUCompatFindFalse(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -false", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+// TestGNUCompatFindNotName — ! -name filters out matches.
+//
+// GNU command: find . -type f ! -name "*.log"
+// Expected:    "./a.txt\n"
+func TestGNUCompatFindNotName(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+		"b.log": "b",
+	})
+	stdout, _, code := cmdRun(t, `find . -type f ! -name "*.log"`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "./a.txt\n", stdout)
+}

--- a/interp/builtins/find/find_pentest_test.go
+++ b/interp/builtins/find/find_pentest_test.go
@@ -1,0 +1,264 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package find_test
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+)
+
+// --- Integer edge cases ---
+
+func TestFindPentestMaxdepthLargeValue(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -maxdepth 999999", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "a.txt")
+}
+
+func TestFindPentestMaxdepthIntOverflow(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -maxdepth "+strconv.FormatInt(math.MaxInt64, 10)+"0", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindPentestMaxdepthNegative(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -maxdepth -1", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindPentestMindepthLargeValue(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -mindepth 999999", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+func TestFindPentestSizeLargeValue(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -type f -size +999999999c", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+func TestFindPentestSizeZero(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -type f -size 0c", dir)
+	assert.Equal(t, 0, code)
+	assert.NotContains(t, stdout, "a.txt")
+}
+
+func TestFindPentestMtimeZero(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -type f -mtime 0", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "a.txt")
+}
+
+func TestFindPentestLinksZero(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find . -type f -links 0", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+func TestFindPentestPermInvalid(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -perm abc", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+// --- Unsafe flag rejection ---
+
+func TestFindPentestRejectAllUnsafe(t *testing.T) {
+	unsafeFlags := []string{
+		"-exec", "-execdir", "-ok", "-okdir",
+		"-delete", "-fprintf", "-fprint", "-fprint0", "-fls",
+		"-printf",
+	}
+	dir := t.TempDir()
+	for _, flag := range unsafeFlags {
+		t.Run(flag, func(t *testing.T) {
+			_, stderr, code := cmdRun(t, "find . "+flag, dir)
+			assert.Equal(t, 1, code, "flag %s should be rejected", flag)
+			assert.Contains(t, stderr, "not permitted", "flag %s should mention 'not permitted'", flag)
+		})
+	}
+}
+
+// --- Flag and argument injection ---
+
+func TestFindPentestUnknownFlag(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -nosuchflag", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindPentestEndOfFlags(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "-name"), []byte("tricky"), 0644))
+	stdout, _, code := cmdRun(t, "find . -name '-name'", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "-name")
+}
+
+func TestFindPentestEmptyNamePattern(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	// Empty pattern passed via shell quotes — parseName returns error for empty arg
+	_, stderr, code := cmdRun(t, "find . -name ''", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+// --- Path edge cases ---
+
+func TestFindPentestNonExistentPath(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find nonexistent_xyz", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindPentestDotSlashPath(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find .", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "./a.txt")
+}
+
+func TestFindPentestAbsolutePath(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	stdout, _, code := cmdRun(t, "find "+dir, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "a.txt")
+}
+
+// --- Symlinks ---
+
+func TestFindPentestSymlinkToFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.txt"), []byte("data"), 0644))
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(dir, "link.txt")))
+	stdout, _, code := cmdRun(t, "find . -type f", dir)
+	assert.Equal(t, 0, code)
+	// Both real file and symlink should be reported (symlink followed for stat)
+	assert.Contains(t, stdout, "real.txt")
+}
+
+func TestFindPentestDanglingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink("nonexistent", filepath.Join(dir, "dangling")))
+	_, stderr, code := cmdRun(t, "find .", dir)
+	// Dangling symlink stat will fail; find should report error and continue
+	_ = code
+	_ = stderr
+}
+
+// --- Context timeout ---
+
+func TestFindPentestTimeout(t *testing.T) {
+	dir := setupDir(t, map[string]string{"a.txt": "a"})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, _, _ = runScriptCtx(ctx, t, "find .", dir, interp.AllowedPaths([]string{dir}))
+	// Just verify it doesn't hang
+}
+
+// --- Large directory ---
+
+func TestFindPentestManyFiles(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 100; i++ {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "file"+strconv.Itoa(i)+".txt"),
+			[]byte("data"), 0644))
+	}
+	stdout, _, code := cmdRun(t, "find . -type f", dir)
+	assert.Equal(t, 0, code)
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	assert.Equal(t, 100, len(lines))
+}
+
+// --- Pathological glob pattern ---
+
+func TestFindPentestPathologicalGlob(t *testing.T) {
+	dir := setupDir(t, map[string]string{"aaaaaa": "a"})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Pattern with multiple wildcards that would cause exponential backtracking
+	stdout, _, code := runScriptCtx(ctx, t,
+		"find . -path '*a*a*a*a*b'",
+		dir, interp.AllowedPaths([]string{dir}))
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout) // no match, but must not hang
+}
+
+// --- Expression edge cases ---
+
+func TestFindPentestMissingCloseParen(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `find . \( -type f`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindPentestExtraCloseParen(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `find . -type f \)`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindPentestMultiplePaths(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a/file.txt": "a",
+		"b/file.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find a b -type f", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "a/file.txt")
+	assert.Contains(t, stdout, "b/file.txt")
+}
+
+func TestFindPentestSizeWithSuffix(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"small.txt": "hi",
+	})
+	// "hi" = 2 bytes; in 1k blocks = 1 block. -size +0k matches files with > 0 blocks.
+	stdout, _, code := cmdRun(t, "find . -type f -size +0k", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "small.txt")
+}
+
+func TestFindPentestInvalidSizeSuffix(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -size 1X", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}

--- a/interp/builtins/find/find_test.go
+++ b/interp/builtins/find/find_test.go
@@ -1,0 +1,505 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package find_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+	"github.com/DataDog/rshell/interp/builtins/testutil"
+)
+
+func runScriptCtx(ctx context.Context, t *testing.T, script, dir string, opts ...interp.RunnerOption) (string, string, int) {
+	t.Helper()
+	return testutil.RunScriptCtx(ctx, t, script, dir, opts...)
+}
+
+func runScript(t *testing.T, script, dir string, opts ...interp.RunnerOption) (string, string, int) {
+	t.Helper()
+	return testutil.RunScript(t, script, dir, opts...)
+}
+
+func cmdRun(t *testing.T, script, dir string) (string, string, int) {
+	t.Helper()
+	return runScript(t, script, dir, interp.AllowedPaths([]string{dir}))
+}
+
+func setupDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		p := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0755))
+		require.NoError(t, os.WriteFile(p, []byte(content), 0644))
+	}
+	return dir
+}
+
+func sortedLines(s string) []string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	sort.Strings(lines)
+	return lines
+}
+
+// --- Default behavior ---
+
+func TestFindDefaultCurrentDir(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":       "hello",
+		"sub/nested.txt": "world",
+	})
+	stdout, _, code := cmdRun(t, "find", dir)
+	assert.Equal(t, 0, code)
+	lines := sortedLines(stdout)
+	assert.Contains(t, lines, ".")
+	assert.Contains(t, lines, "./file.txt")
+	assert.Contains(t, lines, "./sub")
+	assert.Contains(t, lines, "./sub/nested.txt")
+}
+
+func TestFindExplicitPath(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"dir/a.txt": "a",
+		"dir/b.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find dir", dir)
+	assert.Equal(t, 0, code)
+	lines := sortedLines(stdout)
+	assert.Contains(t, lines, "dir")
+	assert.Contains(t, lines, "dir/a.txt")
+	assert.Contains(t, lines, "dir/b.txt")
+}
+
+func TestFindEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, "find .", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, ".\n", stdout)
+}
+
+// --- -name ---
+
+func TestFindNameGlob(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"hello.txt":     "a",
+		"world.log":     "b",
+		"sub/hello.txt": "c",
+	})
+	stdout, _, code := cmdRun(t, `find . -name "*.txt"`, dir)
+	assert.Equal(t, 0, code)
+	lines := sortedLines(stdout)
+	assert.Contains(t, lines, "./hello.txt")
+	assert.Contains(t, lines, "./sub/hello.txt")
+	for _, l := range lines {
+		assert.NotContains(t, l, "world.log")
+	}
+}
+
+func TestFindNameExact(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"target.txt": "a",
+		"other.txt":  "b",
+	})
+	stdout, _, code := cmdRun(t, `find . -name target.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "target.txt")
+	assert.NotContains(t, stdout, "other.txt")
+}
+
+// --- -iname ---
+
+func TestFindIname(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"Hello.TXT": "a",
+		"world.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, `find . -iname "hello*"`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "Hello.TXT")
+}
+
+// --- -type ---
+
+func TestFindTypeFile(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":       "a",
+		"sub/nested.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find . -type f", dir)
+	assert.Equal(t, 0, code)
+	lines := sortedLines(stdout)
+	for _, l := range lines {
+		assert.NotEqual(t, ".", l)
+		assert.NotEqual(t, "./sub", l)
+	}
+	assert.Contains(t, lines, "./file.txt")
+	assert.Contains(t, lines, "./sub/nested.txt")
+}
+
+func TestFindTypeDir(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":       "a",
+		"sub/nested.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find . -type d", dir)
+	assert.Equal(t, 0, code)
+	lines := sortedLines(stdout)
+	assert.Contains(t, lines, ".")
+	assert.Contains(t, lines, "./sub")
+	for _, l := range lines {
+		assert.False(t, strings.HasSuffix(l, ".txt"), "should not contain files: %s", l)
+	}
+}
+
+// --- -empty ---
+
+func TestFindEmptyFile(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"empty.txt":    "",
+		"nonempty.txt": "data",
+	})
+	stdout, _, code := cmdRun(t, "find . -empty -type f", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "empty.txt")
+	assert.NotContains(t, stdout, "nonempty.txt")
+}
+
+// --- -size ---
+
+func TestFindSizeBytes(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"empty.txt": "",
+		"data.txt":  "some data here",
+	})
+	stdout, _, code := cmdRun(t, "find . -type f -size +0c", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "data.txt")
+	assert.NotContains(t, stdout, "empty.txt")
+}
+
+func TestFindSizeExact(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"five.txt": "hello",
+	})
+	stdout, _, code := cmdRun(t, "find . -type f -size 5c", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "five.txt")
+}
+
+// --- -maxdepth / -mindepth ---
+
+func TestFindMaxdepthZero(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":       "a",
+		"sub/nested.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find . -maxdepth 0", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, ".\n", stdout)
+}
+
+func TestFindMaxdepthOne(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":            "a",
+		"sub/deep/deeper.txt": "b",
+	})
+	stdout, _, code := cmdRun(t, "find . -maxdepth 1 -type f", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "file.txt")
+	assert.NotContains(t, stdout, "deeper.txt")
+}
+
+func TestFindMindepthOne(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt": "a",
+	})
+	stdout, _, code := cmdRun(t, "find . -mindepth 1 -maxdepth 1", dir)
+	assert.Equal(t, 0, code)
+	assert.NotContains(t, stdout, ".\n")
+	assert.Contains(t, stdout, "file.txt")
+}
+
+// --- -print0 ---
+
+func TestFindPrint0(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+	})
+	stdout, _, code := cmdRun(t, `find . -name "a.txt" -print0`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "./a.txt\x00", stdout)
+}
+
+// --- Operators ---
+
+func TestFindOrOperator(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+		"b.txt": "b",
+		"c.log": "c",
+	})
+	stdout, _, code := cmdRun(t, `find . -name a.txt -o -name b.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "a.txt")
+	assert.Contains(t, stdout, "b.txt")
+	assert.NotContains(t, stdout, "c.log")
+}
+
+func TestFindNotOperator(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+		"b.log": "b",
+	})
+	stdout, _, code := cmdRun(t, `find . -type f ! -name "*.txt"`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "b.log")
+	assert.NotContains(t, stdout, "a.txt")
+}
+
+func TestFindGrouping(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+		"b.txt": "b",
+		"c.log": "c",
+	})
+	stdout, _, code := cmdRun(t, `find . -type f \( -name a.txt -o -name c.log \)`, dir)
+	assert.Equal(t, 0, code)
+	lines := sortedLines(stdout)
+	assert.Contains(t, lines, "./a.txt")
+	assert.Contains(t, lines, "./c.log")
+	for _, l := range lines {
+		assert.NotContains(t, l, "b.txt")
+	}
+}
+
+// --- -path / -wholename ---
+
+func TestFindPath(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"sub/hello.txt": "a",
+		"other.txt":     "b",
+	})
+	stdout, _, code := cmdRun(t, "find . -path './sub/*'", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "sub/hello.txt")
+	assert.NotContains(t, stdout, "other.txt")
+}
+
+// --- -newer ---
+
+func TestFindNewer(t *testing.T) {
+	dir := t.TempDir()
+	oldFile := filepath.Join(dir, "old.txt")
+	require.NoError(t, os.WriteFile(oldFile, []byte("old"), 0644))
+	newFile := filepath.Join(dir, "new.txt")
+	require.NoError(t, os.WriteFile(newFile, []byte("new"), 0644))
+	stdout, _, code := cmdRun(t, "find . -newer old.txt -type f", dir)
+	assert.Equal(t, 0, code)
+	// new.txt may or may not be newer depending on timing;
+	// at minimum, no error should occur
+	_ = stdout
+}
+
+// --- -prune ---
+
+func TestFindPrune(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt":           "a",
+		"skip/hidden.txt":    "b",
+		"skip/deep/deep.txt": "c",
+	})
+	stdout, _, code := cmdRun(t, `find . -name skip -prune -o -type f -print`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "file.txt")
+	assert.NotContains(t, stdout, "hidden.txt")
+	assert.NotContains(t, stdout, "deep.txt")
+}
+
+// --- -quit ---
+
+func TestFindQuit(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+		"b.txt": "b",
+		"c.txt": "c",
+	})
+	stdout, _, code := cmdRun(t, `find . -type f -quit`, dir)
+	assert.Equal(t, 0, code)
+	// Should only print the first file found
+	lines := sortedLines(stdout)
+	assert.LessOrEqual(t, len(lines), 1)
+}
+
+// --- -depth ---
+
+func TestFindDepthOption(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"sub/file.txt": "a",
+	})
+	stdout, _, code := cmdRun(t, "find . -depth", dir)
+	assert.Equal(t, 0, code)
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	// In -depth mode, files come before their parent directories.
+	// So "." should be the last line.
+	if len(lines) > 0 {
+		assert.Equal(t, ".", lines[len(lines)-1])
+	}
+}
+
+// --- -perm ---
+
+func TestFindPermExact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not meaningful on Windows")
+	}
+	dir := t.TempDir()
+	f := filepath.Join(dir, "script.sh")
+	require.NoError(t, os.WriteFile(f, []byte("#!/bin/sh"), 0755))
+	f2 := filepath.Join(dir, "data.txt")
+	require.NoError(t, os.WriteFile(f2, []byte("data"), 0644))
+	stdout, _, code := cmdRun(t, "find . -type f -perm 0755", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "script.sh")
+	assert.NotContains(t, stdout, "data.txt")
+}
+
+// --- -links ---
+
+func TestFindLinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard links have different semantics on Windows")
+	}
+	dir := setupDir(t, map[string]string{
+		"file.txt": "hello",
+	})
+	stdout, _, code := cmdRun(t, "find . -type f -links 1", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "file.txt")
+}
+
+// --- -true / -false ---
+
+func TestFindTrue(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt": "a",
+	})
+	stdout, _, code := cmdRun(t, "find . -true", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, ".")
+	assert.Contains(t, stdout, "file.txt")
+}
+
+func TestFindFalse(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"file.txt": "a",
+	})
+	stdout, _, code := cmdRun(t, "find . -false", dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+// --- Error cases ---
+
+func TestFindMissingPath(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find nonexistent_xyz", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindRejectExec(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `find . -exec ls {} \;`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "not permitted")
+}
+
+func TestFindRejectDelete(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -delete", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "not permitted")
+}
+
+func TestFindRejectExecdir(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `find . -execdir ls {} \;`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "not permitted")
+}
+
+func TestFindHelp(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, "find --help", dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "Usage:")
+}
+
+func TestFindInvalidName(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `find . -name "[invalid"`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindMissingNameArg(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -name", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindInvalidType(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -type x", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindInvalidMaxdepth(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -maxdepth abc", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindNegativeMaxdepth(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -maxdepth -1", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+func TestFindUnknownPrimary(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, "find . -nosuchprimary", dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "find:")
+}
+
+// --- Context cancellation ---
+
+func TestFindContextCancellation(t *testing.T) {
+	dir := setupDir(t, map[string]string{
+		"a.txt": "a",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	_, _, code := runScriptCtx(ctx, t, "find .", dir, interp.AllowedPaths([]string{dir}))
+	_ = code // just verify no hang
+}

--- a/interp/builtins/find/nlinks_unix.go
+++ b/interp/builtins/find/nlinks_unix.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build unix
+
+package find
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+func nlinks(info fs.FileInfo) int64 {
+	if sys, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int64(sys.Nlink)
+	}
+	return 1
+}

--- a/interp/builtins/find/nlinks_windows.go
+++ b/interp/builtins/find/nlinks_windows.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package find
+
+import (
+	"io/fs"
+)
+
+func nlinks(info fs.FileInfo) int64 {
+	return 1
+}

--- a/interp/builtins/find/time.go
+++ b/interp/builtins/find/time.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package find
+
+import "time"
+
+// currentTime is a variable so tests can override it for deterministic results.
+var currentTime = time.Now

--- a/interp/register_builtins.go
+++ b/interp/register_builtins.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/rshell/interp/builtins/echo"
 	"github.com/DataDog/rshell/interp/builtins/exit"
 	falsecmd "github.com/DataDog/rshell/interp/builtins/false"
+	"github.com/DataDog/rshell/interp/builtins/find"
 	"github.com/DataDog/rshell/interp/builtins/head"
 	truecmd "github.com/DataDog/rshell/interp/builtins/true"
 )
@@ -30,6 +31,7 @@ func registerBuiltins() {
 			echo.Cmd,
 			exit.Cmd,
 			falsecmd.Cmd,
+			find.Cmd,
 			head.Cmd,
 			truecmd.Cmd,
 		} {

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"sync"
 
@@ -211,6 +212,15 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 			LastExitCode: r.lastExit.code,
 			OpenFile: func(ctx context.Context, path string, flags int, mode os.FileMode) (io.ReadWriteCloser, error) {
 				return r.open(ctx, path, flags, mode, false)
+			},
+			ReadDir: func(ctx context.Context, path string) ([]fs.DirEntry, error) {
+				return r.readDirHandler(r.handlerCtx(ctx, todoPos), path)
+			},
+			Stat: func(ctx context.Context, path string) (fs.FileInfo, error) {
+				if r.sandbox != nil {
+					return r.sandbox.stat(r.handlerCtx(ctx, todoPos), path)
+				}
+				return nil, &os.PathError{Op: "stat", Path: path, Err: os.ErrPermission}
 			},
 			PortableErr: portableErrMsg,
 		}

--- a/tests/import_allowlist_test.go
+++ b/tests/import_allowlist_test.go
@@ -38,6 +38,14 @@ var builtinAllowedSymbols = []string{
 	"context.Context",
 	// errors.Is — error comparison; pure function, no I/O.
 	"errors.Is",
+	// filepath.Join — joins path elements; pure function, no I/O.
+	"path/filepath.Join",
+	// filepath.Match — shell glob matching; pure function, no I/O.
+	"path/filepath.Match",
+	// filepath.Separator — OS-specific path separator constant; no side effects.
+	"path/filepath.Separator",
+	// filepath.ToSlash — converts path separators; pure function, no I/O.
+	"path/filepath.ToSlash",
 	// pflag.ContinueOnError — flag parse-error mode constant; no side effects.
 	"github.com/spf13/pflag.ContinueOnError",
 	// pflag.NewFlagSet — CLI flag parsing; operates only on string slices, no I/O.
@@ -54,12 +62,44 @@ var builtinAllowedSymbols = []string{
 	"io.ReadCloser",
 	// io.Reader — interface type; no side effects.
 	"io.Reader",
+	// fs.DirEntry — interface for directory entries; no side effects.
+	"io/fs.DirEntry",
+	// fs.FileInfo — interface for file info; no side effects.
+	"io/fs.FileInfo",
+	// os.FileMode — type alias for file mode bits; pure type, no I/O.
+	"os.FileMode",
+	// os.ModeCharDevice — file mode bit constant; pure constant, no I/O.
+	"os.ModeCharDevice",
+	// os.ModeDevice — file mode bit constant; pure constant, no I/O.
+	"os.ModeDevice",
+	// os.ModeNamedPipe — file mode bit constant; pure constant, no I/O.
+	"os.ModeNamedPipe",
+	// os.ModeSocket — file mode bit constant; pure constant, no I/O.
+	"os.ModeSocket",
+	// os.ModeSymlink — file mode bit constant; pure constant, no I/O.
+	"os.ModeSymlink",
 	// os.O_RDONLY — read-only file flag constant; cannot open files by itself.
 	"os.O_RDONLY",
 	// strconv.Atoi — string-to-int conversion; pure function, no I/O.
 	"strconv.Atoi",
 	// strconv.ParseInt — string-to-int conversion with base/bit-size; pure function, no I/O.
 	"strconv.ParseInt",
+	// strconv.ParseUint — string-to-uint conversion; pure function, no I/O.
+	"strconv.ParseUint",
+	// strings.HasPrefix — string prefix check; pure function, no I/O.
+	"strings.HasPrefix",
+	// strings.IndexByte — byte search in string; pure function, no I/O.
+	"strings.IndexByte",
+	// strings.Split — string splitting; pure function, no I/O.
+	"strings.Split",
+	// strings.ToLower — string case conversion; pure function, no I/O.
+	"strings.ToLower",
+	// syscall.Stat_t — low-level stat struct for nlinks; read-only type, no I/O.
+	"syscall.Stat_t",
+	// time.Now — returns current time; pure observation, no I/O mutation.
+	"time.Now",
+	// time.Time — time value type; no side effects.
+	"time.Time",
 }
 
 // permanentlyBanned lists packages that may never be imported by builtin

--- a/tests/scenarios/cmd/find/actions/print0.yaml
+++ b/tests/scenarios/cmd/find/actions/print0.yaml
@@ -1,0 +1,13 @@
+# find -print0 uses null separator
+description: find -print0 separates output with null bytes
+setup:
+  files:
+    - path: a.txt
+      content: "a"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -name "a.txt" -print0
+expect:
+  stdout: "./a.txt\x00"
+  exit_code: 0

--- a/tests/scenarios/cmd/find/basic/default_current_dir.yaml
+++ b/tests/scenarios/cmd/find/basic/default_current_dir.yaml
@@ -1,0 +1,15 @@
+# find with no arguments lists current directory recursively
+description: find with no arguments defaults to current directory with -print
+setup:
+  files:
+    - path: file.txt
+      content: "hello"
+    - path: sub/nested.txt
+      content: "world"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find
+expect:
+  stdout_contains: [".", "file.txt", "sub"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/basic/help.yaml
+++ b/tests/scenarios/cmd/find/basic/help.yaml
@@ -1,0 +1,9 @@
+# find --help exits 0
+description: find --help prints usage and exits 0
+skip_assert_against_bash: true
+input:
+  script: |+
+    find --help
+expect:
+  stdout_contains: ["Usage:"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/basic/path_argument.yaml
+++ b/tests/scenarios/cmd/find/basic/path_argument.yaml
@@ -1,0 +1,15 @@
+# find with a path argument
+description: find with a path argument searches under that path
+setup:
+  files:
+    - path: dir/a.txt
+      content: "a"
+    - path: dir/b.txt
+      content: "b"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find dir
+expect:
+  stdout_contains: ["dir", "a.txt", "b.txt"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/depth/maxdepth_one.yaml
+++ b/tests/scenarios/cmd/find/depth/maxdepth_one.yaml
@@ -1,0 +1,17 @@
+# find -maxdepth 1 limits to starting point and direct children
+description: find -maxdepth 1 only descends one level
+setup:
+  files:
+    - path: file.txt
+      content: "hello"
+    - path: sub/nested.txt
+      content: "world"
+    - path: sub/deep/deeper.txt
+      content: "deep"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -maxdepth 1 -type f
+expect:
+  stdout: "./file.txt\n"
+  exit_code: 0

--- a/tests/scenarios/cmd/find/depth/maxdepth_zero.yaml
+++ b/tests/scenarios/cmd/find/depth/maxdepth_zero.yaml
@@ -1,0 +1,15 @@
+# find -maxdepth limits traversal depth
+description: find -maxdepth 0 only tests the starting point
+setup:
+  files:
+    - path: file.txt
+      content: "hello"
+    - path: sub/nested.txt
+      content: "world"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -maxdepth 0
+expect:
+  stdout: ".\n"
+  exit_code: 0

--- a/tests/scenarios/cmd/find/depth/mindepth_one.yaml
+++ b/tests/scenarios/cmd/find/depth/mindepth_one.yaml
@@ -1,0 +1,13 @@
+# find -mindepth 1 skips the starting point
+description: find -mindepth 1 does not print the starting point
+setup:
+  files:
+    - path: file.txt
+      content: "hello"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -mindepth 1 -maxdepth 1
+expect:
+  stdout_contains: ["file.txt"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/empty/empty_file.yaml
+++ b/tests/scenarios/cmd/find/empty/empty_file.yaml
@@ -1,0 +1,15 @@
+# find -empty matches empty files
+description: find -empty matches zero-length files
+setup:
+  files:
+    - path: empty.txt
+      content: ""
+    - path: nonempty.txt
+      content: "data"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -empty -type f
+expect:
+  stdout_contains: ["empty.txt"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/errors/missing_path.yaml
+++ b/tests/scenarios/cmd/find/errors/missing_path.yaml
@@ -1,0 +1,10 @@
+# find with missing path exits 1
+description: find reports error for non-existent path
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find /nonexistent_path_xyz
+expect:
+  stdout: ""
+  stderr_contains: ["find:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/find/errors/reject_delete.yaml
+++ b/tests/scenarios/cmd/find/errors/reject_delete.yaml
@@ -1,0 +1,11 @@
+# find -delete is rejected as unsafe
+description: find rejects -delete as unsafe action
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -delete
+expect:
+  stdout: ""
+  stderr_contains: ["find:", "not permitted"]
+  exit_code: 1

--- a/tests/scenarios/cmd/find/errors/reject_exec.yaml
+++ b/tests/scenarios/cmd/find/errors/reject_exec.yaml
@@ -1,0 +1,11 @@
+# find -exec is rejected as unsafe
+description: find rejects -exec as unsafe action
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -exec ls {} \;
+expect:
+  stdout: ""
+  stderr_contains: ["find:", "not permitted"]
+  exit_code: 1

--- a/tests/scenarios/cmd/find/name/iname_case_insensitive.yaml
+++ b/tests/scenarios/cmd/find/name/iname_case_insensitive.yaml
@@ -1,0 +1,15 @@
+# find -iname matches filenames case-insensitively
+description: find -iname is case-insensitive
+setup:
+  files:
+    - path: Hello.TXT
+      content: "hello"
+    - path: world.txt
+      content: "world"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -iname "hello*"
+expect:
+  stdout_contains: ["Hello.TXT"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/name/name_glob.yaml
+++ b/tests/scenarios/cmd/find/name/name_glob.yaml
@@ -1,0 +1,17 @@
+# find -name matches filenames by glob pattern
+description: find -name matches basenames against a glob pattern
+setup:
+  files:
+    - path: hello.txt
+      content: "hello"
+    - path: world.log
+      content: "world"
+    - path: sub/hello.txt
+      content: "nested"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -name "*.txt"
+expect:
+  stdout_contains: ["hello.txt"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/operators/not_operator.yaml
+++ b/tests/scenarios/cmd/find/operators/not_operator.yaml
@@ -1,0 +1,15 @@
+# find with NOT operator
+description: find ! -name "*.txt" excludes .txt files
+setup:
+  files:
+    - path: a.txt
+      content: "a"
+    - path: b.log
+      content: "b"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -type f ! -name "*.txt"
+expect:
+  stdout_contains: ["b.log"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/operators/or_operator.yaml
+++ b/tests/scenarios/cmd/find/operators/or_operator.yaml
@@ -1,0 +1,17 @@
+# find with logical OR
+description: find -name a.txt -o -name b.txt matches both files
+setup:
+  files:
+    - path: a.txt
+      content: "a"
+    - path: b.txt
+      content: "b"
+    - path: c.txt
+      content: "c"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -name a.txt -o -name b.txt
+expect:
+  stdout_contains: ["a.txt", "b.txt"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/size/size_greater.yaml
+++ b/tests/scenarios/cmd/find/size/size_greater.yaml
@@ -1,0 +1,15 @@
+# find -size +0c matches non-empty files
+description: find -size +0c finds files larger than 0 bytes
+setup:
+  files:
+    - path: empty.txt
+      content: ""
+    - path: data.txt
+      content: "some data"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -type f -size +0c
+expect:
+  stdout_contains: ["data.txt"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/type/type_dir.yaml
+++ b/tests/scenarios/cmd/find/type/type_dir.yaml
@@ -1,0 +1,15 @@
+# find -type d matches directories only
+description: find -type d matches only directories
+setup:
+  files:
+    - path: file.txt
+      content: "hello"
+    - path: sub/nested.txt
+      content: "world"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -type d
+expect:
+  stdout_contains: [".", "sub"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/type/type_file.yaml
+++ b/tests/scenarios/cmd/find/type/type_file.yaml
@@ -1,0 +1,15 @@
+# find -type f matches regular files only
+description: find -type f matches only regular files
+setup:
+  files:
+    - path: file.txt
+      content: "hello"
+    - path: sub/nested.txt
+      content: "world"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    find . -type f
+expect:
+  stdout_contains: ["file.txt", "nested.txt"]
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bfacb9f9-8655-4951-aa06-7ae9ae5c2daa","source":"chat","resourceId":"d8f87a85-f007-443c-9543-2f0b3d57b51d","workflowId":"78123091-f41c-4487-8aac-1db82f821443","codeChangeId":"78123091-f41c-4487-8aac-1db82f821443","sourceType":"chat"} -->
### What does this PR do?

Implements the POSIX `find` command as a safe builtin in `interp/builtins/find/`. Supports directory traversal with expression-based filtering, matching GNU findutils behavior for all safe (read-only) primaries while rejecting all dangerous actions (`-exec`, `-delete`, `-fprintf`, etc.).

**Supported primaries:**
- Tests: `-name`, `-iname`, `-path`/`-wholename`, `-ipath`/`-iwholename`, `-type`, `-empty`, `-size`, `-newer`, `-mtime`, `-perm`, `-links`, `-true`, `-false`
- Actions: `-print` (default), `-print0`, `-prune`, `-quit`
- Depth control: `-maxdepth`, `-mindepth`, `-depth`
- Operators: `-a`/`-and`, `-o`/`-or`, `!`/`-not`, `(` `)`

**Infrastructure:** Adds `ReadDir` and `Stat` callbacks to `CallContext` (backed by the existing `pathSandbox`), enabling builtins to traverse directories and stat files through the sandbox.

### Motivation

The `find` command is essential for file discovery in shell scripts. This implementation provides all safe, read-only primaries while blocking all dangerous actions identified by GTFOBins (shell escape via `-exec`, file write via `-fprintf`, file deletion via `-delete`).

### Testing

- 48 Go unit tests covering all primaries, operators, edge cases, and error paths
- 9 GNU compatibility tests with captured reference outputs
- 25 pentest tests covering integer overflow, pathological glob patterns, unsafe flag rejection, symlinks, context cancellation, and large directories
- 15 YAML scenario tests for bash comparison
- Import allowlist test updated and passing
- `go vet` clean, `gofmt` clean

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/d8f87a85-f007-443c-9543-2f0b3d57b51d)

Comment @datadog to request changes