### PR TITLE
Implement awk builtin command

### DIFF
--- a/interp/builtins/awk/awk.go
+++ b/interp/builtins/awk/awk.go
@@ -1,0 +1,303 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package awk implements the awk builtin command.
+//
+// awk — pattern-directed scanning and processing language
+//
+// Usage: awk [OPTION]... 'program' [FILE]...
+//
+// Scan each input FILE (or standard input) for lines matching patterns
+// in the AWK program and execute the associated actions.
+//
+// Accepted flags:
+//
+//	-F fs, --field-separator=fs
+//	    Set the input field separator FS to fs. Default is whitespace
+//	    (runs of spaces and tabs, with leading/trailing stripped).
+//
+//	-v var=val, --assign=var=val
+//	    Assign variable var the value val before execution begins.
+//	    May be specified multiple times.
+//
+//	-f progfile, --file=progfile
+//	    Read the AWK program from progfile instead of the first
+//	    command-line argument. May be specified multiple times;
+//	    the programs are concatenated.
+//
+//	-h, --help
+//	    Print this usage message to stdout and exit 0.
+//
+// Blocked features (safety):
+//
+//	system()              — blocked: would execute shell commands
+//	print > file          — blocked: would write to filesystem
+//	print >> file         — blocked: would write to filesystem
+//	print | cmd           — blocked: would execute commands
+//	getline < file        — blocked: would read files outside sandbox
+//	cmd | getline         — blocked: would execute commands
+//	close()               — blocked: no I/O redirection support
+//
+// Exit codes:
+//
+//	0  All input processed successfully.
+//	1  Error occurred (bad flags, parse error, runtime error, missing file).
+//
+// Memory safety:
+//
+//	Input is processed line-by-line with a per-line cap of MaxLineBytes
+//	(1 MiB). Arrays are capped at MaxArraySize entries. String values
+//	are capped at MaxStringLen bytes. Awk-level loops are capped at
+//	MaxLoopIterations to prevent infinite loops. All loops check
+//	ctx.Err() to honour the shell's execution timeout.
+package awk
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"github.com/DataDog/rshell/interp/builtins"
+	awkcore "github.com/DataDog/rshell/interp/builtins/internal/awkcore"
+)
+
+// Cmd is the awk builtin command descriptor.
+var Cmd = builtins.Command{Name: "awk", Run: run}
+
+// MaxLineBytes is the per-line buffer cap for the input scanner.
+const MaxLineBytes = 1 << 20 // 1 MiB
+
+func run(ctx context.Context, callCtx *builtins.CallContext, args []string) builtins.Result {
+	fs := pflag.NewFlagSet("awk", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	help := fs.BoolP("help", "h", false, "print usage and exit")
+	fieldSep := fs.StringP("field-separator", "F", "", "input field separator")
+	progFiles := fs.StringArrayP("file", "f", nil, "read program from file")
+	assigns := fs.StringArrayP("assign", "v", nil, "assign variable (var=val)")
+
+	if err := fs.Parse(args); err != nil {
+		callCtx.Errf("awk: %v\n", err)
+		return builtins.Result{Code: 1}
+	}
+
+	if *help {
+		callCtx.Out("Usage: awk [OPTION]... 'program' [FILE]...\n")
+		callCtx.Out("Pattern-directed scanning and processing language.\n\n")
+		fs.SetOutput(callCtx.Stdout)
+		fs.PrintDefaults()
+		return builtins.Result{}
+	}
+
+	remaining := fs.Args()
+
+	var programText string
+	if len(*progFiles) > 0 {
+		var sb strings.Builder
+		for _, pf := range *progFiles {
+			src, err := readProgFile(ctx, callCtx, pf)
+			if err != nil {
+				callCtx.Errf("awk: %s: %s\n", pf, callCtx.PortableErr(err))
+				return builtins.Result{Code: 1}
+			}
+			if sb.Len() > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(src)
+		}
+		programText = sb.String()
+	} else {
+		if len(remaining) == 0 {
+			callCtx.Errf("awk: no program text\n")
+			return builtins.Result{Code: 1}
+		}
+		programText = remaining[0]
+		remaining = remaining[1:]
+	}
+
+	prog, err := awkcore.Parse(programText)
+	if err != nil {
+		callCtx.Errf("awk: %s\n", err)
+		return builtins.Result{Code: 1}
+	}
+
+	interp := awkcore.NewInterpreter(prog, callCtx.Stdout, callCtx.Stderr)
+
+	if fs.Changed("field-separator") {
+		interp.SetFS(*fieldSep)
+	}
+
+	for _, a := range *assigns {
+		idx := strings.IndexByte(a, '=')
+		if idx < 1 {
+			callCtx.Errf("awk: invalid -v assignment: %s\n", a)
+			return builtins.Result{Code: 1}
+		}
+		name := a[:idx]
+		val := a[idx+1:]
+		if !isValidVarName(name) {
+			callCtx.Errf("awk: invalid variable name: %s\n", name)
+			return builtins.Result{Code: 1}
+		}
+		interp.SetVar(name, val)
+	}
+
+	files := remaining
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	if err := interp.ExecBegin(ctx); err != nil {
+		if re, ok := err.(*awkcore.RuntimeError); ok {
+			callCtx.Errf("awk: %s\n", re)
+			return builtins.Result{Code: re.ExitCode()}
+		}
+		callCtx.Errf("awk: %s\n", err)
+		return builtins.Result{Code: 1}
+	}
+
+	var failed bool
+	for _, file := range files {
+		if ctx.Err() != nil {
+			break
+		}
+		if err := processFile(ctx, callCtx, interp, file); err != nil {
+			if re, ok := err.(*awkcore.RuntimeError); ok {
+				if re.IsExit() {
+					if err2 := interp.ExecEnd(ctx); err2 != nil {
+						if re2, ok2 := err2.(*awkcore.RuntimeError); ok2 {
+							return builtins.Result{Code: re2.ExitCode()}
+						}
+					}
+					return builtins.Result{Code: re.ExitCode()}
+				}
+				callCtx.Errf("awk: %s\n", re)
+				return builtins.Result{Code: re.ExitCode()}
+			}
+			if file == "-" {
+				callCtx.Errf("awk: standard input: %s\n", callCtx.PortableErr(err))
+			} else {
+				callCtx.Errf("awk: %s: %s\n", file, callCtx.PortableErr(err))
+			}
+			failed = true
+		}
+	}
+
+	if err := interp.ExecEnd(ctx); err != nil {
+		if re, ok := err.(*awkcore.RuntimeError); ok {
+			callCtx.Errf("awk: %s\n", re)
+			return builtins.Result{Code: re.ExitCode()}
+		}
+		callCtx.Errf("awk: %s\n", err)
+		return builtins.Result{Code: 1}
+	}
+
+	if failed {
+		return builtins.Result{Code: 1}
+	}
+	code := interp.ExitCode()
+	return builtins.Result{Code: code}
+}
+
+func processFile(ctx context.Context, callCtx *builtins.CallContext, interp *awkcore.Interpreter, file string) error {
+	var rc io.ReadCloser
+	if file == "-" {
+		if callCtx.Stdin == nil {
+			return nil
+		}
+		rc = io.NopCloser(callCtx.Stdin)
+		interp.SetFilename("") // POSIX: FILENAME is unset for stdin
+	} else {
+		f, err := callCtx.OpenFile(ctx, file, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+		rc = f
+		interp.SetFilename(file)
+	}
+	defer rc.Close()
+
+	interp.ResetFNR()
+
+	sc := bufio.NewScanner(rc)
+	buf := make([]byte, 4096)
+	sc.Buffer(buf, MaxLineBytes)
+
+	for sc.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line := sc.Text()
+		if err := interp.ExecLine(ctx, line); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}
+
+func readProgFile(ctx context.Context, callCtx *builtins.CallContext, path string) (string, error) {
+	f, err := callCtx.OpenFile(ctx, path, os.O_RDONLY, 0)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var sb strings.Builder
+	sc := bufio.NewScanner(f)
+	buf := make([]byte, 4096)
+	sc.Buffer(buf, MaxLineBytes)
+	first := true
+	for sc.Scan() {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		if !first {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(sc.Text())
+		first = false
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+func isValidVarName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	for i, c := range name {
+		if i == 0 {
+			if !isLetter(c) {
+				return false
+			}
+		} else {
+			if !isLetter(c) && !isDigit(c) {
+				return false
+			}
+		}
+	}
+	reserved := map[string]bool{
+		"BEGIN": true, "END": true, "if": true, "else": true,
+		"while": true, "for": true, "do": true, "break": true,
+		"continue": true, "next": true, "exit": true, "delete": true,
+		"in": true, "getline": true, "print": true, "printf": true,
+		"function": true, "return": true,
+	}
+	return !reserved[name]
+}
+
+func isLetter(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+func isDigit(c rune) bool {
+	return c >= '0' && c <= '9'
+}

--- a/interp/builtins/awk/awk_gnu_compat_test.go
+++ b/interp/builtins/awk/awk_gnu_compat_test.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// GNU compatibility tests for the awk builtin.
+//
+// Expected outputs were captured from GNU awk (gawk) 5.3.1 and are embedded
+// as string literals so the tests run without any GNU tooling present on CI.
+// To reproduce a reference output, run:
+//
+//	gawk [program] [file]
+
+package awk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGNUCompatPrintAll — print all lines.
+//
+// GNU command: gawk '{print}' file.txt   (file.txt = "alpha\nbeta\ngamma\n")
+// Expected:    "alpha\nbeta\ngamma\n"
+func TestGNUCompatPrintAll(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "alpha\nbeta\ngamma\n")
+	stdout, _, code := cmdRun(t, `awk '{print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "alpha\nbeta\ngamma\n", stdout)
+}
+
+// TestGNUCompatFieldPrint — print specific fields.
+//
+// GNU command: gawk '{print $1, $3}' file.txt   (file.txt = "one two three\nfour five six\n")
+// Expected:    "one three\nfour six\n"
+func TestGNUCompatFieldPrint(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "one two three\nfour five six\n")
+	stdout, _, code := cmdRun(t, `awk '{print $1, $3}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "one three\nfour six\n", stdout)
+}
+
+// TestGNUCompatFieldSeparator — -F flag.
+//
+// GNU command: gawk -F: '{print $2}' file.csv   (file.csv = "a:b:c\nd:e:f\n")
+// Expected:    "b\ne\n"
+func TestGNUCompatFieldSeparator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.csv", "a:b:c\nd:e:f\n")
+	stdout, _, code := cmdRun(t, `awk -F: '{print $2}' file.csv`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "b\ne\n", stdout)
+}
+
+// TestGNUCompatNR — NR variable.
+//
+// GNU command: gawk '{print NR, $0}' file.txt   (file.txt = "a\nb\nc\n")
+// Expected:    "1 a\n2 b\n3 c\n"
+func TestGNUCompatNR(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\nc\n")
+	stdout, _, code := cmdRun(t, `awk '{print NR, $0}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1 a\n2 b\n3 c\n", stdout)
+}
+
+// TestGNUCompatBeginEnd — BEGIN and END blocks.
+//
+// GNU command: gawk 'BEGIN {print "S"} {c++} END {print c}' file.txt   (3-line file)
+// Expected:    "S\n3\n"
+func TestGNUCompatBeginEnd(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\nc\n")
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print "S"} {c++} END {print c}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "S\n3\n", stdout)
+}
+
+// TestGNUCompatPatternMatch — regex pattern match.
+//
+// GNU command: gawk '/hello/' file.txt   (file.txt = "hello world\nfoo bar\nhello again\n")
+// Expected:    "hello world\nhello again\n"
+func TestGNUCompatPatternMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello world\nfoo bar\nhello again\n")
+	stdout, _, code := cmdRun(t, `awk '/hello/' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello world\nhello again\n", stdout)
+}
+
+// TestGNUCompatEmptyFile — no output on empty file.
+//
+// GNU command: gawk '{print}' empty.txt
+// Expected:    ""
+func TestGNUCompatEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "empty.txt", "")
+	stdout, _, code := cmdRun(t, `awk '{print}' empty.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+// TestGNUCompatPrintf — printf formatting.
+//
+// GNU command: gawk '{printf "%03d %s\n", NR, $0}' file.txt   (file.txt = "a\nb\n")
+// Expected:    "001 a\n002 b\n"
+func TestGNUCompatPrintf(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\n")
+	stdout, _, code := cmdRun(t, `awk '{printf "%03d %s\n", NR, $0}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "001 a\n002 b\n", stdout)
+}
+
+// TestGNUCompatVFlag — -v variable assignment.
+//
+// GNU command: gawk -v x=42 'BEGIN {print x}'
+// Expected:    "42\n"
+func TestGNUCompatVFlag(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk -v x=42 'BEGIN {print x}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "42\n", stdout)
+}
+
+// TestGNUCompatComparisonPattern — comparison selects lines.
+//
+// GNU command: gawk '$1 > 3' file.txt   (file.txt = "1\n2\n3\n4\n5\n")
+// Expected:    "4\n5\n"
+func TestGNUCompatComparisonPattern(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "1\n2\n3\n4\n5\n")
+	stdout, _, code := cmdRun(t, `awk '$1 > 3' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "4\n5\n", stdout)
+}
+
+// TestGNUCompatOFS — output field separator.
+//
+// GNU command: gawk -v OFS="," '{$1=$1; print}' file.txt   (file.txt = "a b c\n")
+// Expected:    "a,b,c\n"
+func TestGNUCompatOFS(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a b c\n")
+	stdout, _, code := cmdRun(t, `awk -v OFS="," '{$1=$1; print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a,b,c\n", stdout)
+}
+
+// TestGNUCompatArrayCounting — word counting with arrays.
+//
+// GNU command: gawk '{count[$1]++} END {for (k in count) print k, count[k]}' file.txt
+// (file.txt = "a\nb\na\nc\nb\na\n")
+// Expected (sorted): "a 3\nb 2\nc 1\n"
+func TestGNUCompatArrayCounting(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\na\nc\nb\na\n")
+	stdout, _, code := cmdRun(t, `awk '{count[$1]++} END {for (k in count) print k, count[k]}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a 3\nb 2\nc 1\n", stdout)
+}
+
+// TestGNUCompatFNR — per-file record number.
+//
+// GNU command: gawk '{print FNR, $0}' a.txt b.txt
+// Expected:    "1 x\n2 y\n1 z\n"
+func TestGNUCompatFNR(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "x\ny\n")
+	writeFile(t, dir, "b.txt", "z\n")
+	stdout, _, code := cmdRun(t, `awk '{print FNR, $0}' a.txt b.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1 x\n2 y\n1 z\n", stdout)
+}
+
+// TestGNUCompatNoProgram — no program text.
+//
+// GNU command: gawk
+// Expected:    exit 1, stderr message
+func TestGNUCompatNoProgram(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk`, dir)
+	assert.Equal(t, 1, code)
+	assert.NotEmpty(t, stderr)
+}
+
+// TestGNUCompatRejectedFlag — unknown flag.
+//
+// GNU command: gawk --garbage
+// Expected:    exit 1, stderr message
+func TestGNUCompatRejectedFlag(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk --garbage '{print}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}

--- a/interp/builtins/awk/awk_pentest_test.go
+++ b/interp/builtins/awk/awk_pentest_test.go
@@ -1,0 +1,224 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awk_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+)
+
+// --- Integer edge cases ---
+
+func TestAwkPentestLargeLoopCount(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, _ = runScriptCtx(ctx, t, `awk 'BEGIN {for (i=0; i<99999999999; i++) x++}'`, dir, interp.AllowedPaths([]string{dir}))
+}
+
+func TestAwkPentestDeepRecursion(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'function f(n) {return f(n+1)} BEGIN {f(0)}'`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "depth")
+}
+
+func TestAwkPentestInfiniteWhile(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, _, _ = runScriptCtx(ctx, t, `awk 'BEGIN {while (1) x++}'`, dir, interp.AllowedPaths([]string{dir}))
+}
+
+// --- Blocked features ---
+
+func TestAwkPentestSystemCall(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {system("id")}'`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkPentestOutputRedirectFile(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print "evil" > "/tmp/pwned"}'`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkPentestOutputRedirectAppend(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print "evil" >> "/tmp/pwned"}'`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkPentestOutputRedirectPipe(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print "evil" | "sh"}'`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkPentestCloseCall(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {close("foo")}'`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "not supported")
+}
+
+// --- Path and filename edge cases ---
+
+func TestAwkPentestNonexistentFile(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk '{print}' no_such_file`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkPentestDirectoryAsFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0755))
+	_, stderr, code := cmdRun(t, `awk '{print}' subdir`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkPentestEmptyFilename(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk '{print}' ""`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkPentestDashDashSeparator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "-v", "content\n")
+	stdout, _, code := cmdRun(t, `awk '{print}' -- -v`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "content\n", stdout)
+}
+
+func TestAwkPentestMultipleStdinDash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "hello\n")
+	stdout, _, code := cmdRun(t, `cat a.txt | awk '{print NR, $0}' - -`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1 hello\n", stdout)
+}
+
+// --- Flag and argument injection ---
+
+func TestAwkPentestUnknownLongFlag(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := runScript(t, `awk --follow '{print}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkPentestFlagViaExpansion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "data.txt", "test\n")
+	_, stderr, code := cmdRun(t, `for flag in --follow; do awk $flag '{print}' data.txt; done`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+// --- Memory / resource exhaustion ---
+
+func TestAwkPentestLargeArrayCapped(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, _ = runScriptCtx(ctx, t, `awk 'BEGIN {for (i=0; i<200000; i++) a[i]=i}'`, dir, interp.AllowedPaths([]string{dir}))
+}
+
+func TestAwkPentestManyFiles(t *testing.T) {
+	dir := t.TempDir()
+	var args []string
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("file_%03d.txt", i)
+		writeFile(t, dir, name, "line\n")
+		args = append(args, name)
+	}
+	script := `awk '{x++} END {print x}' ` + strings.Join(args, " ")
+	stdout, _, code := cmdRun(t, script, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "50\n", stdout)
+}
+
+// --- Division by zero ---
+
+func TestAwkPentestDivByZero(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print 1/0}'`, dir)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "division by zero")
+}
+
+func TestAwkPentestModByZero(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print 1%0}'`, dir)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "division by zero")
+}
+
+// --- String edge cases ---
+
+func TestAwkPentestLongString(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, _ = runScriptCtx(ctx, t, `awk 'BEGIN {s="a"; for (i=0; i<20; i++) s = s s; print length(s)}'`, dir, interp.AllowedPaths([]string{dir}))
+}
+
+func TestAwkPentestBinaryInput(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "bin.txt", "hello\x00world\n")
+	stdout, _, code := cmdRun(t, `awk '{print NR}' bin.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "1")
+}
+
+// --- Regex edge cases ---
+
+func TestAwkPentestInvalidRegex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "data.txt", "test\n")
+	_, stderr, code := cmdRun(t, `awk '$0 ~ "[invalid" {print}' data.txt`, dir)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+// --- Exit code from awk program ---
+
+func TestAwkPentestExitZero(t *testing.T) {
+	dir := t.TempDir()
+	_, _, code := cmdRun(t, `awk 'BEGIN {exit 0}'`, dir)
+	assert.Equal(t, 0, code)
+}
+
+func TestAwkPentestExitNonZero(t *testing.T) {
+	dir := t.TempDir()
+	_, _, code := cmdRun(t, `awk 'BEGIN {exit 2}'`, dir)
+	assert.Equal(t, 2, code)
+}
+
+func TestAwkPentestExitLargeValue(t *testing.T) {
+	dir := t.TempDir()
+	_, _, code := cmdRun(t, `awk 'BEGIN {exit 999}'`, dir)
+	assert.Equal(t, 255, code)
+}

--- a/interp/builtins/awk/awk_test.go
+++ b/interp/builtins/awk/awk_test.go
@@ -1,0 +1,623 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awk_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+	"github.com/DataDog/rshell/interp/builtins/testutil"
+)
+
+func runScriptCtx(ctx context.Context, t *testing.T, script, dir string, opts ...interp.RunnerOption) (string, string, int) {
+	t.Helper()
+	return testutil.RunScriptCtx(ctx, t, script, dir, opts...)
+}
+
+func runScript(t *testing.T, script, dir string, opts ...interp.RunnerOption) (string, string, int) {
+	t.Helper()
+	return testutil.RunScript(t, script, dir, opts...)
+}
+
+func cmdRun(t *testing.T, script, dir string) (string, string, int) {
+	t.Helper()
+	return runScript(t, script, dir, interp.AllowedPaths([]string{dir}))
+}
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+	return name
+}
+
+// --- Basic behavior ---
+
+func TestAwkPrintAll(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "alpha\nbeta\ngamma\n")
+	stdout, stderr, code := cmdRun(t, `awk '{print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "alpha\nbeta\ngamma\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestAwkPatternMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello world\nfoo bar\nhello again\n")
+	stdout, stderr, code := cmdRun(t, `awk '/hello/' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello world\nhello again\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestAwkEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "empty.txt", "")
+	stdout, stderr, code := cmdRun(t, `awk '{print}' empty.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestAwkNoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello")
+	stdout, _, code := cmdRun(t, `awk '{print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+// --- Field operations ---
+
+func TestAwkPrintFields(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "one two three\nfour five six\n")
+	stdout, _, code := cmdRun(t, `awk '{print $1, $3}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "one three\nfour six\n", stdout)
+}
+
+func TestAwkFieldSeparator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.csv", "a:b:c\nd:e:f\n")
+	stdout, _, code := cmdRun(t, `awk -F: '{print $2}' file.csv`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "b\ne\n", stdout)
+}
+
+func TestAwkNFVariable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "one two three\nfour five\n")
+	stdout, _, code := cmdRun(t, `awk '{print NF}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "3\n2\n", stdout)
+}
+
+func TestAwkLastField(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "one two three\n")
+	stdout, _, code := cmdRun(t, `awk '{print $NF}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "three\n", stdout)
+}
+
+func TestAwkFieldAssign(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a b c\n")
+	stdout, _, code := cmdRun(t, `awk '{$2 = "X"; print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a X c\n", stdout)
+}
+
+// --- Variable assignment (-v) ---
+
+func TestAwkVFlag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello\n")
+	stdout, _, code := cmdRun(t, `awk -v greeting=hi '{print greeting, $0}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hi hello\n", stdout)
+}
+
+func TestAwkVFlagMultiple(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "x\n")
+	stdout, _, code := cmdRun(t, `awk -v a=1 -v b=2 'BEGIN {print a + b}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "3\n", stdout)
+}
+
+// --- NR and FNR ---
+
+func TestAwkNRVariable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\nc\n")
+	stdout, _, code := cmdRun(t, `awk '{print NR, $0}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1 a\n2 b\n3 c\n", stdout)
+}
+
+func TestAwkFNR(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "x\ny\n")
+	writeFile(t, dir, "b.txt", "z\n")
+	stdout, _, code := cmdRun(t, `awk '{print FNR, $0}' a.txt b.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1 x\n2 y\n1 z\n", stdout)
+}
+
+// --- BEGIN/END ---
+
+func TestAwkBeginBlock(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "data\n")
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print "start"} {print $0}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "start\ndata\n", stdout)
+}
+
+func TestAwkEndBlock(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\nc\n")
+	stdout, _, code := cmdRun(t, `awk '{count++} END {print count}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "3\n", stdout)
+}
+
+func TestAwkBeginOnly(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print "hello"}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+// --- Printf ---
+
+func TestAwkPrintf(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello\nworld\n")
+	stdout, _, code := cmdRun(t, `awk '{printf "%d: %s\n", NR, $0}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1: hello\n2: world\n", stdout)
+}
+
+func TestAwkPrintfNoNewline(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {printf "ab"; printf "cd"}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "abcd", stdout)
+}
+
+// --- Control flow ---
+
+func TestAwkIfElse(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "1\n2\n3\n4\n")
+	stdout, _, code := cmdRun(t, `awk '{if ($1 % 2 == 0) print "even"; else print "odd"}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "odd\neven\nodd\neven\n", stdout)
+}
+
+func TestAwkForLoop(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {for (i=1; i<=3; i++) print i}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1\n2\n3\n", stdout)
+}
+
+func TestAwkWhileLoop(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {i=1; while (i<=3) {print i; i++}}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1\n2\n3\n", stdout)
+}
+
+func TestAwkDoWhile(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {i=1; do {print i; i++} while (i<=3)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1\n2\n3\n", stdout)
+}
+
+func TestAwkBreak(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {for (i=1; i<=10; i++) {if (i > 3) break; print i}}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1\n2\n3\n", stdout)
+}
+
+func TestAwkContinue(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {for (i=1; i<=5; i++) {if (i == 3) continue; print i}}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1\n2\n4\n5\n", stdout)
+}
+
+func TestAwkNext(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "1\n2\n3\n")
+	stdout, _, code := cmdRun(t, `awk '{if ($1 == 2) next; print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1\n3\n", stdout)
+}
+
+func TestAwkExit(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\nc\n")
+	stdout, _, code := cmdRun(t, `awk '{print; if (NR == 2) exit}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a\nb\n", stdout)
+}
+
+func TestAwkExitCode(t *testing.T) {
+	dir := t.TempDir()
+	_, _, code := cmdRun(t, `awk 'BEGIN {exit 42}'`, dir)
+	assert.Equal(t, 42, code)
+}
+
+// --- String functions ---
+
+func TestAwkLength(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello\nhi\n")
+	stdout, _, code := cmdRun(t, `awk '{print length($0)}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "5\n2\n", stdout)
+}
+
+func TestAwkSubstr(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello world\n")
+	stdout, _, code := cmdRun(t, `awk '{print substr($0, 1, 5)}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+func TestAwkIndex(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print index("hello world", "world")}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "7\n", stdout)
+}
+
+func TestAwkSplit(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {n = split("a:b:c", arr, ":"); for (i=1; i<=n; i++) print arr[i]}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a\nb\nc\n", stdout)
+}
+
+func TestAwkSub(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello world hello\n")
+	stdout, _, code := cmdRun(t, `awk '{sub(/hello/, "hi"); print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hi world hello\n", stdout)
+}
+
+func TestAwkGsub(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello world hello\n")
+	stdout, _, code := cmdRun(t, `awk '{gsub(/hello/, "hi"); print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hi world hi\n", stdout)
+}
+
+func TestAwkMatch(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print match("hello world", /wor/)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "7\n", stdout)
+}
+
+func TestAwkTolower(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print tolower("HELLO")}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+func TestAwkToupper(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print toupper("hello")}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "HELLO\n", stdout)
+}
+
+func TestAwkSprintf(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print sprintf("%05d", 42)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "00042\n", stdout)
+}
+
+// --- Math functions ---
+
+func TestAwkInt(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print int(3.9)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "3\n", stdout)
+}
+
+func TestAwkSqrt(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print sqrt(16)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "4\n", stdout)
+}
+
+// --- Arrays ---
+
+func TestAwkArrays(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a\nb\na\nc\nb\na\n")
+	stdout, _, code := cmdRun(t, `awk '{count[$1]++} END {for (k in count) print k, count[k]}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a 3\nb 2\nc 1\n", stdout)
+}
+
+func TestAwkDeleteArray(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {a[1]=1; a[2]=2; delete a[1]; for (k in a) print k, a[k]}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "2 2\n", stdout)
+}
+
+func TestAwkInArray(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {a["x"]=1; if ("x" in a) print "yes"; if ("y" in a) print "no"}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "yes\n", stdout)
+}
+
+// --- Regex match operators ---
+
+func TestAwkMatchOperator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello\nworld\nhelpful\n")
+	stdout, _, code := cmdRun(t, `awk '$0 ~ /hel/ {print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello\nhelpful\n", stdout)
+}
+
+func TestAwkNotMatchOperator(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "hello\nworld\nhelpful\n")
+	stdout, _, code := cmdRun(t, `awk '$0 !~ /hel/ {print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "world\n", stdout)
+}
+
+// --- Arithmetic ---
+
+func TestAwkArithmetic(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print 2 + 3 * 4}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "14\n", stdout)
+}
+
+func TestAwkModulo(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print 17 % 5}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "2\n", stdout)
+}
+
+func TestAwkPower(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print 2 ^ 10}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "1024\n", stdout)
+}
+
+func TestAwkTernary(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {x = 5; print (x > 3 ? "big" : "small")}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "big\n", stdout)
+}
+
+func TestAwkIncrement(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {x = 0; print x++; print x; print ++x; print x}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "0\n1\n2\n2\n", stdout)
+}
+
+// --- String concatenation ---
+
+func TestAwkConcat(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {print "hello" " " "world"}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "hello world\n", stdout)
+}
+
+// --- Assignment operators ---
+
+func TestAwkAssignOps(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'BEGIN {x=10; x+=5; print x; x-=3; print x; x*=2; print x; x/=4; print x; x%=5; print x}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "15\n12\n24\n6\n1\n", stdout)
+}
+
+// --- Comparison pattern ---
+
+func TestAwkComparisonPattern(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "1\n2\n3\n4\n5\n")
+	stdout, _, code := cmdRun(t, `awk '$1 > 3' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "4\n5\n", stdout)
+}
+
+// --- Stdin ---
+
+func TestAwkStdin(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "data.txt", "hello\nworld\n")
+	stdout, _, code := cmdRun(t, `cat data.txt | awk '{print toupper($0)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "HELLO\nWORLD\n", stdout)
+}
+
+// --- Multiple files ---
+
+func TestAwkMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "one\n")
+	writeFile(t, dir, "b.txt", "two\n")
+	stdout, _, code := cmdRun(t, `awk '{print FILENAME, $0}' a.txt b.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a.txt one\nb.txt two\n", stdout)
+}
+
+// --- Help ---
+
+func TestAwkHelp(t *testing.T) {
+	dir := t.TempDir()
+	stdout, stderr, code := runScript(t, `awk --help`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "Usage:")
+	assert.Empty(t, stderr)
+}
+
+func TestAwkHelpShort(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := runScript(t, `awk -h`, dir)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout, "Usage:")
+}
+
+// --- Errors ---
+
+func TestAwkNoProgram(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := runScript(t, `awk`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk '{print}' nonexistent.txt`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkSyntaxError(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk '{print'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkUnknownFlag(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := runScript(t, `awk --unknown '{print}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkInvalidVAssignment(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := runScript(t, `awk -v badassign '{print}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+func TestAwkDivisionByZero(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print 1/0}'`, dir)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+// --- Safety: blocked features ---
+
+func TestAwkBlockedSystem(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {system("echo bad")}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkBlockedOutputRedirect(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print "bad" > "/tmp/evil"}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkBlockedPipeRedirect(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {print "bad" | "cat"}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "blocked")
+}
+
+func TestAwkBlockedClose(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk 'BEGIN {close("file")}'`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "not supported")
+}
+
+// --- RULES.md compliance ---
+
+func TestAwkContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, _ = runScriptCtx(ctx, t, `awk 'BEGIN {while (1) {x++}}'`, dir, interp.AllowedPaths([]string{dir}))
+}
+
+func TestAwkOutsideAllowedPaths(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := cmdRun(t, `awk '{print}' /etc/passwd`, dir)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "awk:")
+}
+
+// --- -f flag ---
+
+func TestAwkProgFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "prog.awk", `{print toupper($0)}`)
+	writeFile(t, dir, "data.txt", "hello\n")
+	stdout, _, code := cmdRun(t, `awk -f prog.awk data.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "HELLO\n", stdout)
+}
+
+// --- User-defined functions ---
+
+func TestAwkUserFunction(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := cmdRun(t, `awk 'function double(x) {return x*2} BEGIN {print double(21)}'`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "42\n", stdout)
+}
+
+// --- OFS ---
+
+func TestAwkOFS(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "file.txt", "a b c\n")
+	stdout, _, code := cmdRun(t, `awk -v OFS="," '{$1=$1; print}' file.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "a,b,c\n", stdout)
+}

--- a/interp/builtins/awk/awk_unix_test.go
+++ b/interp/builtins/awk/awk_unix_test.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build unix
+
+package awk_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+)
+
+func TestAwkDevNull(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, code := runScript(t, `awk '{print}' /dev/null`, dir, interp.AllowedPaths([]string{dir, "/dev"}))
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "", stdout)
+}
+
+func TestAwkSymlinkFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "real.txt", "data\n")
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(dir, "link.txt")))
+	stdout, _, code := cmdRun(t, `awk '{print}' link.txt`, dir)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "data\n", stdout)
+}

--- a/interp/builtins/internal/awkcore/ast.go
+++ b/interp/builtins/internal/awkcore/ast.go
@@ -1,0 +1,257 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awkcore
+
+// Program represents a complete awk program.
+type Program struct {
+	Begin []*Action
+	End   []*Action
+	Rules []*Rule
+	Funcs map[string]*FuncDef
+}
+
+// Rule is a pattern-action pair.
+type Rule struct {
+	Pattern Pattern
+	Action  *Action
+}
+
+// Action is a block of statements.
+type Action struct {
+	Stmts []Stmt
+}
+
+// Pattern types.
+type Pattern interface {
+	patternNode()
+}
+
+type BeginPattern struct{}
+type EndPattern struct{}
+
+// ExprPattern matches when the expression evaluates to true.
+type ExprPattern struct {
+	Expr Expr
+}
+
+// RangePattern matches from the first pattern to the second.
+type RangePattern struct {
+	Begin Expr
+	End   Expr
+}
+
+func (BeginPattern) patternNode()  {}
+func (EndPattern) patternNode()    {}
+func (*ExprPattern) patternNode()  {}
+func (*RangePattern) patternNode() {}
+
+// Stmt types.
+type Stmt interface {
+	stmtNode()
+}
+
+type ExprStmt struct {
+	Expr Expr
+}
+
+type PrintStmt struct {
+	Args []Expr
+	Dest *OutputDest
+}
+
+type PrintfStmt struct {
+	Args []Expr
+	Dest *OutputDest
+}
+
+// OutputDest represents an output redirection (blocked in safe mode).
+type OutputDest struct {
+	Type   outputDestType
+	Target Expr
+}
+
+type outputDestType int
+
+const (
+	destFile   outputDestType = iota // > file (blocked)
+	destAppend                       // >> file (blocked)
+	destPipe                         // | cmd (blocked)
+)
+
+type IfStmt struct {
+	Cond Expr
+	Then []Stmt
+	Else []Stmt
+}
+
+type WhileStmt struct {
+	Cond Expr
+	Body []Stmt
+}
+
+type DoWhileStmt struct {
+	Cond Expr
+	Body []Stmt
+}
+
+type ForStmt struct {
+	Init Stmt
+	Cond Expr
+	Post Stmt
+	Body []Stmt
+}
+
+type ForInStmt struct {
+	Var   string
+	Array string
+	Body  []Stmt
+}
+
+type BreakStmt struct{}
+type ContinueStmt struct{}
+type NextStmt struct{}
+
+type ExitStmt struct {
+	Value Expr // may be nil
+}
+
+type DeleteStmt struct {
+	Array string
+	Index []Expr // nil means delete entire array
+}
+
+type BlockStmt struct {
+	Stmts []Stmt
+}
+
+type ReturnStmt struct {
+	Value Expr // may be nil
+}
+
+func (*ExprStmt) stmtNode()     {}
+func (*PrintStmt) stmtNode()    {}
+func (*PrintfStmt) stmtNode()   {}
+func (*IfStmt) stmtNode()       {}
+func (*WhileStmt) stmtNode()    {}
+func (*DoWhileStmt) stmtNode()  {}
+func (*ForStmt) stmtNode()      {}
+func (*ForInStmt) stmtNode()    {}
+func (*BreakStmt) stmtNode()    {}
+func (*ContinueStmt) stmtNode() {}
+func (*NextStmt) stmtNode()     {}
+func (*ExitStmt) stmtNode()     {}
+func (*DeleteStmt) stmtNode()   {}
+func (*BlockStmt) stmtNode()    {}
+func (*ReturnStmt) stmtNode()   {}
+
+// Expr types.
+type Expr interface {
+	exprNode()
+}
+
+type NumberLit struct {
+	Val string
+}
+
+type StringLit struct {
+	Val string
+}
+
+type RegexLit struct {
+	Val string
+}
+
+type UnaryExpr struct {
+	Op   tokenType
+	Expr Expr
+}
+
+type BinaryExpr struct {
+	Op    tokenType
+	Left  Expr
+	Right Expr
+}
+
+type TernaryExpr struct {
+	Cond Expr
+	Then Expr
+	Else Expr
+}
+
+type AssignExpr struct {
+	Op     tokenType // tokASSIGN, tokPLUSASSIGN, etc.
+	Target Expr
+	Value  Expr
+}
+
+type IncrDecrExpr struct {
+	Op   tokenType // tokINCR or tokDECR
+	Expr Expr
+	Pre  bool // prefix (++x) vs postfix (x++)
+}
+
+type FieldExpr struct {
+	Index Expr
+}
+
+type VarExpr struct {
+	Name string
+}
+
+type ArrayExpr struct {
+	Name  string
+	Index []Expr
+}
+
+type InExpr struct {
+	Index []Expr
+	Array string
+}
+
+type MatchExpr struct {
+	Expr  Expr
+	Regex Expr
+	Not   bool
+}
+
+type ConcatExpr struct {
+	Left  Expr
+	Right Expr
+}
+
+type CallExpr struct {
+	Name string
+	Args []Expr
+}
+
+type GetlineExpr struct {
+	// simplified: plain getline with no I/O
+	Var string // optional variable to read into
+}
+
+// FuncDef is a user-defined function.
+type FuncDef struct {
+	Name   string
+	Params []string
+	Body   []Stmt
+}
+
+func (*NumberLit) exprNode()    {}
+func (*StringLit) exprNode()    {}
+func (*RegexLit) exprNode()     {}
+func (*UnaryExpr) exprNode()    {}
+func (*BinaryExpr) exprNode()   {}
+func (*TernaryExpr) exprNode()  {}
+func (*AssignExpr) exprNode()   {}
+func (*IncrDecrExpr) exprNode() {}
+func (*FieldExpr) exprNode()    {}
+func (*VarExpr) exprNode()      {}
+func (*ArrayExpr) exprNode()    {}
+func (*InExpr) exprNode()       {}
+func (*MatchExpr) exprNode()    {}
+func (*ConcatExpr) exprNode()   {}
+func (*CallExpr) exprNode()     {}
+func (*GetlineExpr) exprNode()  {}

--- a/interp/builtins/internal/awkcore/interp.go
+++ b/interp/builtins/internal/awkcore/interp.go
@@ -1,0 +1,1641 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awkcore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// Limits for safety.
+const (
+	MaxArraySize      = 100000
+	MaxStringLen      = 1 << 20 // 1 MiB
+	MaxLoopIterations = 10000000
+	MaxCallDepth      = 100
+	MaxOutputBytes    = 1 << 20 // 1 MiB
+	MaxRegexCache     = 1000
+	MaxSprintfWidth   = 1000
+	MaxProgFileSize   = 10 << 20 // 10 MiB
+)
+
+// RuntimeError is returned when awk encounters a runtime error.
+type RuntimeError struct {
+	msg      string
+	exitCode uint8
+	isExit   bool
+}
+
+func (e *RuntimeError) Error() string   { return e.msg }
+func (e *RuntimeError) ExitCode() uint8 { return e.exitCode }
+func (e *RuntimeError) IsExit() bool    { return e.isExit }
+
+// Control flow signals.
+type breakSignal struct{}
+type continueSignal struct{}
+type nextSignal struct{}
+type exitSignal struct{ code uint8 }
+type returnSignal struct{ val value }
+
+func (breakSignal) Error() string    { return "break" }
+func (continueSignal) Error() string { return "continue" }
+func (nextSignal) Error() string     { return "next" }
+func (e exitSignal) Error() string   { return fmt.Sprintf("exit %d", e.code) }
+func (returnSignal) Error() string   { return "return" }
+
+// value represents an awk value (number or string, lazily converted).
+type value struct {
+	str    string
+	num    float64
+	isNum  bool
+	strSet bool
+}
+
+var zeroValue = value{}
+
+func numVal(n float64) value {
+	return value{num: n, isNum: true}
+}
+
+func strVal(s string) value {
+	return value{str: s, strSet: true}
+}
+
+func (v value) toNum() float64 {
+	if v.isNum {
+		return v.num
+	}
+	s := strings.TrimSpace(v.str)
+	f, _ := strconv.ParseFloat(s, 64)
+	return f
+}
+
+func (v value) toStr() string {
+	if v.strSet {
+		return v.str
+	}
+	if v.isNum {
+		if v.num == float64(int64(v.num)) && !math.IsInf(v.num, 0) {
+			return strconv.FormatInt(int64(v.num), 10)
+		}
+		return strconv.FormatFloat(v.num, 'g', 6, 64)
+	}
+	return ""
+}
+
+func (v value) toBool() bool {
+	if v.isNum {
+		return v.num != 0
+	}
+	return v.str != ""
+}
+
+// Interpreter executes an awk program.
+type Interpreter struct {
+	prog   *Program
+	stdout io.Writer
+	stderr io.Writer
+
+	globals    map[string]value
+	arrays     map[string]map[string]value
+	fields     []string
+	record     string
+	rng        *rand.Rand
+	exitCode   uint8
+	callDepth  int
+	outBytes   int
+	regexCache map[string]*regexp.Regexp
+
+	// range pattern states: true when active.
+	rangeActive []bool
+}
+
+// NewInterpreter creates a new awk interpreter.
+func NewInterpreter(prog *Program, stdout, stderr io.Writer) *Interpreter {
+	interp := &Interpreter{
+		prog:       prog,
+		stdout:     stdout,
+		stderr:     stderr,
+		globals:    make(map[string]value),
+		arrays:     make(map[string]map[string]value),
+		rng:        rand.New(rand.NewSource(0)),
+		regexCache: make(map[string]*regexp.Regexp),
+	}
+	// Initialize built-in variables.
+	interp.globals["FS"] = strVal(" ")
+	interp.globals["RS"] = strVal("\n")
+	interp.globals["OFS"] = strVal(" ")
+	interp.globals["ORS"] = strVal("\n")
+	interp.globals["NR"] = numVal(0)
+	interp.globals["NF"] = numVal(0)
+	interp.globals["FNR"] = numVal(0)
+	interp.globals["FILENAME"] = strVal("")
+	interp.globals["SUBSEP"] = strVal("\x1c")
+	interp.globals["RSTART"] = numVal(0)
+	interp.globals["RLENGTH"] = numVal(-1)
+	interp.rangeActive = make([]bool, len(prog.Rules))
+
+	// ARGC/ARGV are set externally.
+	return interp
+}
+
+// SetFS sets the field separator.
+func (interp *Interpreter) SetFS(fs string) {
+	interp.globals["FS"] = strVal(fs)
+}
+
+// SetVar sets a global variable.
+func (interp *Interpreter) SetVar(name, val string) {
+	interp.globals[name] = strVal(val)
+}
+
+// SetFilename sets the FILENAME variable.
+func (interp *Interpreter) SetFilename(name string) {
+	interp.globals["FILENAME"] = strVal(name)
+}
+
+// ResetFNR resets the per-file record counter.
+func (interp *Interpreter) ResetFNR() {
+	interp.globals["FNR"] = numVal(0)
+}
+
+// ExitCode returns the program's exit code.
+func (interp *Interpreter) ExitCode() uint8 {
+	return interp.exitCode
+}
+
+// ExecBegin executes all BEGIN blocks.
+func (interp *Interpreter) ExecBegin(ctx context.Context) error {
+	for _, action := range interp.prog.Begin {
+		if err := interp.execStmts(ctx, action.Stmts); err != nil {
+			return interp.handleError(err)
+		}
+	}
+	return nil
+}
+
+// ExecEnd executes all END blocks.
+func (interp *Interpreter) ExecEnd(ctx context.Context) error {
+	for _, action := range interp.prog.End {
+		if err := interp.execStmts(ctx, action.Stmts); err != nil {
+			return interp.handleError(err)
+		}
+	}
+	return nil
+}
+
+// ExecLine processes one input line.
+func (interp *Interpreter) ExecLine(ctx context.Context, line string) error {
+	// Update NR and FNR.
+	interp.globals["NR"] = numVal(interp.globals["NR"].toNum() + 1)
+	interp.globals["FNR"] = numVal(interp.globals["FNR"].toNum() + 1)
+
+	interp.setRecord(line)
+
+	for i, rule := range interp.prog.Rules {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		matched, err := interp.matchPattern(ctx, rule.Pattern, i)
+		if err != nil {
+			return interp.handleError(err)
+		}
+		if !matched {
+			continue
+		}
+		if rule.Action != nil {
+			if err := interp.execStmts(ctx, rule.Action.Stmts); err != nil {
+				return interp.handleError(err)
+			}
+		} else {
+			// Default action: print $0.
+			interp.writeOut(interp.record + interp.globals["ORS"].toStr())
+		}
+	}
+	return nil
+}
+
+func (interp *Interpreter) setRecord(line string) {
+	interp.record = line
+	interp.globals["$0"] = strVal(line)
+	interp.splitRecord()
+}
+
+func (interp *Interpreter) splitRecord() {
+	fs := interp.globals["FS"].toStr()
+	parts := splitFields(interp.record, fs)
+	interp.fields = parts
+	interp.globals["NF"] = numVal(float64(len(parts)))
+}
+
+func (interp *Interpreter) matchPattern(ctx context.Context, pat Pattern, ruleIdx int) (bool, error) {
+	if pat == nil {
+		return true, nil
+	}
+	switch p := pat.(type) {
+	case *ExprPattern:
+		if re, ok := p.Expr.(*RegexLit); ok {
+			return interp.matchRegex(re.Val, interp.record)
+		}
+		v, err := interp.eval(ctx, p.Expr)
+		if err != nil {
+			return false, err
+		}
+		return v.toBool(), nil
+	case *RangePattern:
+		if !interp.rangeActive[ruleIdx] {
+			v, err := interp.eval(ctx, p.Begin)
+			if err != nil {
+				return false, err
+			}
+			if v.toBool() {
+				interp.rangeActive[ruleIdx] = true
+				return true, nil
+			}
+			return false, nil
+		}
+		v, err := interp.eval(ctx, p.End)
+		if err != nil {
+			return false, err
+		}
+		if v.toBool() {
+			interp.rangeActive[ruleIdx] = false
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (interp *Interpreter) handleError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch e := err.(type) {
+	case exitSignal:
+		interp.exitCode = e.code
+		return &RuntimeError{msg: e.Error(), exitCode: e.code, isExit: true}
+	case nextSignal:
+		return nil
+	case breakSignal, continueSignal:
+		return nil
+	case returnSignal:
+		return nil
+	case *RuntimeError:
+		return e
+	}
+	return &RuntimeError{msg: err.Error(), exitCode: 1}
+}
+
+func (interp *Interpreter) execStmts(ctx context.Context, stmts []Stmt) error {
+	for _, stmt := range stmts {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := interp.execStmt(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (interp *Interpreter) execStmt(ctx context.Context, stmt Stmt) error {
+	switch s := stmt.(type) {
+	case *ExprStmt:
+		_, err := interp.eval(ctx, s.Expr)
+		return err
+	case *PrintStmt:
+		return interp.execPrint(ctx, s)
+	case *PrintfStmt:
+		return interp.execPrintf(ctx, s)
+	case *IfStmt:
+		return interp.execIf(ctx, s)
+	case *WhileStmt:
+		return interp.execWhile(ctx, s)
+	case *DoWhileStmt:
+		return interp.execDoWhile(ctx, s)
+	case *ForStmt:
+		return interp.execFor(ctx, s)
+	case *ForInStmt:
+		return interp.execForIn(ctx, s)
+	case *BreakStmt:
+		return breakSignal{}
+	case *ContinueStmt:
+		return continueSignal{}
+	case *NextStmt:
+		return nextSignal{}
+	case *ExitStmt:
+		return interp.execExit(ctx, s)
+	case *DeleteStmt:
+		return interp.execDelete(ctx, s)
+	case *BlockStmt:
+		return interp.execStmts(ctx, s.Stmts)
+	case *ReturnStmt:
+		return interp.execReturn(ctx, s)
+	}
+	return nil
+}
+
+func (interp *Interpreter) execPrint(ctx context.Context, s *PrintStmt) error {
+	if s.Dest != nil {
+		return &RuntimeError{msg: "output redirection is not supported (blocked for safety)", exitCode: 1}
+	}
+	ofs := interp.globals["OFS"].toStr()
+	ors := interp.globals["ORS"].toStr()
+	if len(s.Args) == 0 {
+		interp.writeOut(interp.record + ors)
+		return nil
+	}
+	var parts []string
+	for _, arg := range s.Args {
+		v, err := interp.eval(ctx, arg)
+		if err != nil {
+			return err
+		}
+		parts = append(parts, v.toStr())
+	}
+	interp.writeOut(strings.Join(parts, ofs) + ors)
+	return nil
+}
+
+func (interp *Interpreter) execPrintf(ctx context.Context, s *PrintfStmt) error {
+	if s.Dest != nil {
+		return &RuntimeError{msg: "output redirection is not supported (blocked for safety)", exitCode: 1}
+	}
+	if len(s.Args) == 0 {
+		return nil
+	}
+	var vals []value
+	for _, arg := range s.Args {
+		v, err := interp.eval(ctx, arg)
+		if err != nil {
+			return err
+		}
+		vals = append(vals, v)
+	}
+	result := awkSprintf(vals)
+	interp.writeOut(result)
+	return nil
+}
+
+func (interp *Interpreter) execIf(ctx context.Context, s *IfStmt) error {
+	v, err := interp.eval(ctx, s.Cond)
+	if err != nil {
+		return err
+	}
+	if v.toBool() {
+		return interp.execStmts(ctx, s.Then)
+	}
+	if s.Else != nil {
+		return interp.execStmts(ctx, s.Else)
+	}
+	return nil
+}
+
+func (interp *Interpreter) execWhile(ctx context.Context, s *WhileStmt) error {
+	for i := 0; i < MaxLoopIterations; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		v, err := interp.eval(ctx, s.Cond)
+		if err != nil {
+			return err
+		}
+		if !v.toBool() {
+			break
+		}
+		if err := interp.execStmts(ctx, s.Body); err != nil {
+			if _, ok := err.(breakSignal); ok {
+				break
+			}
+			if _, ok := err.(continueSignal); ok {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (interp *Interpreter) execDoWhile(ctx context.Context, s *DoWhileStmt) error {
+	for i := 0; i < MaxLoopIterations; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := interp.execStmts(ctx, s.Body); err != nil {
+			if _, ok := err.(breakSignal); ok {
+				break
+			}
+			if _, ok := err.(continueSignal); ok {
+				// fall through to condition
+			} else {
+				return err
+			}
+		}
+		v, err := interp.eval(ctx, s.Cond)
+		if err != nil {
+			return err
+		}
+		if !v.toBool() {
+			break
+		}
+	}
+	return nil
+}
+
+func (interp *Interpreter) execFor(ctx context.Context, s *ForStmt) error {
+	if s.Init != nil {
+		if err := interp.execStmt(ctx, s.Init); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < MaxLoopIterations; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if s.Cond != nil {
+			v, err := interp.eval(ctx, s.Cond)
+			if err != nil {
+				return err
+			}
+			if !v.toBool() {
+				break
+			}
+		}
+		if err := interp.execStmts(ctx, s.Body); err != nil {
+			if _, ok := err.(breakSignal); ok {
+				break
+			}
+			if _, ok := err.(continueSignal); ok {
+				// fall through to post
+			} else {
+				return err
+			}
+		}
+		if s.Post != nil {
+			if err := interp.execStmt(ctx, s.Post); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (interp *Interpreter) execForIn(ctx context.Context, s *ForInStmt) error {
+	arr := interp.arrays[s.Array]
+	if arr == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(arr))
+	for k := range arr {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if i >= MaxLoopIterations {
+			break
+		}
+		interp.globals[s.Var] = strVal(k)
+		if err := interp.execStmts(ctx, s.Body); err != nil {
+			if _, ok := err.(breakSignal); ok {
+				break
+			}
+			if _, ok := err.(continueSignal); ok {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (interp *Interpreter) execExit(ctx context.Context, s *ExitStmt) error {
+	code := uint8(0)
+	if s.Value != nil {
+		v, err := interp.eval(ctx, s.Value)
+		if err != nil {
+			return err
+		}
+		n := v.toNum()
+		if n < 0 {
+			n = 0
+		} else if n > 255 {
+			n = 255
+		}
+		code = uint8(n)
+	}
+	return exitSignal{code: code}
+}
+
+func (interp *Interpreter) execDelete(ctx context.Context, s *DeleteStmt) error {
+	if s.Index == nil {
+		delete(interp.arrays, s.Array)
+		return nil
+	}
+	arr := interp.arrays[s.Array]
+	if arr == nil {
+		return nil
+	}
+	key, err := interp.buildArrayKey(ctx, s.Index)
+	if err != nil {
+		return err
+	}
+	delete(arr, key)
+	return nil
+}
+
+func (interp *Interpreter) execReturn(ctx context.Context, s *ReturnStmt) error {
+	var v value
+	if s.Value != nil {
+		var err error
+		v, err = interp.eval(ctx, s.Value)
+		if err != nil {
+			return err
+		}
+	}
+	return returnSignal{val: v}
+}
+
+// eval evaluates an expression.
+func (interp *Interpreter) eval(ctx context.Context, expr Expr) (value, error) {
+	if ctx.Err() != nil {
+		return zeroValue, ctx.Err()
+	}
+	switch e := expr.(type) {
+	case *NumberLit:
+		f, _ := strconv.ParseFloat(e.Val, 64)
+		return numVal(f), nil
+	case *StringLit:
+		return strVal(e.Val), nil
+	case *RegexLit:
+		matched, err := interp.matchRegex(e.Val, interp.record)
+		if err != nil {
+			return zeroValue, err
+		}
+		if matched {
+			return numVal(1), nil
+		}
+		return numVal(0), nil
+	case *VarExpr:
+		return interp.getVar(e.Name), nil
+	case *FieldExpr:
+		return interp.evalField(ctx, e)
+	case *ArrayExpr:
+		return interp.evalArray(ctx, e)
+	case *UnaryExpr:
+		return interp.evalUnary(ctx, e)
+	case *BinaryExpr:
+		return interp.evalBinary(ctx, e)
+	case *TernaryExpr:
+		return interp.evalTernary(ctx, e)
+	case *AssignExpr:
+		return interp.evalAssign(ctx, e)
+	case *IncrDecrExpr:
+		return interp.evalIncrDecr(ctx, e)
+	case *ConcatExpr:
+		return interp.evalConcat(ctx, e)
+	case *MatchExpr:
+		return interp.evalMatch(ctx, e)
+	case *InExpr:
+		return interp.evalIn(ctx, e)
+	case *CallExpr:
+		return interp.evalCall(ctx, e)
+	case *GetlineExpr:
+		return zeroValue, &RuntimeError{msg: "getline is not supported in this context", exitCode: 1}
+	}
+	return zeroValue, nil
+}
+
+func (interp *Interpreter) getVar(name string) value {
+	if v, ok := interp.globals[name]; ok {
+		return v
+	}
+	return zeroValue
+}
+
+func (interp *Interpreter) evalField(ctx context.Context, e *FieldExpr) (value, error) {
+	v, err := interp.eval(ctx, e.Index)
+	if err != nil {
+		return zeroValue, err
+	}
+	idx := int(v.toNum())
+	if idx == 0 {
+		return strVal(interp.record), nil
+	}
+	if idx < 0 || idx > len(interp.fields) {
+		return strVal(""), nil
+	}
+	return strVal(interp.fields[idx-1]), nil
+}
+
+func (interp *Interpreter) evalArray(ctx context.Context, e *ArrayExpr) (value, error) {
+	key, err := interp.buildArrayKey(ctx, e.Index)
+	if err != nil {
+		return zeroValue, err
+	}
+	arr := interp.arrays[e.Name]
+	if arr == nil {
+		return zeroValue, nil
+	}
+	return arr[key], nil
+}
+
+func (interp *Interpreter) evalUnary(ctx context.Context, e *UnaryExpr) (value, error) {
+	v, err := interp.eval(ctx, e.Expr)
+	if err != nil {
+		return zeroValue, err
+	}
+	switch e.Op {
+	case tokNOT:
+		if v.toBool() {
+			return numVal(0), nil
+		}
+		return numVal(1), nil
+	case tokMINUS:
+		return numVal(-v.toNum()), nil
+	}
+	return v, nil
+}
+
+func (interp *Interpreter) evalBinary(ctx context.Context, e *BinaryExpr) (value, error) {
+	// Short-circuit for logical operators.
+	if e.Op == tokAND {
+		left, err := interp.eval(ctx, e.Left)
+		if err != nil {
+			return zeroValue, err
+		}
+		if !left.toBool() {
+			return numVal(0), nil
+		}
+		right, err := interp.eval(ctx, e.Right)
+		if err != nil {
+			return zeroValue, err
+		}
+		if right.toBool() {
+			return numVal(1), nil
+		}
+		return numVal(0), nil
+	}
+	if e.Op == tokOR {
+		left, err := interp.eval(ctx, e.Left)
+		if err != nil {
+			return zeroValue, err
+		}
+		if left.toBool() {
+			return numVal(1), nil
+		}
+		right, err := interp.eval(ctx, e.Right)
+		if err != nil {
+			return zeroValue, err
+		}
+		if right.toBool() {
+			return numVal(1), nil
+		}
+		return numVal(0), nil
+	}
+
+	left, err := interp.eval(ctx, e.Left)
+	if err != nil {
+		return zeroValue, err
+	}
+	right, err := interp.eval(ctx, e.Right)
+	if err != nil {
+		return zeroValue, err
+	}
+
+	switch e.Op {
+	case tokPLUS:
+		return numVal(left.toNum() + right.toNum()), nil
+	case tokMINUS:
+		return numVal(left.toNum() - right.toNum()), nil
+	case tokSTAR:
+		return numVal(left.toNum() * right.toNum()), nil
+	case tokSLASH:
+		d := right.toNum()
+		if d == 0 {
+			return zeroValue, &RuntimeError{msg: "division by zero", exitCode: 2}
+		}
+		return numVal(left.toNum() / d), nil
+	case tokPERCENT:
+		d := right.toNum()
+		if d == 0 {
+			return zeroValue, &RuntimeError{msg: "division by zero", exitCode: 2}
+		}
+		return numVal(math.Mod(left.toNum(), d)), nil
+	case tokPOWER:
+		return numVal(math.Pow(left.toNum(), right.toNum())), nil
+	case tokLT:
+		return boolToNum(compareValues(left, right) < 0), nil
+	case tokLE:
+		return boolToNum(compareValues(left, right) <= 0), nil
+	case tokGT:
+		return boolToNum(compareValues(left, right) > 0), nil
+	case tokGE:
+		return boolToNum(compareValues(left, right) >= 0), nil
+	case tokEQ:
+		return boolToNum(compareValues(left, right) == 0), nil
+	case tokNE:
+		return boolToNum(compareValues(left, right) != 0), nil
+	}
+	return zeroValue, nil
+}
+
+func compareValues(a, b value) int {
+	// If both are numeric, compare as numbers.
+	aNum, aIsNum := tryParseNum(a)
+	bNum, bIsNum := tryParseNum(b)
+	if aIsNum && bIsNum {
+		if aNum < bNum {
+			return -1
+		}
+		if aNum > bNum {
+			return 1
+		}
+		return 0
+	}
+	// Otherwise compare as strings.
+	as := a.toStr()
+	bs := b.toStr()
+	if as < bs {
+		return -1
+	}
+	if as > bs {
+		return 1
+	}
+	return 0
+}
+
+func tryParseNum(v value) (float64, bool) {
+	if v.isNum {
+		return v.num, true
+	}
+	if v.strSet {
+		s := strings.TrimSpace(v.str)
+		if s == "" {
+			return 0, false
+		}
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	}
+	return 0, true
+}
+
+func boolToNum(b bool) value {
+	if b {
+		return numVal(1)
+	}
+	return numVal(0)
+}
+
+func (interp *Interpreter) evalTernary(ctx context.Context, e *TernaryExpr) (value, error) {
+	v, err := interp.eval(ctx, e.Cond)
+	if err != nil {
+		return zeroValue, err
+	}
+	if v.toBool() {
+		return interp.eval(ctx, e.Then)
+	}
+	return interp.eval(ctx, e.Else)
+}
+
+func (interp *Interpreter) evalAssign(ctx context.Context, e *AssignExpr) (value, error) {
+	val, err := interp.eval(ctx, e.Value)
+	if err != nil {
+		return zeroValue, err
+	}
+
+	if e.Op != tokASSIGN {
+		old, err := interp.eval(ctx, e.Target)
+		if err != nil {
+			return zeroValue, err
+		}
+		switch e.Op {
+		case tokPLUSASSIGN:
+			val = numVal(old.toNum() + val.toNum())
+		case tokMINUSASSIGN:
+			val = numVal(old.toNum() - val.toNum())
+		case tokSTARASSIGN:
+			val = numVal(old.toNum() * val.toNum())
+		case tokSLASHASSIGN:
+			d := val.toNum()
+			if d == 0 {
+				return zeroValue, &RuntimeError{msg: "division by zero", exitCode: 2}
+			}
+			val = numVal(old.toNum() / d)
+		case tokPERCENTASSIGN:
+			d := val.toNum()
+			if d == 0 {
+				return zeroValue, &RuntimeError{msg: "division by zero", exitCode: 2}
+			}
+			val = numVal(math.Mod(old.toNum(), d))
+		case tokPOWERASSIGN:
+			val = numVal(math.Pow(old.toNum(), val.toNum()))
+		}
+	}
+
+	interp.assignTo(ctx, e.Target, val)
+	return val, nil
+}
+
+func (interp *Interpreter) assignTo(ctx context.Context, target Expr, val value) {
+	switch t := target.(type) {
+	case *VarExpr:
+		interp.globals[t.Name] = val
+	case *FieldExpr:
+		v, _ := interp.eval(ctx, t.Index)
+		idx := int(v.toNum())
+		interp.setField(idx, val.toStr())
+	case *ArrayExpr:
+		key, _ := interp.buildArrayKey(ctx, t.Index)
+		arr := interp.arrays[t.Name]
+		if arr == nil {
+			arr = make(map[string]value)
+			interp.arrays[t.Name] = arr
+		}
+		if len(arr) >= MaxArraySize {
+			return
+		}
+		arr[key] = val
+	}
+}
+
+func (interp *Interpreter) setField(idx int, val string) {
+	if idx == 0 {
+		interp.setRecord(val)
+		return
+	}
+	if idx < 0 || idx > MaxArraySize {
+		return
+	}
+	for len(interp.fields) < idx {
+		interp.fields = append(interp.fields, "")
+	}
+	interp.fields[idx-1] = val
+	interp.globals["NF"] = numVal(float64(len(interp.fields)))
+	interp.rebuildRecord()
+}
+
+func (interp *Interpreter) rebuildRecord() {
+	ofs := interp.globals["OFS"].toStr()
+	interp.record = strings.Join(interp.fields, ofs)
+	interp.globals["$0"] = strVal(interp.record)
+}
+
+func (interp *Interpreter) evalIncrDecr(ctx context.Context, e *IncrDecrExpr) (value, error) {
+	old, err := interp.eval(ctx, e.Expr)
+	if err != nil {
+		return zeroValue, err
+	}
+	n := old.toNum()
+	var newVal float64
+	if e.Op == tokINCR {
+		newVal = n + 1
+	} else {
+		newVal = n - 1
+	}
+	interp.assignTo(ctx, e.Expr, numVal(newVal))
+	if e.Pre {
+		return numVal(newVal), nil
+	}
+	return numVal(n), nil
+}
+
+func (interp *Interpreter) evalConcat(ctx context.Context, e *ConcatExpr) (value, error) {
+	left, err := interp.eval(ctx, e.Left)
+	if err != nil {
+		return zeroValue, err
+	}
+	right, err := interp.eval(ctx, e.Right)
+	if err != nil {
+		return zeroValue, err
+	}
+	result := left.toStr() + right.toStr()
+	if len(result) > MaxStringLen {
+		result = result[:MaxStringLen]
+	}
+	return strVal(result), nil
+}
+
+func (interp *Interpreter) evalMatch(ctx context.Context, e *MatchExpr) (value, error) {
+	left, err := interp.eval(ctx, e.Expr)
+	if err != nil {
+		return zeroValue, err
+	}
+	pattern := interp.regexPattern(ctx, e.Regex)
+	matched, err := interp.matchRegex(pattern, left.toStr())
+	if err != nil {
+		return zeroValue, err
+	}
+	if e.Not {
+		matched = !matched
+	}
+	return boolToNum(matched), nil
+}
+
+func (interp *Interpreter) evalIn(ctx context.Context, e *InExpr) (value, error) {
+	key, err := interp.buildArrayKey(ctx, e.Index)
+	if err != nil {
+		return zeroValue, err
+	}
+	arr := interp.arrays[e.Array]
+	if arr == nil {
+		return numVal(0), nil
+	}
+	if _, ok := arr[key]; ok {
+		return numVal(1), nil
+	}
+	return numVal(0), nil
+}
+
+func (interp *Interpreter) evalCall(ctx context.Context, e *CallExpr) (value, error) {
+	// Check for built-in functions first.
+	if v, err, handled := interp.callBuiltin(ctx, e); handled {
+		return v, err
+	}
+
+	// User-defined function.
+	fn, ok := interp.prog.Funcs[e.Name]
+	if !ok {
+		return zeroValue, &RuntimeError{
+			msg:      fmt.Sprintf("undefined function: %s", e.Name),
+			exitCode: 1,
+		}
+	}
+
+	interp.callDepth++
+	if interp.callDepth > MaxCallDepth {
+		interp.callDepth--
+		return zeroValue, &RuntimeError{msg: "call depth exceeded", exitCode: 1}
+	}
+	defer func() { interp.callDepth-- }()
+
+	// Save and restore globals that are parameters.
+	saved := make(map[string]value)
+	savedArrays := make(map[string]map[string]value)
+	for _, p := range fn.Params {
+		if v, ok := interp.globals[p]; ok {
+			saved[p] = v
+		}
+		if a, ok := interp.arrays[p]; ok {
+			savedArrays[p] = a
+		}
+		delete(interp.globals, p)
+		delete(interp.arrays, p)
+	}
+	defer func() {
+		for _, p := range fn.Params {
+			delete(interp.globals, p)
+			delete(interp.arrays, p)
+		}
+		for k, v := range saved {
+			interp.globals[k] = v
+		}
+		for k, v := range savedArrays {
+			interp.arrays[k] = v
+		}
+	}()
+
+	// Assign parameter values.
+	for i, p := range fn.Params {
+		if i < len(e.Args) {
+			v, err := interp.eval(ctx, e.Args[i])
+			if err != nil {
+				return zeroValue, err
+			}
+			interp.globals[p] = v
+		}
+	}
+
+	// Execute body.
+	err := interp.execStmts(ctx, fn.Body)
+	if err != nil {
+		if rs, ok := err.(returnSignal); ok {
+			return rs.val, nil
+		}
+		return zeroValue, err
+	}
+	return zeroValue, nil
+}
+
+func (interp *Interpreter) callBuiltin(ctx context.Context, e *CallExpr) (value, error, bool) {
+	evalArgs := func() ([]value, error) {
+		vals := make([]value, len(e.Args))
+		for i, a := range e.Args {
+			v, err := interp.eval(ctx, a)
+			if err != nil {
+				return nil, err
+			}
+			vals[i] = v
+		}
+		return vals, nil
+	}
+
+	switch e.Name {
+	case "length":
+		if len(e.Args) == 0 {
+			return numVal(float64(len(interp.record))), nil, true
+		}
+		// Check if argument is an array name.
+		if ve, ok := e.Args[0].(*VarExpr); ok {
+			if arr, ok := interp.arrays[ve.Name]; ok {
+				return numVal(float64(len(arr))), nil, true
+			}
+		}
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		return numVal(float64(utf8.RuneCountInString(args[0].toStr()))), nil, true
+
+	case "substr":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 2 {
+			return zeroValue, &RuntimeError{msg: "substr: too few arguments", exitCode: 1}, true
+		}
+		s := args[0].toStr()
+		start := int(args[1].toNum()) - 1
+		runes := []rune(s)
+		if start < 0 {
+			start = 0
+		}
+		if start >= len(runes) {
+			return strVal(""), nil, true
+		}
+		if len(args) >= 3 {
+			length := int(args[2].toNum())
+			if length < 0 {
+				length = 0
+			}
+			end := start + length
+			if end > len(runes) {
+				end = len(runes)
+			}
+			return strVal(string(runes[start:end])), nil, true
+		}
+		return strVal(string(runes[start:])), nil, true
+
+	case "index":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 2 {
+			return zeroValue, &RuntimeError{msg: "index: too few arguments", exitCode: 1}, true
+		}
+		idx := strings.Index(args[0].toStr(), args[1].toStr())
+		return numVal(float64(idx + 1)), nil, true
+
+	case "split":
+		if len(e.Args) < 2 {
+			return zeroValue, &RuntimeError{msg: "split: too few arguments", exitCode: 1}, true
+		}
+		strArg, err := interp.eval(ctx, e.Args[0])
+		if err != nil {
+			return zeroValue, err, true
+		}
+		arrayExpr, ok := e.Args[1].(*VarExpr)
+		if !ok {
+			return zeroValue, &RuntimeError{msg: "split: second argument must be an array", exitCode: 1}, true
+		}
+		var fs string
+		if len(e.Args) >= 3 {
+			fsVal, err := interp.eval(ctx, e.Args[2])
+			if err != nil {
+				return zeroValue, err, true
+			}
+			fs = fsVal.toStr()
+		} else {
+			fs = interp.globals["FS"].toStr()
+		}
+		parts := splitFields(strArg.toStr(), fs)
+		arr := make(map[string]value)
+		for i, p := range parts {
+			if i >= MaxArraySize {
+				break
+			}
+			arr[strconv.Itoa(i+1)] = strVal(p)
+		}
+		interp.arrays[arrayExpr.Name] = arr
+		return numVal(float64(len(parts))), nil, true
+
+	case "sub":
+		return interp.callSub(ctx, e, false)
+	case "gsub":
+		return interp.callSub(ctx, e, true)
+
+	case "match":
+		if len(e.Args) < 2 {
+			return zeroValue, &RuntimeError{msg: "match: too few arguments", exitCode: 1}, true
+		}
+		strArg, err := interp.eval(ctx, e.Args[0])
+		if err != nil {
+			return zeroValue, err, true
+		}
+		pattern := interp.regexPattern(ctx, e.Args[1])
+		re, err := interp.compileRegex(pattern)
+		if err != nil {
+			return zeroValue, &RuntimeError{msg: fmt.Sprintf("match: %s", err), exitCode: 1}, true
+		}
+		loc := re.FindStringIndex(strArg.toStr())
+		if loc == nil {
+			interp.globals["RSTART"] = numVal(0)
+			interp.globals["RLENGTH"] = numVal(-1)
+			return numVal(0), nil, true
+		}
+		interp.globals["RSTART"] = numVal(float64(loc[0] + 1))
+		interp.globals["RLENGTH"] = numVal(float64(loc[1] - loc[0]))
+		return numVal(float64(loc[0] + 1)), nil, true
+
+	case "sprintf":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		return strVal(awkSprintf(args)), nil, true
+
+	case "tolower":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return strVal(""), nil, true
+		}
+		return strVal(strings.ToLower(args[0].toStr())), nil, true
+
+	case "toupper":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return strVal(""), nil, true
+		}
+		return strVal(strings.ToUpper(args[0].toStr())), nil, true
+
+	case "int":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return numVal(0), nil, true
+		}
+		return numVal(float64(int64(args[0].toNum()))), nil, true
+
+	case "sqrt":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return numVal(0), nil, true
+		}
+		return numVal(math.Sqrt(args[0].toNum())), nil, true
+
+	case "sin":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return numVal(0), nil, true
+		}
+		return numVal(math.Sin(args[0].toNum())), nil, true
+
+	case "cos":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return numVal(1), nil, true
+		}
+		return numVal(math.Cos(args[0].toNum())), nil, true
+
+	case "atan2":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 2 {
+			return numVal(0), nil, true
+		}
+		return numVal(math.Atan2(args[0].toNum(), args[1].toNum())), nil, true
+
+	case "exp":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return numVal(1), nil, true
+		}
+		return numVal(math.Exp(args[0].toNum())), nil, true
+
+	case "log":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		if len(args) < 1 {
+			return numVal(math.Inf(-1)), nil, true
+		}
+		return numVal(math.Log(args[0].toNum())), nil, true
+
+	case "rand":
+		return numVal(interp.rng.Float64()), nil, true
+
+	case "srand":
+		args, err := evalArgs()
+		if err != nil {
+			return zeroValue, err, true
+		}
+		var seed int64
+		if len(args) > 0 {
+			seed = int64(args[0].toNum())
+		} else {
+			seed = 1
+		}
+		interp.rng = rand.New(rand.NewSource(seed))
+		return numVal(float64(seed)), nil, true
+
+	case "system":
+		return zeroValue, &RuntimeError{
+			msg:      "system() is not supported (blocked for safety)",
+			exitCode: 1,
+		}, true
+
+	case "close":
+		return zeroValue, &RuntimeError{
+			msg:      "close() is not supported (no I/O redirection)",
+			exitCode: 1,
+		}, true
+	}
+	return zeroValue, nil, false
+}
+
+func (interp *Interpreter) callSub(ctx context.Context, e *CallExpr, global bool) (value, error, bool) {
+	if len(e.Args) < 2 {
+		name := "sub"
+		if global {
+			name = "gsub"
+		}
+		return zeroValue, &RuntimeError{msg: fmt.Sprintf("%s: too few arguments", name), exitCode: 1}, true
+	}
+	pattern := interp.regexPattern(ctx, e.Args[0])
+	replVal, err := interp.eval(ctx, e.Args[1])
+	if err != nil {
+		return zeroValue, err, true
+	}
+	var target Expr
+	if len(e.Args) >= 3 {
+		target = e.Args[2]
+	} else {
+		target = &FieldExpr{Index: &NumberLit{Val: "0"}}
+	}
+	origVal, err := interp.eval(ctx, target)
+	if err != nil {
+		return zeroValue, err, true
+	}
+
+	re, err := interp.compileRegex(pattern)
+	if err != nil {
+		return zeroValue, &RuntimeError{msg: fmt.Sprintf("sub: %s", err), exitCode: 1}, true
+	}
+
+	orig := origVal.toStr()
+	repl := replVal.toStr()
+	// In awk, & in replacement means matched text.
+	count := 0
+	var result string
+	if global {
+		result = re.ReplaceAllStringFunc(orig, func(m string) string {
+			count++
+			return expandReplacement(repl, m)
+		})
+	} else {
+		replaced := false
+		result = re.ReplaceAllStringFunc(orig, func(m string) string {
+			if replaced {
+				return m
+			}
+			replaced = true
+			count++
+			return expandReplacement(repl, m)
+		})
+	}
+
+	interp.assignTo(ctx, target, strVal(result))
+	return numVal(float64(count)), nil, true
+}
+
+func expandReplacement(repl, matched string) string {
+	var sb strings.Builder
+	for i := 0; i < len(repl); i++ {
+		if repl[i] == '\\' && i+1 < len(repl) {
+			if repl[i+1] == '&' {
+				sb.WriteByte('&')
+				i++
+				continue
+			}
+			if repl[i+1] == '\\' {
+				sb.WriteByte('\\')
+				i++
+				continue
+			}
+		}
+		if repl[i] == '&' {
+			sb.WriteString(matched)
+			continue
+		}
+		sb.WriteByte(repl[i])
+	}
+	return sb.String()
+}
+
+func (interp *Interpreter) buildArrayKey(ctx context.Context, indices []Expr) (string, error) {
+	if len(indices) == 1 {
+		v, err := interp.eval(ctx, indices[0])
+		if err != nil {
+			return "", err
+		}
+		return v.toStr(), nil
+	}
+	subsep := interp.globals["SUBSEP"].toStr()
+	var parts []string
+	for _, idx := range indices {
+		v, err := interp.eval(ctx, idx)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, v.toStr())
+	}
+	return strings.Join(parts, subsep), nil
+}
+
+// regexPattern extracts a regex pattern string from an expression.
+// If the expression is a RegexLit, returns its pattern directly.
+// Otherwise, evaluates the expression and returns its string value.
+func (interp *Interpreter) regexPattern(ctx context.Context, expr Expr) string {
+	if re, ok := expr.(*RegexLit); ok {
+		return re.Val
+	}
+	v, _ := interp.eval(ctx, expr)
+	return v.toStr()
+}
+
+func (interp *Interpreter) compileRegex(pattern string) (*regexp.Regexp, error) {
+	if re, ok := interp.regexCache[pattern]; ok {
+		return re, nil
+	}
+	if len(interp.regexCache) >= MaxRegexCache {
+		// Evict all to prevent unbounded growth.
+		interp.regexCache = make(map[string]*regexp.Regexp)
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex %q: %s", pattern, err)
+	}
+	interp.regexCache[pattern] = re
+	return re, nil
+}
+
+func (interp *Interpreter) matchRegex(pattern, s string) (bool, error) {
+	re, err := interp.compileRegex(pattern)
+	if err != nil {
+		return false, &RuntimeError{msg: err.Error(), exitCode: 1}
+	}
+	return re.MatchString(s), nil
+}
+
+func (interp *Interpreter) writeOut(s string) {
+	if interp.outBytes+len(s) > MaxOutputBytes {
+		remaining := MaxOutputBytes - interp.outBytes
+		if remaining > 0 {
+			_, _ = io.WriteString(interp.stdout, s[:remaining])
+			interp.outBytes = MaxOutputBytes
+		}
+		return
+	}
+	_, _ = io.WriteString(interp.stdout, s)
+	interp.outBytes += len(s)
+}
+
+// awkSprintf implements awk's sprintf formatting.
+func awkSprintf(args []value) string {
+	if len(args) == 0 {
+		return ""
+	}
+	format := args[0].toStr()
+	argIdx := 1
+	var sb strings.Builder
+	i := 0
+	for i < len(format) {
+		if format[i] == '%' {
+			i++
+			if i >= len(format) {
+				sb.WriteByte('%')
+				break
+			}
+			if format[i] == '%' {
+				sb.WriteByte('%')
+				i++
+				continue
+			}
+			// Parse format specifier.
+			specStart := i - 1
+			// Flags.
+			for i < len(format) && (format[i] == '-' || format[i] == '+' || format[i] == ' ' || format[i] == '0' || format[i] == '#') {
+				i++
+			}
+			// Width (capped to prevent memory exhaustion).
+			widthStart := i
+			if i < len(format) && format[i] == '*' {
+				i++
+			} else {
+				for i < len(format) && format[i] >= '0' && format[i] <= '9' {
+					i++
+				}
+			}
+			if w, err := strconv.Atoi(format[widthStart:i]); err == nil && w > MaxSprintfWidth {
+				i = widthStart
+				for i < len(format) && format[i] >= '0' && format[i] <= '9' {
+					i++
+				}
+			}
+			// Precision (capped to prevent memory exhaustion).
+			if i < len(format) && format[i] == '.' {
+				i++
+				precStart := i
+				if i < len(format) && format[i] == '*' {
+					i++
+				} else {
+					for i < len(format) && format[i] >= '0' && format[i] <= '9' {
+						i++
+					}
+				}
+				if p, err := strconv.Atoi(format[precStart:i]); err == nil && p > MaxSprintfWidth {
+					_ = p
+				}
+			}
+			if i >= len(format) {
+				sb.WriteString(format[specStart:])
+				break
+			}
+			conv := format[i]
+			i++
+			rawSpec := format[specStart:i]
+			spec := clampFormatSpec(rawSpec, MaxSprintfWidth)
+
+			var arg value
+			if argIdx < len(args) {
+				arg = args[argIdx]
+				argIdx++
+			}
+			switch conv {
+			case 'd', 'i':
+				sb.WriteString(fmt.Sprintf(strings.Replace(spec, string(conv), "d", 1), int64(arg.toNum())))
+			case 'o', 'x', 'X':
+				n := int64(arg.toNum())
+				if n < 0 {
+					n = 0
+				}
+				sb.WriteString(fmt.Sprintf(spec, uint64(n)))
+			case 'f', 'e', 'E', 'g', 'G':
+				sb.WriteString(fmt.Sprintf(spec, arg.toNum()))
+			case 's':
+				sb.WriteString(fmt.Sprintf(spec, arg.toStr()))
+			case 'c':
+				n := int(arg.toNum())
+				if n > 0 && n < 128 {
+					sb.WriteByte(byte(n))
+				} else {
+					s := arg.toStr()
+					if s != "" {
+						sb.WriteByte(s[0])
+					}
+				}
+			default:
+				sb.WriteString(spec)
+			}
+		} else if format[i] == '\\' && i+1 < len(format) {
+			i++
+			switch format[i] {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case 'r':
+				sb.WriteByte('\r')
+			case '\\':
+				sb.WriteByte('\\')
+			case '"':
+				sb.WriteByte('"')
+			default:
+				sb.WriteByte('\\')
+				sb.WriteByte(format[i])
+			}
+			i++
+		} else {
+			sb.WriteByte(format[i])
+			i++
+		}
+	}
+	return sb.String()
+}
+
+// clampFormatSpec rewrites a printf format specifier to cap width and
+// precision at maxW, preventing memory exhaustion from specs like "%999999999s".
+func clampFormatSpec(spec string, maxW int) string {
+	if len(spec) < 2 {
+		return spec
+	}
+	maxStr := strconv.Itoa(maxW)
+	var result strings.Builder
+	i := 0
+	result.WriteByte(spec[i])
+	i++
+	for i < len(spec) && (spec[i] == '-' || spec[i] == '+' || spec[i] == ' ' || spec[i] == '0' || spec[i] == '#') {
+		result.WriteByte(spec[i])
+		i++
+	}
+	if i < len(spec) && spec[i] == '*' {
+		result.WriteByte(spec[i])
+		i++
+	} else {
+		start := i
+		for i < len(spec) && spec[i] >= '0' && spec[i] <= '9' {
+			i++
+		}
+		if w, err := strconv.Atoi(spec[start:i]); err == nil && w > maxW {
+			result.WriteString(maxStr)
+		} else {
+			result.WriteString(spec[start:i])
+		}
+	}
+	if i < len(spec) && spec[i] == '.' {
+		result.WriteByte('.')
+		i++
+		if i < len(spec) && spec[i] == '*' {
+			result.WriteByte(spec[i])
+			i++
+		} else {
+			start := i
+			for i < len(spec) && spec[i] >= '0' && spec[i] <= '9' {
+				i++
+			}
+			if p, err := strconv.Atoi(spec[start:i]); err == nil && p > maxW {
+				result.WriteString(maxStr)
+			} else {
+				result.WriteString(spec[start:i])
+			}
+		}
+	}
+	for i < len(spec) {
+		result.WriteByte(spec[i])
+		i++
+	}
+	return result.String()
+}
+
+// splitFields splits a string by the given field separator, following awk semantics.
+func splitFields(s, fs string) []string {
+	if fs == " " {
+		return strings.Fields(s)
+	}
+	if fs == "" {
+		var parts []string
+		for _, r := range s {
+			parts = append(parts, string(r))
+		}
+		return parts
+	}
+	if len(fs) == 1 {
+		return strings.Split(s, fs)
+	}
+	re, err := regexp.Compile(fs)
+	if err != nil {
+		return []string{s}
+	}
+	return re.Split(s, -1)
+}

--- a/interp/builtins/internal/awkcore/lexer.go
+++ b/interp/builtins/internal/awkcore/lexer.go
@@ -1,0 +1,456 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awkcore
+
+import (
+	"fmt"
+	"strings"
+)
+
+// lexer tokenizes awk program source text.
+type lexer struct {
+	src    string
+	pos    int
+	tokens []token
+}
+
+func lex(src string) ([]token, error) {
+	l := &lexer{src: src}
+	if err := l.run(); err != nil {
+		return nil, err
+	}
+	l.tokens = append(l.tokens, token{typ: tokEOF, pos: l.pos})
+	return l.tokens, nil
+}
+
+func (l *lexer) run() error {
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+
+		// Skip spaces and tabs.
+		if ch == ' ' || ch == '\t' {
+			l.pos++
+			continue
+		}
+
+		// Skip comments.
+		if ch == '#' {
+			for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+				l.pos++
+			}
+			continue
+		}
+
+		// Backslash-newline continuation.
+		if ch == '\\' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '\n' {
+			l.pos += 2
+			continue
+		}
+
+		// Newline.
+		if ch == '\n' || ch == '\r' {
+			l.emit(tokNEWLINE, l.pos, l.pos+1)
+			l.pos++
+			if ch == '\r' && l.pos < len(l.src) && l.src[l.pos] == '\n' {
+				l.pos++
+			}
+			continue
+		}
+
+		if ch == ';' {
+			l.emit(tokSEMI, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '{' {
+			l.emit(tokLBRACE, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '}' {
+			l.emit(tokRBRACE, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '(' {
+			l.emit(tokLPAREN, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == ')' {
+			l.emit(tokRPAREN, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '[' {
+			l.emit(tokLBRACKET, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == ']' {
+			l.emit(tokRBRACKET, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == ',' {
+			l.emit(tokCOMMA, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '$' {
+			l.emit(tokDOLLAR, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '?' {
+			l.emit(tokQUESTION, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == ':' {
+			l.emit(tokCOLON, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+
+		// Two-character operators.
+		if ch == '+' {
+			if l.peek(1) == '+' {
+				l.emit(tokINCR, l.pos, l.pos+2)
+				l.pos += 2
+			} else if l.peek(1) == '=' {
+				l.emit(tokPLUSASSIGN, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokPLUS, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '-' {
+			if l.peek(1) == '-' {
+				l.emit(tokDECR, l.pos, l.pos+2)
+				l.pos += 2
+			} else if l.peek(1) == '=' {
+				l.emit(tokMINUSASSIGN, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokMINUS, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '*' {
+			if l.peek(1) == '=' {
+				l.emit(tokSTARASSIGN, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokSTAR, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '%' {
+			if l.peek(1) == '=' {
+				l.emit(tokPERCENTASSIGN, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokPERCENT, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '^' {
+			if l.peek(1) == '=' {
+				l.emit(tokPOWERASSIGN, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokPOWER, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '<' {
+			if l.peek(1) == '=' {
+				l.emit(tokLE, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokLT, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '>' {
+			if l.peek(1) == '=' {
+				l.emit(tokGE, l.pos, l.pos+2)
+				l.pos += 2
+			} else if l.peek(1) == '>' {
+				l.emit(tokAPPEND, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokGT, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '=' {
+			if l.peek(1) == '=' {
+				l.emit(tokEQ, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokASSIGN, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '!' {
+			if l.peek(1) == '=' {
+				l.emit(tokNE, l.pos, l.pos+2)
+				l.pos += 2
+			} else if l.peek(1) == '~' {
+				l.emit(tokNOTMATCH, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokNOT, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+		if ch == '~' {
+			l.emit(tokMATCH, l.pos, l.pos+1)
+			l.pos++
+			continue
+		}
+		if ch == '&' {
+			if l.peek(1) == '&' {
+				l.emit(tokAND, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				return fmt.Errorf("unexpected character '&' at position %d", l.pos)
+			}
+			continue
+		}
+		if ch == '|' {
+			if l.peek(1) == '|' {
+				l.emit(tokOR, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokPIPE, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+
+		// String literal.
+		if ch == '"' {
+			if err := l.lexString(); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Regex literal — context-dependent: only after certain tokens.
+		if ch == '/' && l.canStartRegex() {
+			if err := l.lexRegex(); err != nil {
+				return err
+			}
+			continue
+		}
+		if ch == '/' {
+			if l.peek(1) == '=' {
+				l.emit(tokSLASHASSIGN, l.pos, l.pos+2)
+				l.pos += 2
+			} else {
+				l.emit(tokSLASH, l.pos, l.pos+1)
+				l.pos++
+			}
+			continue
+		}
+
+		// Number literal.
+		if ch >= '0' && ch <= '9' || (ch == '.' && l.pos+1 < len(l.src) && l.src[l.pos+1] >= '0' && l.src[l.pos+1] <= '9') {
+			l.lexNumber()
+			continue
+		}
+
+		// Identifier or keyword.
+		if isIdentStart(ch) {
+			l.lexIdent()
+			continue
+		}
+
+		return fmt.Errorf("unexpected character %q at position %d", ch, l.pos)
+	}
+	return nil
+}
+
+func (l *lexer) peek(offset int) byte {
+	i := l.pos + offset
+	if i >= len(l.src) {
+		return 0
+	}
+	return l.src[i]
+}
+
+func (l *lexer) emit(typ tokenType, start, end int) {
+	l.tokens = append(l.tokens, token{typ: typ, val: l.src[start:end], pos: start})
+}
+
+func (l *lexer) canStartRegex() bool {
+	// A '/' starts a regex if preceded by an operator or start of expression,
+	// NOT after a value (number, string, identifier, closing paren/bracket).
+	for i := len(l.tokens) - 1; i >= 0; i-- {
+		t := l.tokens[i]
+		if t.typ == tokNEWLINE || t.typ == tokSEMI {
+			return true
+		}
+		switch t.typ {
+		case tokNUMBER, tokSTRING, tokIDENT, tokRPAREN, tokRBRACKET, tokINCR, tokDECR:
+			return false
+		default:
+			return true
+		}
+	}
+	return true // start of input
+}
+
+func (l *lexer) lexString() error {
+	start := l.pos
+	l.pos++ // skip opening quote
+	var sb strings.Builder
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+		if ch == '"' {
+			l.pos++
+			l.tokens = append(l.tokens, token{typ: tokSTRING, val: sb.String(), pos: start})
+			return nil
+		}
+		if ch == '\\' && l.pos+1 < len(l.src) {
+			l.pos++
+			esc := l.src[l.pos]
+			switch esc {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case 'r':
+				sb.WriteByte('\r')
+			case '\\':
+				sb.WriteByte('\\')
+			case '"':
+				sb.WriteByte('"')
+			case 'a':
+				sb.WriteByte('\a')
+			case 'b':
+				sb.WriteByte('\b')
+			case 'f':
+				sb.WriteByte('\f')
+			case 'v':
+				sb.WriteByte('\v')
+			case '/':
+				sb.WriteByte('/')
+			default:
+				sb.WriteByte('\\')
+				sb.WriteByte(esc)
+			}
+			l.pos++
+			continue
+		}
+		if ch == '\n' {
+			return fmt.Errorf("unterminated string at position %d", start)
+		}
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	return fmt.Errorf("unterminated string at position %d", start)
+}
+
+func (l *lexer) lexRegex() error {
+	start := l.pos
+	l.pos++ // skip opening /
+	var sb strings.Builder
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+		if ch == '/' {
+			l.pos++
+			l.tokens = append(l.tokens, token{typ: tokREGEX, val: sb.String(), pos: start})
+			return nil
+		}
+		if ch == '\\' && l.pos+1 < len(l.src) {
+			next := l.src[l.pos+1]
+			if next == '/' {
+				sb.WriteByte('/')
+				l.pos += 2
+				continue
+			}
+			sb.WriteByte('\\')
+			sb.WriteByte(next)
+			l.pos += 2
+			continue
+		}
+		if ch == '\n' {
+			return fmt.Errorf("unterminated regex at position %d", start)
+		}
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	return fmt.Errorf("unterminated regex at position %d", start)
+}
+
+func (l *lexer) lexNumber() {
+	start := l.pos
+	if l.src[l.pos] == '0' && l.pos+1 < len(l.src) && (l.src[l.pos+1] == 'x' || l.src[l.pos+1] == 'X') {
+		l.pos += 2
+		for l.pos < len(l.src) && isHexDigit(l.src[l.pos]) {
+			l.pos++
+		}
+	} else {
+		for l.pos < len(l.src) && l.src[l.pos] >= '0' && l.src[l.pos] <= '9' {
+			l.pos++
+		}
+		if l.pos < len(l.src) && l.src[l.pos] == '.' {
+			l.pos++
+			for l.pos < len(l.src) && l.src[l.pos] >= '0' && l.src[l.pos] <= '9' {
+				l.pos++
+			}
+		}
+		if l.pos < len(l.src) && (l.src[l.pos] == 'e' || l.src[l.pos] == 'E') {
+			l.pos++
+			if l.pos < len(l.src) && (l.src[l.pos] == '+' || l.src[l.pos] == '-') {
+				l.pos++
+			}
+			for l.pos < len(l.src) && l.src[l.pos] >= '0' && l.src[l.pos] <= '9' {
+				l.pos++
+			}
+		}
+	}
+	l.tokens = append(l.tokens, token{typ: tokNUMBER, val: l.src[start:l.pos], pos: start})
+}
+
+func (l *lexer) lexIdent() {
+	start := l.pos
+	for l.pos < len(l.src) && isIdentCont(l.src[l.pos]) {
+		l.pos++
+	}
+	word := l.src[start:l.pos]
+	if typ, ok := keywords[word]; ok {
+		l.tokens = append(l.tokens, token{typ: typ, val: word, pos: start})
+	} else {
+		l.tokens = append(l.tokens, token{typ: tokIDENT, val: word, pos: start})
+	}
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isIdentCont(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9')
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}

--- a/interp/builtins/internal/awkcore/parser.go
+++ b/interp/builtins/internal/awkcore/parser.go
@@ -1,0 +1,965 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awkcore
+
+import "fmt"
+
+// Parse parses an awk program text into an AST.
+func Parse(src string) (*Program, error) {
+	tokens, err := lex(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &parser{tokens: tokens, funcs: make(map[string]*FuncDef)}
+	return p.parse()
+}
+
+type parser struct {
+	tokens  []token
+	pos     int
+	funcs   map[string]*FuncDef
+	inPrint bool
+}
+
+func (p *parser) parse() (*Program, error) {
+	prog := &Program{Funcs: make(map[string]*FuncDef)}
+	p.skipNewlines()
+	for p.cur().typ != tokEOF {
+		if err := p.parseTopLevel(prog); err != nil {
+			return nil, err
+		}
+		p.skipNewlines()
+	}
+	prog.Funcs = p.funcs
+	return prog, nil
+}
+
+func (p *parser) parseTopLevel(prog *Program) error {
+	p.skipNewlines()
+
+	if p.cur().typ == tokFUNCTION {
+		return p.parseFuncDef()
+	}
+
+	if p.cur().typ == tokBEGIN {
+		p.advance()
+		p.skipNewlines()
+		action, err := p.parseAction()
+		if err != nil {
+			return err
+		}
+		prog.Begin = append(prog.Begin, action)
+		return nil
+	}
+
+	if p.cur().typ == tokEND {
+		p.advance()
+		p.skipNewlines()
+		action, err := p.parseAction()
+		if err != nil {
+			return err
+		}
+		prog.End = append(prog.End, action)
+		return nil
+	}
+
+	// pattern { action } or pattern or { action }
+	if p.cur().typ == tokLBRACE {
+		action, err := p.parseAction()
+		if err != nil {
+			return err
+		}
+		prog.Rules = append(prog.Rules, &Rule{Action: action})
+		return nil
+	}
+
+	// Parse pattern.
+	expr, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+
+	// Check for range pattern.
+	if p.cur().typ == tokCOMMA {
+		p.advance()
+		p.skipNewlines()
+		end, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		p.skipNewlines()
+		var action *Action
+		if p.cur().typ == tokLBRACE {
+			action, err = p.parseAction()
+			if err != nil {
+				return err
+			}
+		}
+		prog.Rules = append(prog.Rules, &Rule{
+			Pattern: &RangePattern{Begin: expr, End: end},
+			Action:  action,
+		})
+		return nil
+	}
+
+	p.skipNewlines()
+	var action *Action
+	if p.cur().typ == tokLBRACE {
+		action, err = p.parseAction()
+		if err != nil {
+			return err
+		}
+	}
+	prog.Rules = append(prog.Rules, &Rule{
+		Pattern: &ExprPattern{Expr: expr},
+		Action:  action,
+	})
+	return nil
+}
+
+func (p *parser) parseFuncDef() error {
+	p.advance() // skip 'function'
+	p.skipNewlines()
+	if p.cur().typ != tokIDENT {
+		return p.errorf("expected function name")
+	}
+	name := p.cur().val
+	p.advance()
+	if p.cur().typ != tokLPAREN {
+		return p.errorf("expected '(' after function name")
+	}
+	p.advance()
+	var params []string
+	for p.cur().typ != tokRPAREN {
+		if p.cur().typ != tokIDENT {
+			return p.errorf("expected parameter name")
+		}
+		params = append(params, p.cur().val)
+		p.advance()
+		if p.cur().typ == tokCOMMA {
+			p.advance()
+		}
+	}
+	p.advance() // skip ')'
+	p.skipNewlines()
+	action, err := p.parseAction()
+	if err != nil {
+		return err
+	}
+	p.funcs[name] = &FuncDef{Name: name, Params: params, Body: action.Stmts}
+	return nil
+}
+
+func (p *parser) parseAction() (*Action, error) {
+	if p.cur().typ != tokLBRACE {
+		return nil, p.errorf("expected '{'")
+	}
+	p.advance()
+	p.skipNewlines()
+	var stmts []Stmt
+	for p.cur().typ != tokRBRACE && p.cur().typ != tokEOF {
+		stmt, err := p.parseStmt()
+		if err != nil {
+			return nil, err
+		}
+		if stmt != nil {
+			stmts = append(stmts, stmt)
+		}
+		p.skipNewlines()
+	}
+	if p.cur().typ != tokRBRACE {
+		return nil, p.errorf("expected '}'")
+	}
+	p.advance()
+	return &Action{Stmts: stmts}, nil
+}
+
+func (p *parser) parseStmt() (Stmt, error) {
+	switch p.cur().typ {
+	case tokNEWLINE, tokSEMI:
+		p.advance()
+		return nil, nil
+	case tokLBRACE:
+		return p.parseBlockStmt()
+	case tokIF:
+		return p.parseIf()
+	case tokWHILE:
+		return p.parseWhile()
+	case tokDO:
+		return p.parseDo()
+	case tokFOR:
+		return p.parseFor()
+	case tokBREAK:
+		p.advance()
+		return &BreakStmt{}, nil
+	case tokCONTINUE:
+		p.advance()
+		return &ContinueStmt{}, nil
+	case tokNEXT:
+		p.advance()
+		return &NextStmt{}, nil
+	case tokEXIT:
+		return p.parseExit()
+	case tokDELETE:
+		return p.parseDelete()
+	case tokPRINT:
+		return p.parsePrint()
+	case tokPRINTF:
+		return p.parsePrintf()
+	case tokRETURN:
+		return p.parseReturn()
+	default:
+		return p.parseExprStmt()
+	}
+}
+
+func (p *parser) parseBlockStmt() (Stmt, error) {
+	action, err := p.parseAction()
+	if err != nil {
+		return nil, err
+	}
+	return &BlockStmt{Stmts: action.Stmts}, nil
+}
+
+func (p *parser) parseIf() (Stmt, error) {
+	p.advance() // skip 'if'
+	p.skipNewlines()
+	if p.cur().typ != tokLPAREN {
+		return nil, p.errorf("expected '(' after if")
+	}
+	p.advance()
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ != tokRPAREN {
+		return nil, p.errorf("expected ')' after if condition")
+	}
+	p.advance()
+	p.skipNewlines()
+	thenStmts, err := p.parseStmtBody()
+	if err != nil {
+		return nil, err
+	}
+	var elseStmts []Stmt
+	p.skipNewlines()
+	if p.cur().typ == tokELSE {
+		p.advance()
+		p.skipNewlines()
+		elseStmts, err = p.parseStmtBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &IfStmt{Cond: cond, Then: thenStmts, Else: elseStmts}, nil
+}
+
+func (p *parser) parseStmtBody() ([]Stmt, error) {
+	if p.cur().typ == tokLBRACE {
+		action, err := p.parseAction()
+		if err != nil {
+			return nil, err
+		}
+		return action.Stmts, nil
+	}
+	stmt, err := p.parseStmt()
+	if err != nil {
+		return nil, err
+	}
+	if stmt == nil {
+		return nil, nil
+	}
+	return []Stmt{stmt}, nil
+}
+
+func (p *parser) parseWhile() (Stmt, error) {
+	p.advance() // skip 'while'
+	p.skipNewlines()
+	if p.cur().typ != tokLPAREN {
+		return nil, p.errorf("expected '(' after while")
+	}
+	p.advance()
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ != tokRPAREN {
+		return nil, p.errorf("expected ')' after while condition")
+	}
+	p.advance()
+	p.skipNewlines()
+	body, err := p.parseStmtBody()
+	if err != nil {
+		return nil, err
+	}
+	return &WhileStmt{Cond: cond, Body: body}, nil
+}
+
+func (p *parser) parseDo() (Stmt, error) {
+	p.advance() // skip 'do'
+	p.skipNewlines()
+	body, err := p.parseStmtBody()
+	if err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+	if p.cur().typ != tokWHILE {
+		return nil, p.errorf("expected 'while' after do body")
+	}
+	p.advance()
+	p.skipNewlines()
+	if p.cur().typ != tokLPAREN {
+		return nil, p.errorf("expected '(' after while in do-while")
+	}
+	p.advance()
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ != tokRPAREN {
+		return nil, p.errorf("expected ')' in do-while")
+	}
+	p.advance()
+	return &DoWhileStmt{Cond: cond, Body: body}, nil
+}
+
+func (p *parser) parseFor() (Stmt, error) {
+	p.advance() // skip 'for'
+	p.skipNewlines()
+	if p.cur().typ != tokLPAREN {
+		return nil, p.errorf("expected '(' after for")
+	}
+	p.advance()
+	p.skipNewlines()
+
+	// Check for 'for (var in array)'
+	if p.cur().typ == tokIDENT {
+		saved := p.pos
+		varName := p.cur().val
+		p.advance()
+		if p.cur().typ == tokIN {
+			p.advance()
+			if p.cur().typ != tokIDENT {
+				return nil, p.errorf("expected array name after 'in'")
+			}
+			arrayName := p.cur().val
+			p.advance()
+			if p.cur().typ != tokRPAREN {
+				return nil, p.errorf("expected ')' in for-in")
+			}
+			p.advance()
+			p.skipNewlines()
+			body, err := p.parseStmtBody()
+			if err != nil {
+				return nil, err
+			}
+			return &ForInStmt{Var: varName, Array: arrayName, Body: body}, nil
+		}
+		p.pos = saved
+	}
+
+	// Standard C-style for loop.
+	var init Stmt
+	if p.cur().typ != tokSEMI {
+		s, err := p.parseSimpleStmt()
+		if err != nil {
+			return nil, err
+		}
+		init = s
+	}
+	if p.cur().typ != tokSEMI {
+		return nil, p.errorf("expected ';' in for loop")
+	}
+	p.advance()
+	p.skipNewlines()
+	var cond Expr
+	if p.cur().typ != tokSEMI {
+		var err error
+		cond, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if p.cur().typ != tokSEMI {
+		return nil, p.errorf("expected ';' in for loop")
+	}
+	p.advance()
+	p.skipNewlines()
+	var post Stmt
+	if p.cur().typ != tokRPAREN {
+		s, err := p.parseSimpleStmt()
+		if err != nil {
+			return nil, err
+		}
+		post = s
+	}
+	if p.cur().typ != tokRPAREN {
+		return nil, p.errorf("expected ')' in for loop")
+	}
+	p.advance()
+	p.skipNewlines()
+	body, err := p.parseStmtBody()
+	if err != nil {
+		return nil, err
+	}
+	return &ForStmt{Init: init, Cond: cond, Post: post, Body: body}, nil
+}
+
+func (p *parser) parseSimpleStmt() (Stmt, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ExprStmt{Expr: expr}, nil
+}
+
+func (p *parser) parseExit() (Stmt, error) {
+	p.advance() // skip 'exit'
+	var val Expr
+	if p.cur().typ != tokNEWLINE && p.cur().typ != tokSEMI &&
+		p.cur().typ != tokRBRACE && p.cur().typ != tokEOF {
+		var err error
+		val, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ExitStmt{Value: val}, nil
+}
+
+func (p *parser) parseDelete() (Stmt, error) {
+	p.advance() // skip 'delete'
+	if p.cur().typ != tokIDENT {
+		return nil, p.errorf("expected array name after delete")
+	}
+	name := p.cur().val
+	p.advance()
+	if p.cur().typ == tokLBRACKET {
+		p.advance()
+		indices, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		if p.cur().typ != tokRBRACKET {
+			return nil, p.errorf("expected ']' after delete index")
+		}
+		p.advance()
+		return &DeleteStmt{Array: name, Index: indices}, nil
+	}
+	return &DeleteStmt{Array: name}, nil
+}
+
+func (p *parser) parsePrint() (Stmt, error) {
+	p.advance() // skip 'print'
+	var args []Expr
+	var dest *OutputDest
+
+	if p.cur().typ != tokNEWLINE && p.cur().typ != tokSEMI &&
+		p.cur().typ != tokRBRACE && p.cur().typ != tokEOF &&
+		p.cur().typ != tokPIPE && p.cur().typ != tokGT && p.cur().typ != tokAPPEND {
+		exprs, err := p.parsePrintArgs()
+		if err != nil {
+			return nil, err
+		}
+		args = exprs
+	}
+
+	var err error
+	dest, err = p.parseOutputDest()
+	if err != nil {
+		return nil, err
+	}
+
+	return &PrintStmt{Args: args, Dest: dest}, nil
+}
+
+func (p *parser) parsePrintf() (Stmt, error) {
+	p.advance() // skip 'printf'
+	args, err := p.parsePrintArgs()
+	if err != nil {
+		return nil, err
+	}
+
+	dest, err := p.parseOutputDest()
+	if err != nil {
+		return nil, err
+	}
+
+	return &PrintfStmt{Args: args, Dest: dest}, nil
+}
+
+func (p *parser) parsePrintArgs() ([]Expr, error) {
+	saved := p.inPrint
+	p.inPrint = true
+	defer func() { p.inPrint = saved }()
+	var args []Expr
+	expr, err := p.parseNonAssignExpr()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, expr)
+	for p.cur().typ == tokCOMMA {
+		p.advance()
+		p.skipNewlines()
+		expr, err = p.parseNonAssignExpr()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, expr)
+	}
+	return args, nil
+}
+
+func (p *parser) parseOutputDest() (*OutputDest, error) {
+	var dtype outputDestType
+	switch p.cur().typ {
+	case tokGT:
+		dtype = destFile
+	case tokAPPEND:
+		dtype = destAppend
+	case tokPIPE:
+		dtype = destPipe
+	default:
+		return nil, nil
+	}
+	p.advance()
+	saved := p.inPrint
+	p.inPrint = false
+	defer func() { p.inPrint = saved }()
+	target, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &OutputDest{Type: dtype, Target: target}, nil
+}
+
+func (p *parser) parseReturn() (Stmt, error) {
+	p.advance() // skip 'return'
+	var val Expr
+	if p.cur().typ != tokNEWLINE && p.cur().typ != tokSEMI &&
+		p.cur().typ != tokRBRACE && p.cur().typ != tokEOF {
+		var err error
+		val, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ReturnStmt{Value: val}, nil
+}
+
+func (p *parser) parseExprStmt() (Stmt, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ExprStmt{Expr: expr}, nil
+}
+
+// Expression parsing with precedence climbing.
+
+func (p *parser) parseExpr() (Expr, error) {
+	return p.parseAssign()
+}
+
+func (p *parser) parseNonAssignExpr() (Expr, error) {
+	return p.parseTernary()
+}
+
+func (p *parser) parseAssign() (Expr, error) {
+	expr, err := p.parseTernary()
+	if err != nil {
+		return nil, err
+	}
+
+	switch p.cur().typ {
+	case tokASSIGN, tokPLUSASSIGN, tokMINUSASSIGN, tokSTARASSIGN,
+		tokSLASHASSIGN, tokPERCENTASSIGN, tokPOWERASSIGN:
+		op := p.cur().typ
+		p.advance()
+		val, err := p.parseAssign()
+		if err != nil {
+			return nil, err
+		}
+		return &AssignExpr{Op: op, Target: expr, Value: val}, nil
+	}
+	return expr, nil
+}
+
+func (p *parser) parseTernary() (Expr, error) {
+	expr, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ == tokQUESTION {
+		p.advance()
+		then, err := p.parseAssign()
+		if err != nil {
+			return nil, err
+		}
+		if p.cur().typ != tokCOLON {
+			return nil, p.errorf("expected ':' in ternary expression")
+		}
+		p.advance()
+		els, err := p.parseAssign()
+		if err != nil {
+			return nil, err
+		}
+		return &TernaryExpr{Cond: expr, Then: then, Else: els}, nil
+	}
+	return expr, nil
+}
+
+func (p *parser) parseOr() (Expr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur().typ == tokOR {
+		p.advance()
+		p.skipNewlines()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{Op: tokOR, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (Expr, error) {
+	left, err := p.parseIn()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur().typ == tokAND {
+		p.advance()
+		p.skipNewlines()
+		right, err := p.parseIn()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{Op: tokAND, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseIn() (Expr, error) {
+	left, err := p.parseMatch()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ == tokIN {
+		p.advance()
+		if p.cur().typ != tokIDENT {
+			return nil, p.errorf("expected array name after 'in'")
+		}
+		name := p.cur().val
+		p.advance()
+		idxList := []Expr{left}
+		return &InExpr{Index: idxList, Array: name}, nil
+	}
+	return left, nil
+}
+
+func (p *parser) parseMatch() (Expr, error) {
+	left, err := p.parseComparison()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur().typ == tokMATCH || p.cur().typ == tokNOTMATCH {
+		not := p.cur().typ == tokNOTMATCH
+		p.advance()
+		p.skipNewlines()
+		right, err := p.parsePrimary()
+		if err != nil {
+			return nil, err
+		}
+		left = &MatchExpr{Expr: left, Regex: right, Not: not}
+	}
+	return left, nil
+}
+
+func (p *parser) parseComparison() (Expr, error) {
+	left, err := p.parseConcat()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur().typ == tokLT || p.cur().typ == tokLE ||
+		(!p.inPrint && p.cur().typ == tokGT) || p.cur().typ == tokGE ||
+		p.cur().typ == tokEQ || p.cur().typ == tokNE {
+		op := p.cur().typ
+		p.advance()
+		p.skipNewlines()
+		right, err := p.parseAdd()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{Op: op, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseConcat() (Expr, error) {
+	left, err := p.parseAdd()
+	if err != nil {
+		return nil, err
+	}
+	for p.canStartConcat() {
+		right, err := p.parseAdd()
+		if err != nil {
+			return nil, err
+		}
+		left = &ConcatExpr{Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) canStartConcat() bool {
+	t := p.cur().typ
+	return t == tokNUMBER || t == tokSTRING || t == tokIDENT ||
+		t == tokDOLLAR || t == tokLPAREN || t == tokNOT ||
+		t == tokINCR || t == tokDECR
+}
+
+func (p *parser) parseAdd() (Expr, error) {
+	left, err := p.parseMul()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur().typ == tokPLUS || p.cur().typ == tokMINUS {
+		op := p.cur().typ
+		p.advance()
+		p.skipNewlines()
+		right, err := p.parseMul()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{Op: op, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseMul() (Expr, error) {
+	left, err := p.parsePower()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur().typ == tokSTAR || p.cur().typ == tokSLASH || p.cur().typ == tokPERCENT {
+		op := p.cur().typ
+		p.advance()
+		p.skipNewlines()
+		right, err := p.parsePower()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{Op: op, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parsePower() (Expr, error) {
+	base, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ == tokPOWER {
+		p.advance()
+		p.skipNewlines()
+		exp, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &BinaryExpr{Op: tokPOWER, Left: base, Right: exp}, nil
+	}
+	return base, nil
+}
+
+func (p *parser) parseUnary() (Expr, error) {
+	if p.cur().typ == tokNOT {
+		p.advance()
+		expr, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &UnaryExpr{Op: tokNOT, Expr: expr}, nil
+	}
+	if p.cur().typ == tokMINUS {
+		p.advance()
+		expr, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &UnaryExpr{Op: tokMINUS, Expr: expr}, nil
+	}
+	if p.cur().typ == tokPLUS {
+		p.advance()
+		return p.parseUnary()
+	}
+	if p.cur().typ == tokINCR || p.cur().typ == tokDECR {
+		op := p.cur().typ
+		p.advance()
+		expr, err := p.parsePostfix()
+		if err != nil {
+			return nil, err
+		}
+		return &IncrDecrExpr{Op: op, Expr: expr, Pre: true}, nil
+	}
+	return p.parsePostfix()
+}
+
+func (p *parser) parsePostfix() (Expr, error) {
+	expr, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur().typ == tokINCR || p.cur().typ == tokDECR {
+		op := p.cur().typ
+		p.advance()
+		return &IncrDecrExpr{Op: op, Expr: expr, Pre: false}, nil
+	}
+	return expr, nil
+}
+
+func (p *parser) parsePrimary() (Expr, error) {
+	switch p.cur().typ {
+	case tokNUMBER:
+		val := p.cur().val
+		p.advance()
+		return &NumberLit{Val: val}, nil
+	case tokSTRING:
+		val := p.cur().val
+		p.advance()
+		return &StringLit{Val: val}, nil
+	case tokREGEX:
+		val := p.cur().val
+		p.advance()
+		return &RegexLit{Val: val}, nil
+	case tokDOLLAR:
+		p.advance()
+		expr, err := p.parsePrimary()
+		if err != nil {
+			return nil, err
+		}
+		return &FieldExpr{Index: expr}, nil
+	case tokLPAREN:
+		p.advance()
+		saved := p.inPrint
+		p.inPrint = false
+		expr, err := p.parseExpr()
+		p.inPrint = saved
+		if err != nil {
+			return nil, err
+		}
+		if p.cur().typ != tokRPAREN {
+			return nil, p.errorf("expected ')'")
+		}
+		p.advance()
+		return expr, nil
+	case tokIDENT:
+		return p.parseIdentExpr()
+	case tokGETLINE:
+		return p.parseGetline()
+	default:
+		return nil, p.errorf("unexpected token %q", p.cur().val)
+	}
+}
+
+func (p *parser) parseIdentExpr() (Expr, error) {
+	name := p.cur().val
+	p.advance()
+
+	// Function call: ident(args...)
+	if p.cur().typ == tokLPAREN {
+		p.advance()
+		var args []Expr
+		if p.cur().typ != tokRPAREN {
+			exprs, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			args = exprs
+		}
+		if p.cur().typ != tokRPAREN {
+			return nil, p.errorf("expected ')' after function arguments")
+		}
+		p.advance()
+		return &CallExpr{Name: name, Args: args}, nil
+	}
+
+	// Array subscript: ident[expr]
+	if p.cur().typ == tokLBRACKET {
+		p.advance()
+		indices, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		if p.cur().typ != tokRBRACKET {
+			return nil, p.errorf("expected ']' after array index")
+		}
+		p.advance()
+		return &ArrayExpr{Name: name, Index: indices}, nil
+	}
+
+	return &VarExpr{Name: name}, nil
+}
+
+func (p *parser) parseGetline() (Expr, error) {
+	p.advance() // skip 'getline'
+	var varName string
+	if p.cur().typ == tokIDENT {
+		varName = p.cur().val
+		p.advance()
+	}
+	return &GetlineExpr{Var: varName}, nil
+}
+
+func (p *parser) parseExprList() ([]Expr, error) {
+	var exprs []Expr
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	exprs = append(exprs, expr)
+	for p.cur().typ == tokCOMMA {
+		p.advance()
+		p.skipNewlines()
+		expr, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+	return exprs, nil
+}
+
+// Helper methods.
+
+func (p *parser) cur() token {
+	if p.pos >= len(p.tokens) {
+		return token{typ: tokEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *parser) advance() {
+	if p.pos < len(p.tokens) {
+		p.pos++
+	}
+}
+
+func (p *parser) skipNewlines() {
+	for p.cur().typ == tokNEWLINE || p.cur().typ == tokSEMI {
+		p.advance()
+	}
+}
+
+func (p *parser) errorf(format string, args ...any) error {
+	pos := 0
+	if p.pos < len(p.tokens) {
+		pos = p.tokens[p.pos].pos
+	}
+	return fmt.Errorf("parse error at position %d: %s", pos, fmt.Sprintf(format, args...))
+}

--- a/interp/builtins/internal/awkcore/token.go
+++ b/interp/builtins/internal/awkcore/token.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package internal implements the core awk language: lexer, parser, and interpreter.
+package awkcore
+
+// Token types for the awk lexer.
+type tokenType int
+
+const (
+	tokEOF tokenType = iota
+	tokNEWLINE
+	tokSEMI
+	tokLBRACE
+	tokRBRACE
+	tokLPAREN
+	tokRPAREN
+	tokLBRACKET
+	tokRBRACKET
+	tokCOMMA
+	tokDOLLAR
+	tokNOT
+
+	// Arithmetic
+	tokPLUS
+	tokMINUS
+	tokSTAR
+	tokSLASH
+	tokPERCENT
+	tokPOWER
+
+	// Comparison
+	tokLT
+	tokLE
+	tokGT
+	tokGE
+	tokEQ
+	tokNE
+
+	// Assignment
+	tokASSIGN
+	tokPLUSASSIGN
+	tokMINUSASSIGN
+	tokSTARASSIGN
+	tokSLASHASSIGN
+	tokPERCENTASSIGN
+	tokPOWERASSIGN
+
+	// Logical
+	tokAND
+	tokOR
+
+	// Match
+	tokMATCH    // ~
+	tokNOTMATCH // !~
+
+	// Increment/decrement
+	tokINCR // ++
+	tokDECR // --
+
+	// String concatenation is implicit (space)
+	tokAPPEND // >>
+
+	// Pipe
+	tokPIPE // |
+
+	// Ternary
+	tokQUESTION
+	tokCOLON
+
+	// Literals
+	tokNUMBER
+	tokSTRING
+	tokREGEX
+
+	// Identifiers and keywords
+	tokIDENT
+	tokBEGIN
+	tokEND
+	tokIF
+	tokELSE
+	tokWHILE
+	tokFOR
+	tokDO
+	tokBREAK
+	tokCONTINUE
+	tokNEXT
+	tokEXIT
+	tokDELETE
+	tokIN
+	tokGETLINE
+	tokPRINT
+	tokPRINTF
+	tokFUNCTION
+	tokRETURN
+)
+
+type token struct {
+	typ tokenType
+	val string
+	pos int
+}
+
+// keywords maps awk keywords to their token types.
+var keywords = map[string]tokenType{
+	"BEGIN":    tokBEGIN,
+	"END":      tokEND,
+	"if":       tokIF,
+	"else":     tokELSE,
+	"while":    tokWHILE,
+	"for":      tokFOR,
+	"do":       tokDO,
+	"break":    tokBREAK,
+	"continue": tokCONTINUE,
+	"next":     tokNEXT,
+	"exit":     tokEXIT,
+	"delete":   tokDELETE,
+	"in":       tokIN,
+	"getline":  tokGETLINE,
+	"print":    tokPRINT,
+	"printf":   tokPRINTF,
+	"function": tokFUNCTION,
+	"return":   tokRETURN,
+}

--- a/interp/register_builtins.go
+++ b/interp/register_builtins.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/rshell/interp/builtins"
+	"github.com/DataDog/rshell/interp/builtins/awk"
 	breakcmd "github.com/DataDog/rshell/interp/builtins/break"
 	"github.com/DataDog/rshell/interp/builtins/cat"
 	continuecmd "github.com/DataDog/rshell/interp/builtins/continue"
@@ -24,6 +25,7 @@ var registerOnce sync.Once
 func registerBuiltins() {
 	registerOnce.Do(func() {
 		for _, cmd := range []builtins.Command{
+			awk.Cmd,
 			breakcmd.Cmd,
 			cat.Cmd,
 			continuecmd.Cmd,

--- a/tests/import_allowlist_test.go
+++ b/tests/import_allowlist_test.go
@@ -32,12 +32,18 @@ import (
 // All packages not listed here are implicitly banned, including all
 // third-party packages and other internal module packages.
 var builtinAllowedSymbols = []string{
+	// bufio.NewReader — buffered reader for streaming input; no write or exec capability.
+	"bufio.NewReader",
 	// bufio.NewScanner — line-by-line input reading (e.g. head, cat); no write or exec capability.
 	"bufio.NewScanner",
 	// context.Context — deadline/cancellation plumbing; pure interface, no side effects.
 	"context.Context",
 	// errors.Is — error comparison; pure function, no I/O.
 	"errors.Is",
+	// fmt.Errorf — error formatting; pure function, no I/O.
+	"fmt.Errorf",
+	// fmt.Sprintf — string formatting; pure function, no I/O.
+	"fmt.Sprintf",
 	// pflag.ContinueOnError — flag parse-error mode constant; no side effects.
 	"github.com/spf13/pflag.ContinueOnError",
 	// pflag.NewFlagSet — CLI flag parsing; operates only on string slices, no I/O.
@@ -54,12 +60,80 @@ var builtinAllowedSymbols = []string{
 	"io.ReadCloser",
 	// io.Reader — interface type; no side effects.
 	"io.Reader",
+	// io.WriteString — writes string to writer; pure function on provided writer.
+	"io.WriteString",
+	// io.Writer — interface type; no side effects.
+	"io.Writer",
+	// math.Atan2 — arc tangent; pure math function, no I/O.
+	"math.Atan2",
+	// math.Cos — cosine; pure math function, no I/O.
+	"math.Cos",
+	// math.Exp — exponential; pure math function, no I/O.
+	"math.Exp",
+	// math.Inf — infinity constant; pure function, no I/O.
+	"math.Inf",
+	// math.IsInf — infinity check; pure function, no I/O.
+	"math.IsInf",
+	// math.Log — natural log; pure math function, no I/O.
+	"math.Log",
+	// math.Mod — modulo; pure math function, no I/O.
+	"math.Mod",
+	// math.Pow — power; pure math function, no I/O.
+	"math.Pow",
+	// math.Sin — sine; pure math function, no I/O.
+	"math.Sin",
+	// math.Sqrt — square root; pure math function, no I/O.
+	"math.Sqrt",
+	// math/rand.New — seeded random source; pure function, no I/O.
+	"math/rand.New",
+	// math/rand.NewSource — random seed source; pure function, no I/O.
+	"math/rand.NewSource",
+	// math/rand.Rand — random number generator type; pure, no I/O.
+	"math/rand.Rand",
 	// os.O_RDONLY — read-only file flag constant; cannot open files by itself.
 	"os.O_RDONLY",
+	// regexp.Compile — compiles a regex; pure function, no I/O. Uses Go RE2 (linear time, no ReDoS).
+	"regexp.Compile",
+	// regexp.Regexp — compiled regex type; pure, no I/O.
+	"regexp.Regexp",
+	// sort.Strings — sorts string slice in place; pure function, no I/O.
+	"sort.Strings",
 	// strconv.Atoi — string-to-int conversion; pure function, no I/O.
 	"strconv.Atoi",
+	// strconv.FormatFloat — float-to-string conversion; pure function, no I/O.
+	"strconv.FormatFloat",
+	// strconv.FormatInt — int-to-string conversion; pure function, no I/O.
+	"strconv.FormatInt",
+	// strconv.Itoa — int-to-string conversion; pure function, no I/O.
+	"strconv.Itoa",
+	// strconv.ParseFloat — string-to-float conversion; pure function, no I/O.
+	"strconv.ParseFloat",
 	// strconv.ParseInt — string-to-int conversion with base/bit-size; pure function, no I/O.
 	"strconv.ParseInt",
+	// strings.Builder — efficient string building; pure in-memory, no I/O.
+	"strings.Builder",
+	// strings.Contains — substring check; pure function, no I/O.
+	"strings.Contains",
+	// strings.Fields — splits on whitespace; pure function, no I/O.
+	"strings.Fields",
+	// strings.Index — finds substring position; pure function, no I/O.
+	"strings.Index",
+	// strings.IndexByte — finds byte position; pure function, no I/O.
+	"strings.IndexByte",
+	// strings.Join — joins strings; pure function, no I/O.
+	"strings.Join",
+	// strings.Replace — replaces substrings; pure function, no I/O.
+	"strings.Replace",
+	// strings.Split — splits string; pure function, no I/O.
+	"strings.Split",
+	// strings.ToLower — lowercase conversion; pure function, no I/O.
+	"strings.ToLower",
+	// strings.ToUpper — uppercase conversion; pure function, no I/O.
+	"strings.ToUpper",
+	// strings.TrimSpace — trims whitespace; pure function, no I/O.
+	"strings.TrimSpace",
+	// unicode/utf8.RuneCountInString — counts runes; pure function, no I/O.
+	"unicode/utf8.RuneCountInString",
 }
 
 // permanentlyBanned lists packages that may never be imported by builtin

--- a/tests/scenarios/cmd/awk/arrays/count.yaml
+++ b/tests/scenarios/cmd/awk/arrays/count.yaml
@@ -1,0 +1,14 @@
+# Arrays and for-in
+description: awk arrays and for-in iteration.
+setup:
+  files:
+    - path: file.txt
+      content: "a\nb\na\nc\nb\na\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{count[$1]++} END {for (k in count) print k, count[k]}' file.txt
+expect:
+  stdout: "a 3\nb 2\nc 1\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/basic/empty_file.yaml
+++ b/tests/scenarios/cmd/awk/basic/empty_file.yaml
@@ -1,0 +1,14 @@
+# Empty file handling
+description: awk handles empty files without error.
+setup:
+  files:
+    - path: empty.txt
+      content: ""
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print}' empty.txt
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/basic/help.yaml
+++ b/tests/scenarios/cmd/awk/basic/help.yaml
@@ -1,0 +1,10 @@
+# Help flag
+description: awk --help prints usage to stdout.
+skip_assert_against_bash: true
+input:
+  script: |+
+    awk --help
+expect:
+  stdout_contains: ["Usage:"]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/basic/pattern_match.yaml
+++ b/tests/scenarios/cmd/awk/basic/pattern_match.yaml
@@ -1,0 +1,14 @@
+# Basic awk: default print action
+description: awk with pattern prints matching lines.
+setup:
+  files:
+    - path: file.txt
+      content: "hello world\nfoo bar\nhello again\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '/hello/' file.txt
+expect:
+  stdout: "hello world\nhello again\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/basic/print_all.yaml
+++ b/tests/scenarios/cmd/awk/basic/print_all.yaml
@@ -1,0 +1,14 @@
+# Basic awk: print all lines
+description: awk with no pattern prints all lines.
+setup:
+  files:
+    - path: file.txt
+      content: "alpha\nbeta\ngamma\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print}' file.txt
+expect:
+  stdout: "alpha\nbeta\ngamma\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/basic/printf.yaml
+++ b/tests/scenarios/cmd/awk/basic/printf.yaml
@@ -1,0 +1,14 @@
+# printf formatting
+description: awk printf formats output.
+setup:
+  files:
+    - path: file.txt
+      content: "hello\nworld\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{printf "%d: %s\n", NR, $0}' file.txt
+expect:
+  stdout: "1: hello\n2: world\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/control/for_loop.yaml
+++ b/tests/scenarios/cmd/awk/control/for_loop.yaml
@@ -1,0 +1,9 @@
+# For loop
+description: awk for loop iterates correctly.
+input:
+  script: |+
+    awk 'BEGIN {for (i=1; i<=3; i++) print i}'
+expect:
+  stdout: "1\n2\n3\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/control/if_else.yaml
+++ b/tests/scenarios/cmd/awk/control/if_else.yaml
@@ -1,0 +1,14 @@
+# If-else control flow
+description: awk if-else conditional execution.
+setup:
+  files:
+    - path: file.txt
+      content: "1\n2\n3\n4\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{if ($1 % 2 == 0) print "even"; else print "odd"}' file.txt
+expect:
+  stdout: "odd\neven\nodd\neven\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/control/while_loop.yaml
+++ b/tests/scenarios/cmd/awk/control/while_loop.yaml
@@ -1,0 +1,9 @@
+# While loop
+description: awk while loop iterates correctly.
+input:
+  script: |+
+    awk 'BEGIN {i=1; while (i<=3) {print i; i++}}'
+expect:
+  stdout: "1\n2\n3\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/errors/missing_file.yaml
+++ b/tests/scenarios/cmd/awk/errors/missing_file.yaml
@@ -1,0 +1,10 @@
+# Error: missing file
+description: awk exits 1 when file does not exist.
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print}' nonexistent.txt
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/errors/no_program.yaml
+++ b/tests/scenarios/cmd/awk/errors/no_program.yaml
@@ -1,0 +1,9 @@
+# Error: no program text
+description: awk exits 1 with no program text.
+input:
+  script: |+
+    awk
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/errors/syntax_error.yaml
+++ b/tests/scenarios/cmd/awk/errors/syntax_error.yaml
@@ -1,0 +1,9 @@
+# Error: syntax error in program
+description: awk exits 1 on syntax error.
+input:
+  script: |+
+    awk '{print' /dev/null
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/errors/unknown_flag.yaml
+++ b/tests/scenarios/cmd/awk/errors/unknown_flag.yaml
@@ -1,0 +1,10 @@
+# Error: unknown flag
+description: awk exits 1 on unknown flag.
+skip_assert_against_bash: true
+input:
+  script: |+
+    awk --unknown '{print}'
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/fields/field_separator.yaml
+++ b/tests/scenarios/cmd/awk/fields/field_separator.yaml
@@ -1,0 +1,14 @@
+# Field separator flag
+description: awk -F sets the field separator.
+setup:
+  files:
+    - path: file.csv
+      content: "a:b:c\nd:e:f\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk -F: '{print $2}' file.csv
+expect:
+  stdout: "b\ne\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/fields/nf_variable.yaml
+++ b/tests/scenarios/cmd/awk/fields/nf_variable.yaml
@@ -1,0 +1,14 @@
+# NF built-in variable
+description: awk NF gives the number of fields.
+setup:
+  files:
+    - path: file.txt
+      content: "one two three\nfour five\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print NF}' file.txt
+expect:
+  stdout: "3\n2\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/fields/print_fields.yaml
+++ b/tests/scenarios/cmd/awk/fields/print_fields.yaml
@@ -1,0 +1,14 @@
+# Basic awk: print specific fields
+description: awk prints specific fields from input.
+setup:
+  files:
+    - path: file.txt
+      content: "one two three\nfour five six\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print $1, $3}' file.txt
+expect:
+  stdout: "one three\nfour six\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/functions/length.yaml
+++ b/tests/scenarios/cmd/awk/functions/length.yaml
@@ -1,0 +1,14 @@
+# String function: length
+description: awk length() returns string length.
+setup:
+  files:
+    - path: file.txt
+      content: "hello\nhi\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print length($0)}' file.txt
+expect:
+  stdout: "5\n2\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/functions/substr.yaml
+++ b/tests/scenarios/cmd/awk/functions/substr.yaml
@@ -1,0 +1,14 @@
+# String function: substr
+description: awk substr extracts substrings.
+setup:
+  files:
+    - path: file.txt
+      content: "hello world\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print substr($0, 1, 5)}' file.txt
+expect:
+  stdout: "hello\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/functions/tolower.yaml
+++ b/tests/scenarios/cmd/awk/functions/tolower.yaml
@@ -1,0 +1,14 @@
+# String function: tolower/toupper
+description: awk tolower and toupper convert case.
+setup:
+  files:
+    - path: file.txt
+      content: "Hello World\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print tolower($0)}' file.txt
+expect:
+  stdout: "hello world\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/hardening/blocked_redirect.yaml
+++ b/tests/scenarios/cmd/awk/hardening/blocked_redirect.yaml
@@ -1,0 +1,11 @@
+# Blocked: output redirection
+description: awk blocks output redirection for safety.
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk 'BEGIN {print "bad" > "/tmp/evil"}'
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/hardening/blocked_system.yaml
+++ b/tests/scenarios/cmd/awk/hardening/blocked_system.yaml
@@ -1,0 +1,10 @@
+# Blocked: system() function
+description: awk blocks system() for safety.
+skip_assert_against_bash: true
+input:
+  script: |+
+    awk 'BEGIN {system("echo bad")}'
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/hardening/outside_allowed_paths.yaml
+++ b/tests/scenarios/cmd/awk/hardening/outside_allowed_paths.yaml
@@ -1,0 +1,11 @@
+# Outside allowed paths
+description: awk rejects files outside allowed paths.
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print}' /etc/passwd
+expect:
+  stdout: ""
+  stderr_contains: ["awk:"]
+  exit_code: 1

--- a/tests/scenarios/cmd/awk/multifile/two_files.yaml
+++ b/tests/scenarios/cmd/awk/multifile/two_files.yaml
@@ -1,0 +1,16 @@
+# Multiple files
+description: awk processes multiple files.
+setup:
+  files:
+    - path: a.txt
+      content: "one\n"
+    - path: b.txt
+      content: "two\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print FILENAME, $0}' a.txt b.txt
+expect:
+  stdout: "a.txt one\nb.txt two\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/patterns/begin_block.yaml
+++ b/tests/scenarios/cmd/awk/patterns/begin_block.yaml
@@ -1,0 +1,14 @@
+# BEGIN block
+description: awk BEGIN block executes before input processing.
+setup:
+  files:
+    - path: file.txt
+      content: "data\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk 'BEGIN {print "start"} {print $0}' file.txt
+expect:
+  stdout: "start\ndata\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/patterns/comparison.yaml
+++ b/tests/scenarios/cmd/awk/patterns/comparison.yaml
@@ -1,0 +1,14 @@
+# Comparison pattern
+description: awk comparison pattern matches lines.
+setup:
+  files:
+    - path: file.txt
+      content: "1\n2\n3\n4\n5\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '$1 > 3' file.txt
+expect:
+  stdout: "4\n5\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/patterns/end_block.yaml
+++ b/tests/scenarios/cmd/awk/patterns/end_block.yaml
@@ -1,0 +1,14 @@
+# END block
+description: awk END block executes after input processing.
+setup:
+  files:
+    - path: file.txt
+      content: "a\nb\nc\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{count++} END {print count}' file.txt
+expect:
+  stdout: "3\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/stdin/pipe.yaml
+++ b/tests/scenarios/cmd/awk/stdin/pipe.yaml
@@ -1,0 +1,14 @@
+# Stdin: awk reads from stdin when no files given
+description: awk reads from stdin by default.
+setup:
+  files:
+    - path: data.txt
+      content: "hello\nworld\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    cat data.txt | awk '{print toupper($0)}'
+expect:
+  stdout: "HELLO\nWORLD\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/variables/nr_variable.yaml
+++ b/tests/scenarios/cmd/awk/variables/nr_variable.yaml
@@ -1,0 +1,14 @@
+# NR built-in variable
+description: awk NR gives the record number.
+setup:
+  files:
+    - path: file.txt
+      content: "alpha\nbeta\ngamma\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk '{print NR, $0}' file.txt
+expect:
+  stdout: "1 alpha\n2 beta\n3 gamma\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/awk/variables/v_flag.yaml
+++ b/tests/scenarios/cmd/awk/variables/v_flag.yaml
@@ -1,0 +1,14 @@
+# Variable assignment with -v
+description: awk -v assigns variables before execution.
+setup:
+  files:
+    - path: file.txt
+      content: "hello\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    awk -v greeting=hi '{print greeting, $0}' file.txt
+expect:
+  stdout: "hi hello\n"
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c72572fb-4c9c-4da5-8894-789068dc9249","source":"chat","resourceId":"d61189bc-b9ca-4ac3-8e9d-f89c298dc25d","workflowId":"b449afa3-75cd-4280-9130-e9182d1ac9f9","codeChangeId":"b449afa3-75cd-4280-9130-e9182d1ac9f9","sourceType":"chat"} -->
### What does this PR do?

Implements the POSIX `awk` command as a safe builtin in the shell interpreter. This includes a complete awk language interpreter (lexer, parser, evaluator) with all dangerous features blocked per the safety rules.

**Supported flags:** `-F` (field separator), `-v` (variable assignment), `-f` (program file), `-h`/`--help`

**Language features:** pattern-action rules, BEGIN/END blocks, field splitting, regex matching, arithmetic, control flow (if/else/for/while/do-while/break/continue/next/exit), arrays, user-defined functions, 20+ built-in functions (length, substr, split, sub, gsub, match, sprintf, tolower/toupper, math functions, rand/srand).

**Blocked features (safety):** `system()`, output redirection (`>`, `>>`, `|` in awk), `getline` from pipe/file, `close()`.

### Motivation

Adds `awk` — one of the most commonly used POSIX text processing commands — to the shell's builtin command set, enabling agents to use awk for data extraction and transformation without executing external binaries.

### Testing

- 60+ Go unit tests covering all flags, language features, error cases, and GNU compatibility
- 25+ YAML scenario tests for bash equivalence testing
- Pentest suite covering integer edge cases, blocked features, resource exhaustion, path injection, regex safety
- Unix-specific tests (symlinks, /dev/null) with build tags
- Import allowlist updated and validated

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)

## Changes

- `interp/builtins/awk/awk.go` — Main builtin entry point with flag parsing, file processing, stdin handling
- `interp/builtins/internal/awkcore/` — Core awk interpreter:
  - `token.go` — Token types and keywords
  - `lexer.go` — Tokenizer for awk programs
  - `ast.go` — Abstract syntax tree node types
  - `parser.go` — Recursive descent parser with print-context-aware `>` handling
  - `interp.go` — Tree-walking interpreter with safety limits (MaxArraySize, MaxLoopIterations, MaxCallDepth, MaxStringLen, MaxOutputBytes, MaxSprintfWidth)
- `interp/register_builtins.go` — Registered awk in the builtin registry
- `tests/import_allowlist_test.go` — Added required symbols (math, regexp, strings, sort, unicode/utf8)
- `tests/scenarios/cmd/awk/` — 25 YAML scenario tests across 8 categories
- `interp/builtins/awk/*_test.go` — Go tests (unit, GNU compat, pentest, unix-specific)

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/d61189bc-b9ca-4ac3-8e9d-f89c298dc25d)

Comment @datadog to request changes