### PR TITLE
Split import allowlist into per-command symbol lists

### DIFF
--- a/tests/import_allowlist_test.go
+++ b/tests/import_allowlist_test.go
@@ -11,19 +11,21 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
 
-// builtinAllowedSymbols lists every "importpath.Symbol" that may be used by
-// command implementation files in interp/builtins/. Each entry must be in
-// "importpath.Symbol" form, where importpath is the full Go import path.
+// builtinAllowedSymbols maps each builtin command (keyed by its subdirectory
+// name under interp/builtins/) to the set of "importpath.Symbol" references it
+// may use. Internal shared packages use "internal/<pkg>" as their key.
 //
 // Each symbol must have a comment explaining what it does and why it is safe
 // to use inside a sandboxed builtin (e.g. pure function, constant, interface,
 // no filesystem/network/exec side effects).
 //
-// To use a new symbol, add a single line here with its safety justification.
+// To use a new symbol, add it to the relevant command's list with its safety
+// justification.
 //
 // Permanently banned (cannot be added):
 //   - reflect  — reflection defeats static safety analysis
@@ -31,103 +33,129 @@ import (
 //
 // All packages not listed here are implicitly banned, including all
 // third-party packages and other internal module packages.
-var builtinAllowedSymbols = []string{
-	// bufio.NewScanner — line-by-line input reading (e.g. head, cat); no write or exec capability.
-	"bufio.NewScanner",
-	// bufio.SplitFunc — type for custom scanner split functions; pure type, no I/O.
-	"bufio.SplitFunc",
-	// context.Context — deadline/cancellation plumbing; pure interface, no side effects.
-	"context.Context",
-	// errors.Is — error comparison; pure function, no I/O.
-	"errors.Is",
-	// errors.New — creates a simple error value; pure function, no I/O.
-	"errors.New",
-	// fmt.Sprintf — string formatting; pure function, no I/O.
-	"fmt.Sprintf",
-	// io/fs.DirEntry — interface type for directory entries; no side effects.
-	"io/fs.DirEntry",
-	// io/fs.FileInfo — interface type for file information; no side effects.
-	"io/fs.FileInfo",
-	// io/fs.ModeDir — file mode bit constant for directories; pure constant.
-	"io/fs.ModeDir",
-	// io/fs.ModeNamedPipe — file mode bit constant for named pipes; pure constant.
-	"io/fs.ModeNamedPipe",
-	// io/fs.ModeSetgid — file mode bit constant for setgid; pure constant.
-	"io/fs.ModeSetgid",
-	// io/fs.ModeSetuid — file mode bit constant for setuid; pure constant.
-	"io/fs.ModeSetuid",
-	// io/fs.ModeSocket — file mode bit constant for sockets; pure constant.
-	"io/fs.ModeSocket",
-	// io/fs.ModeSticky — file mode bit constant for sticky bit; pure constant.
-	"io/fs.ModeSticky",
-	// io/fs.ModeSymlink — file mode bit constant for symlinks; pure constant.
-	"io/fs.ModeSymlink",
-	// io.EOF — sentinel error value; pure constant.
-	"io.EOF",
-	// io.NopCloser — wraps a Reader with a no-op Close; no side effects.
-	"io.NopCloser",
-	// io.ReadCloser — interface type; no side effects.
-	"io.ReadCloser",
-	// io.Reader — interface type; no side effects.
-	"io.Reader",
-	// math.MaxInt64 — integer constant; no side effects.
-	"math.MaxInt64",
-	// math.MinInt64 — integer constant; no side effects.
-	"math.MinInt64",
-	// os.FileInfo — file metadata interface returned by Stat; no I/O side effects.
-	"os.FileInfo",
-	// os.O_RDONLY — read-only file flag constant; cannot open files by itself.
-	"os.O_RDONLY",
-	// slices.Reverse — reverses a slice in-place; pure function, no I/O.
-	"slices.Reverse",
-	// slices.SortFunc — sorts a slice with a comparison function; pure function, no I/O.
-	"slices.SortFunc",
-	// strings.Builder — efficient string concatenation; pure in-memory buffer, no I/O.
-	"strings.Builder",
-	// strconv.Atoi — string-to-int conversion; pure function, no I/O.
-	"strconv.Atoi",
-	// strconv.ErrRange — sentinel error value for overflow; pure constant.
-	"strconv.ErrRange",
-	// strconv.NumError — error type for numeric conversion failures; pure type.
-	"strconv.NumError",
-	// strconv.ParseInt — string-to-int conversion with base/bit-size; pure function, no I/O.
-	"strconv.ParseInt",
-	// strconv.FormatInt — int-to-string conversion; pure function, no I/O.
-	"strconv.FormatInt",
-	// strings.HasPrefix — pure function for prefix matching; no I/O.
-	"strings.HasPrefix",
-	// strings.TrimSpace — removes leading/trailing whitespace; pure function.
-	"strings.TrimSpace",
-	// io.WriteString — writes a string to a writer; no filesystem access, delegates to Write.
-	"io.WriteString",
-	// io.Writer — interface type for writing; no side effects.
-	"io.Writer",
-	// unicode.Cc — control character category range table; pure data, no I/O.
-	"unicode.Cc",
-	// unicode.Cf — format character category range table; pure data, no I/O.
-	"unicode.Cf",
-	// unicode.Is — checks if rune belongs to a range table; pure function, no I/O.
-	"unicode.Is",
-	// unicode.Me — enclosing mark category range table; pure data, no I/O.
-	"unicode.Me",
-	// unicode.Mn — nonspacing mark category range table; pure data, no I/O.
-	"unicode.Mn",
-	// unicode.Range16 — struct type for 16-bit Unicode ranges; pure data.
-	"unicode.Range16",
-	// unicode.Range32 — struct type for 32-bit Unicode ranges; pure data.
-	"unicode.Range32",
-	// unicode.RangeTable — struct type for Unicode range tables; pure data.
-	"unicode.RangeTable",
-	// unicode/utf8.DecodeRune — decodes first UTF-8 rune from a byte slice; pure function, no I/O.
-	"unicode/utf8.DecodeRune",
-	// unicode/utf8.RuneCount — counts UTF-8 runes in a byte slice; pure function, no I/O.
-	"unicode/utf8.RuneCount",
-	// unicode/utf8.UTFMax — maximum number of bytes in a UTF-8 encoding; constant, no I/O.
-	"unicode/utf8.UTFMax",
-	// unicode/utf8.Valid — checks if a byte slice is valid UTF-8; pure function, no I/O.
-	"unicode/utf8.Valid",
-	// time.Time — time value type; pure data, no side effects.
-	"time.Time",
+var builtinAllowedSymbols = map[string][]string{
+	"break": {
+		"context.Context", // deadline/cancellation plumbing; pure interface, no side effects.
+	},
+	"cat": {
+		"bufio.NewScanner", // line-by-line input reading; no write or exec capability.
+		"context.Context",  // deadline/cancellation plumbing; pure interface, no side effects.
+		"errors.Is",        // error comparison; pure function, no I/O.
+		"io.EOF",           // sentinel error value; pure constant.
+		"io.NopCloser",     // wraps a Reader with a no-op Close; no side effects.
+		"io.ReadCloser",    // interface type; no side effects.
+		"os.O_RDONLY",      // read-only file flag constant; cannot open files by itself.
+	},
+	"continue": {
+		"context.Context", // deadline/cancellation plumbing; pure interface, no side effects.
+	},
+	"echo": {
+		"context.Context", // deadline/cancellation plumbing; pure interface, no side effects.
+		"strings.Builder", // efficient string concatenation; pure in-memory buffer, no I/O.
+	},
+	"exit": {
+		"context.Context", // deadline/cancellation plumbing; pure interface, no side effects.
+		"strconv.Atoi",    // string-to-int conversion; pure function, no I/O.
+	},
+	"false": {
+		"context.Context", // deadline/cancellation plumbing; pure interface, no side effects.
+	},
+	"head": {
+		"bufio.NewScanner", // line-by-line input reading; no write or exec capability.
+		"context.Context",  // deadline/cancellation plumbing; pure interface, no side effects.
+		"errors.Is",        // error comparison; pure function, no I/O.
+		"io.EOF",           // sentinel error value; pure constant.
+		"io.NopCloser",     // wraps a Reader with a no-op Close; no side effects.
+		"io.ReadCloser",    // interface type; no side effects.
+		"io.Reader",        // interface type; no side effects.
+		"os.O_RDONLY",      // read-only file flag constant; cannot open files by itself.
+		"strconv.ParseInt", // string-to-int conversion with base/bit-size; pure function, no I/O.
+	},
+	"internal/loopctl": {
+		"strconv.Atoi", // string-to-int conversion; pure function, no I/O.
+	},
+	"ls": {
+		"context.Context",  // deadline/cancellation plumbing; pure interface, no side effects.
+		"errors.New",       // creates a simple error value; pure function, no I/O.
+		"fmt.Sprintf",      // string formatting; pure function, no I/O.
+		"io/fs.FileInfo",   // interface type for file information; no side effects.
+		"io/fs.ModeDir",    // file mode bit constant for directories; pure constant.
+		"io/fs.ModeNamedPipe", // file mode bit constant for named pipes; pure constant.
+		"io/fs.ModeSetgid", // file mode bit constant for setgid; pure constant.
+		"io/fs.ModeSetuid", // file mode bit constant for setuid; pure constant.
+		"io/fs.ModeSocket", // file mode bit constant for sockets; pure constant.
+		"io/fs.ModeSticky", // file mode bit constant for sticky bit; pure constant.
+		"io/fs.ModeSymlink", // file mode bit constant for symlinks; pure constant.
+		"slices.Reverse",   // reverses a slice in-place; pure function, no I/O.
+		"slices.SortFunc",  // sorts a slice with a comparison function; pure function, no I/O.
+		"time.Time",        // time value type; pure data, no side effects.
+	},
+	"tail": {
+		"bufio.NewScanner", // line-by-line input reading; no write or exec capability.
+		"context.Context",  // deadline/cancellation plumbing; pure interface, no side effects.
+		"errors.Is",        // error comparison; pure function, no I/O.
+		"errors.New",       // creates a simple error value; pure function, no I/O.
+		"io.EOF",           // sentinel error value; pure constant.
+		"io.NopCloser",     // wraps a Reader with a no-op Close; no side effects.
+		"io.ReadCloser",    // interface type; no side effects.
+		"io.Reader",        // interface type; no side effects.
+		"os.FileInfo",      // file metadata interface returned by Stat; no I/O side effects.
+		"os.O_RDONLY",      // read-only file flag constant; cannot open files by itself.
+		"strconv.ParseInt", // string-to-int conversion with base/bit-size; pure function, no I/O.
+	},
+	"testcmd": {
+		"context.Context",    // deadline/cancellation plumbing; pure interface, no side effects.
+		"io/fs.FileInfo",     // interface type for file information; no side effects.
+		"io/fs.ModeNamedPipe", // file mode bit constant for named pipes; pure constant.
+		"io/fs.ModeSymlink",  // file mode bit constant for symlinks; pure constant.
+		"math.MaxInt64",      // integer constant; no side effects.
+		"math.MinInt64",      // integer constant; no side effects.
+		"strconv.ErrRange",   // sentinel error value for overflow; pure constant.
+		"strconv.NumError",   // error type for numeric conversion failures; pure type.
+		"strconv.ParseInt",   // string-to-int conversion with base/bit-size; pure function, no I/O.
+		"strings.TrimSpace",  // removes leading/trailing whitespace; pure function.
+	},
+	"true": {
+		"context.Context", // deadline/cancellation plumbing; pure interface, no side effects.
+	},
+	"uniq": {
+		"bufio.NewScanner", // line-by-line input reading; no write or exec capability.
+		"bufio.SplitFunc",  // type for custom scanner split functions; pure type, no I/O.
+		"context.Context",  // deadline/cancellation plumbing; pure interface, no side effects.
+		"io.NopCloser",     // wraps a Reader with a no-op Close; no side effects.
+		"io.ReadCloser",    // interface type; no side effects.
+		"io.Reader",        // interface type; no side effects.
+		"io.WriteString",   // writes a string to a writer; no filesystem access, delegates to Write.
+		"io.Writer",        // interface type for writing; no side effects.
+		"math.MaxInt64",    // integer constant; no side effects.
+		"os.O_RDONLY",      // read-only file flag constant; cannot open files by itself.
+		"strconv.ErrRange", // sentinel error value for overflow; pure constant.
+		"strconv.FormatInt", // int-to-string conversion; pure function, no I/O.
+		"strconv.NumError",  // error type for numeric conversion failures; pure type.
+		"strconv.ParseInt",  // string-to-int conversion with base/bit-size; pure function, no I/O.
+		"strings.HasPrefix", // pure function for prefix matching; no I/O.
+	},
+	"wc": {
+		"context.Context",       // deadline/cancellation plumbing; pure interface, no side effects.
+		"io.EOF",                // sentinel error value; pure constant.
+		"io.NopCloser",          // wraps a Reader with a no-op Close; no side effects.
+		"io.ReadCloser",         // interface type; no side effects.
+		"io.Reader",             // interface type; no side effects.
+		"os.O_RDONLY",           // read-only file flag constant; cannot open files by itself.
+		"strconv.FormatInt",     // int-to-string conversion; pure function, no I/O.
+		"unicode.Cc",            // control character category range table; pure data, no I/O.
+		"unicode.Cf",            // format character category range table; pure data, no I/O.
+		"unicode.Is",            // checks if rune belongs to a range table; pure function, no I/O.
+		"unicode.Me",            // enclosing mark category range table; pure data, no I/O.
+		"unicode.Mn",            // nonspacing mark category range table; pure data, no I/O.
+		"unicode.Range16",       // struct type for 16-bit Unicode ranges; pure data.
+		"unicode.Range32",       // struct type for 32-bit Unicode ranges; pure data.
+		"unicode.RangeTable",    // struct type for Unicode range tables; pure data.
+		"unicode/utf8.DecodeRune", // decodes first UTF-8 rune from a byte slice; pure function, no I/O.
+		"unicode/utf8.RuneCount",  // counts UTF-8 runes in a byte slice; pure function, no I/O.
+		"unicode/utf8.UTFMax",     // maximum number of bytes in a UTF-8 encoding; constant, no I/O.
+		"unicode/utf8.Valid",      // checks if a byte slice is valid UTF-8; pure function, no I/O.
+	},
 }
 
 // permanentlyBanned lists packages that may never be imported by builtin
@@ -137,36 +165,29 @@ var permanentlyBanned = map[string]string{
 	"unsafe":  "bypasses Go's type and memory safety guarantees",
 }
 
-// TestBuiltinImportAllowlist enforces symbol-level import restrictions on
-// command implementation files in interp/builtins/. builtins.go is exempt as
-// the package framework. Every other file's imports and pkg.Symbol references
-// must be explicitly listed in builtinAllowedSymbols.
+// TestBuiltinImportAllowlist enforces per-command symbol-level import
+// restrictions on command implementation files in interp/builtins/.
+// builtins.go is exempt as the package framework. Every other file's imports
+// and pkg.Symbol references must be explicitly listed in the command's entry
+// in builtinAllowedSymbols. The test also verifies that no command lists
+// symbols it does not actually use.
 func TestBuiltinImportAllowlist(t *testing.T) {
-	// Build lookup sets from the allowlist.
-	allowedSymbols := make(map[string]bool, len(builtinAllowedSymbols))
-	allowedPackages := make(map[string]bool)
-	for _, entry := range builtinAllowedSymbols {
-		dot := strings.LastIndexByte(entry, '.')
-		if dot <= 0 {
-			t.Fatalf("malformed allowlist entry (no dot): %q", entry)
-		}
-		allowedSymbols[entry] = true
-		allowedPackages[entry[:dot]] = true
-	}
-
 	root := repoRoot(t)
 	builtinsDir := filepath.Join(root, "interp", "builtins")
 
-	// Collect all .go files in builtin sub-packages (each builtin lives
-	// in its own subdirectory, e.g. cat/cat.go, head/head.go). Internal
-	// shared packages (internal/) are also checked.
-	var goFiles []string
+	// Collect all .go files in builtin sub-packages, grouped by command key.
+	// Command key is the first path component (e.g. "cat", "internal/loopctl").
+	type fileEntry struct {
+		absPath string
+		rel     string // relative to builtinsDir
+	}
+	commandFiles := make(map[string][]fileEntry)
+
 	err := filepath.Walk(builtinsDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if info.IsDir() {
-			// testutil/ is a test-only helper package, not a command implementation.
 			if info.Name() == "testutil" {
 				return filepath.SkipDir
 			}
@@ -176,96 +197,151 @@ func TestBuiltinImportAllowlist(t *testing.T) {
 			return nil
 		}
 		rel, _ := filepath.Rel(builtinsDir, path)
-		// builtins.go is the package framework (CallContext, Result, Register,
-		// Lookup) and is exempt. Only command implementation files are checked.
 		if rel == "builtins.go" {
 			return nil
 		}
-		// Only check files inside subdirectories (the per-builtin packages).
 		if !strings.Contains(rel, string(filepath.Separator)) {
 			return nil
 		}
-		goFiles = append(goFiles, path)
+
+		// Determine command key from relative path.
+		// e.g. "cat/cat.go" → "cat", "internal/loopctl/loopctl.go" → "internal/loopctl"
+		parts := strings.Split(rel, string(filepath.Separator))
+		var cmdKey string
+		if parts[0] == "internal" && len(parts) >= 3 {
+			cmdKey = parts[0] + "/" + parts[1]
+		} else {
+			cmdKey = parts[0]
+		}
+
+		commandFiles[cmdKey] = append(commandFiles[cmdKey], fileEntry{absPath: path, rel: rel})
 		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fset := token.NewFileSet()
-	checked := 0
-	for _, path := range goFiles {
-		rel, _ := filepath.Rel(builtinsDir, path)
-		checked++
-
-		f, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			t.Errorf("%s: parse error: %v", rel, err)
-			continue
-		}
-
-		// Build a map from local package name → import path and validate each import.
-		localToPath := make(map[string]string)
-		for _, imp := range f.Imports {
-			importPath := strings.Trim(imp.Path.Value, `"`)
-
-			if reason, banned := permanentlyBanned[importPath]; banned {
-				t.Errorf("%s: import of %q is permanently banned (%s)", rel, importPath, reason)
-				continue
-			}
-
-			// The parent builtins package and sibling internal packages are
-			// always allowed — they are part of the builtins module.
-			if importPath == "github.com/DataDog/rshell/interp/builtins" ||
-				strings.HasPrefix(importPath, "github.com/DataDog/rshell/interp/builtins/internal/") {
-				continue
-			}
-
-			// Determine the local name used to reference this package.
-			var localName string
-			if imp.Name != nil {
-				localName = imp.Name.Name
-			} else {
-				parts := strings.Split(importPath, "/")
-				localName = parts[len(parts)-1]
-			}
-
-			if localName == "_" || localName == "." {
-				t.Errorf("%s: blank/dot import of %q is not allowed", rel, importPath)
-				continue
-			}
-
-			if !allowedPackages[importPath] {
-				t.Errorf("%s: import of %q is not in the allowlist", rel, importPath)
-				continue
-			}
-
-			localToPath[localName] = importPath
-		}
-
-		// Walk all selector expressions and verify each pkg.Symbol is allowed.
-		ast.Inspect(f, func(n ast.Node) bool {
-			sel, ok := n.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			ident, ok := sel.X.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			importPath, ok := localToPath[ident.Name]
-			if !ok {
-				return true // not a package-level selector
-			}
-			key := importPath + "." + sel.Sel.Name
-			if !allowedSymbols[key] {
-				pos := fset.Position(sel.Pos())
-				t.Errorf("%s:%d: %s is not in the allowlist", rel, pos.Line, key)
-			}
-			return true
-		})
-	}
-	if checked == 0 {
+	if len(commandFiles) == 0 {
 		t.Fatal("no command implementation files found in interp/builtins/ sub-packages")
+	}
+
+	// Verify every discovered command has an allowlist entry.
+	for cmdKey := range commandFiles {
+		if _, ok := builtinAllowedSymbols[cmdKey]; !ok {
+			t.Errorf("command %q has no entry in builtinAllowedSymbols", cmdKey)
+		}
+	}
+
+	// Verify every allowlist entry corresponds to a real command.
+	for cmdKey := range builtinAllowedSymbols {
+		if _, ok := commandFiles[cmdKey]; !ok {
+			t.Errorf("builtinAllowedSymbols has entry for %q but no matching command directory exists", cmdKey)
+		}
+	}
+
+	fset := token.NewFileSet()
+
+	for cmdKey, files := range commandFiles {
+		allowedList, ok := builtinAllowedSymbols[cmdKey]
+		if !ok {
+			continue // already reported above
+		}
+
+		// Build per-command lookup sets.
+		allowedSymbols := make(map[string]bool, len(allowedList))
+		allowedPackages := make(map[string]bool)
+		for _, entry := range allowedList {
+			dot := strings.LastIndexByte(entry, '.')
+			if dot <= 0 {
+				t.Fatalf("%s: malformed allowlist entry (no dot): %q", cmdKey, entry)
+			}
+			allowedSymbols[entry] = true
+			allowedPackages[entry[:dot]] = true
+		}
+
+		// Track which allowed symbols are actually used.
+		usedSymbols := make(map[string]bool)
+
+		for _, fe := range files {
+			f, err := parser.ParseFile(fset, fe.absPath, nil, 0)
+			if err != nil {
+				t.Errorf("%s: parse error: %v", fe.rel, err)
+				continue
+			}
+
+			localToPath := make(map[string]string)
+			for _, imp := range f.Imports {
+				importPath := strings.Trim(imp.Path.Value, `"`)
+
+				if reason, banned := permanentlyBanned[importPath]; banned {
+					t.Errorf("%s: import of %q is permanently banned (%s)", fe.rel, importPath, reason)
+					continue
+				}
+
+				if importPath == "github.com/DataDog/rshell/interp/builtins" ||
+					strings.HasPrefix(importPath, "github.com/DataDog/rshell/interp/builtins/internal/") {
+					continue
+				}
+
+				var localName string
+				if imp.Name != nil {
+					localName = imp.Name.Name
+				} else {
+					parts := strings.Split(importPath, "/")
+					localName = parts[len(parts)-1]
+				}
+
+				if localName == "_" || localName == "." {
+					t.Errorf("%s: blank/dot import of %q is not allowed", fe.rel, importPath)
+					continue
+				}
+
+				if !allowedPackages[importPath] {
+					t.Errorf("%s: import of %q is not in the %s allowlist", fe.rel, importPath, cmdKey)
+					continue
+				}
+
+				localToPath[localName] = importPath
+			}
+
+			ast.Inspect(f, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				importPath, ok := localToPath[ident.Name]
+				if !ok {
+					return true
+				}
+				key := importPath + "." + sel.Sel.Name
+				usedSymbols[key] = true
+				if !allowedSymbols[key] {
+					pos := fset.Position(sel.Pos())
+					t.Errorf("%s:%d: %s is not in the %s allowlist", fe.rel, pos.Line, key, cmdKey)
+				}
+				return true
+			})
+		}
+
+		// Verify no unused symbols in the allowlist.
+		for _, entry := range allowedList {
+			if !usedSymbols[entry] {
+				t.Errorf("%s: allowlist contains %q but it is not used by any source file", cmdKey, entry)
+			}
+		}
+	}
+}
+
+// TestBuiltinAllowlistSorted verifies that each command's allowlist entries
+// are in sorted order, making it easier to maintain and review.
+func TestBuiltinAllowlistSorted(t *testing.T) {
+	for cmdKey, symbols := range builtinAllowedSymbols {
+		if !sort.StringsAreSorted(symbols) {
+			t.Errorf("%s: allowlist entries are not sorted", cmdKey)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replace the single global `builtinAllowedSymbols` slice with a `map[string][]string` keyed by command subdirectory name (e.g., `"cat"`, `"ls"`, `"internal/loopctl"`)
- Each builtin now has its own isolated symbol list — no shared base, maximum isolation
- Test enforces that no command lists symbols it doesn't actually use (unused symbol detection)
- Test verifies every command directory has an allowlist entry and vice versa
- Drops unused `io/fs.DirEntry` symbol that was in the old global list
- Adds `TestBuiltinAllowlistSorted` to ensure entries stay sorted per command

## Test plan
- [x] `TestBuiltinImportAllowlist` passes
- [x] `TestBuiltinAllowlistSorted` passes
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)