### PR TITLE
Fix Windows CI failures in ls builtin tests

### DIFF
--- a/interp/portable.go
+++ b/interp/portable.go
@@ -18,14 +18,26 @@ func portableErrMsg(err error) string {
 	if err == nil {
 		return ""
 	}
+	// On Windows, os.Root operations may return nested *os.PathError values
+	// (e.g. *os.PathError{Op:"lstat", Err:*os.PathError{Op:"statat", Err:syscall.ENOENT}}).
+	// Unwrap nested PathErrors so errors.Is can reach the underlying sentinel.
+	unwrapped := err
+	for {
+		var pe *os.PathError
+		if errors.As(unwrapped, &pe) {
+			unwrapped = pe.Err
+		} else {
+			break
+		}
+	}
 	switch {
-	case errors.Is(err, fs.ErrNotExist):
+	case errors.Is(unwrapped, fs.ErrNotExist):
 		return "no such file or directory"
-	case errors.Is(err, fs.ErrPermission):
+	case errors.Is(unwrapped, fs.ErrPermission):
 		return "permission denied"
-	case errors.Is(err, fs.ErrExist):
+	case errors.Is(unwrapped, fs.ErrExist):
 		return "file exists"
-	case isErrIsDirectory(err):
+	case isErrIsDirectory(unwrapped):
 		return "is a directory"
 	}
 	return err.Error()

--- a/tests/scenarios/cmd/ls/long_format/basic_long.yaml
+++ b/tests/scenarios/cmd/ls/long_format/basic_long.yaml
@@ -14,5 +14,10 @@ expect:
     - "-rw-r--r--"
     - "11"
     - "hello.txt"
+  # Windows maps chmod 0644 to -rw-rw-rw- (no granular Unix permissions).
+  stdout_contains_windows:
+    - "-rw-rw-rw-"
+    - "11"
+    - "hello.txt"
   stderr: ""
   exit_code: 0

--- a/tests/scenarios/cmd/ls/long_format/human_readable.yaml
+++ b/tests/scenarios/cmd/ls/long_format/human_readable.yaml
@@ -13,5 +13,9 @@ expect:
   stdout_contains:
     - "-rw-r--r--"
     - "tiny.txt"
+  # Windows maps chmod 0644 to -rw-rw-rw- (no granular Unix permissions).
+  stdout_contains_windows:
+    - "-rw-rw-rw-"
+    - "tiny.txt"
   stderr: ""
   exit_code: 0


### PR DESCRIPTION
## Summary
- **portableErrMsg**: Unwrap nested `*os.PathError` from `os.Root` operations on Windows so `errors.Is` can reach the underlying sentinel error. This fixes the `statat etc:` prefix leaking into error messages (e.g. `ls: cannot access '/etc': statat etc: no such file or directory` → `ls: cannot access '/etc': no such file or directory`).
- **ls long_format tests**: Add `stdout_contains_windows` for `-rw-rw-rw-` since Windows maps `chmod 0644` without granular Unix permission bits.

Fixes 3 failing tests on `Test (windows-latest)`:
- `cmd/ls/sandbox/outside_allowed_paths`
- `cmd/ls/long_format/basic_long`
- `cmd/ls/long_format/human_readable`

## Test plan
- [x] All tests pass locally (`go test -race ./interp/... ./tests/...`)
- [ ] Windows CI should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)