### PR TITLE
Prefer scenario tests over Go tests in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ The shell is supported on Linux, Windows and macOS.
   ```
   The test suite runs all scenarios against `debian:bookworm-slim` (GNU bash + GNU coreutils) and compares output byte-for-byte. Only set `skip_assert_against_bash: true` in a scenario when the behavior intentionally diverges from bash (e.g. sandbox restrictions, blocked commands).
 
+- **Prefer scenario tests (`tests/scenarios/`) over Go tests.** Scenario tests are declarative YAML files that are automatically validated against both the shell and bash, making them easier to write, review, and maintain. Only use Go tests when scenario tests cannot express the required behaviour (e.g. testing Go APIs directly, complex programmatic assertions).
 - In test scenarios, use `expect.stderr` when possible instead of `stderr_contains`.
 - Test scenarios are asserted against bash by default. Only set `skip_assert_against_bash: true` for features that intentionally diverge from standard bash behavior (e.g. blocked commands, restricted redirects, readonly enforcement).
 - When expected output differs on Windows (e.g. path separators `\` vs `/`), use Windows-specific assertion fields:


### PR DESCRIPTION
## Summary
- Added guideline to AGENTS.md to prefer scenario tests (`tests/scenarios/`) over Go tests, since they are declarative YAML validated against both the shell and bash
- Go tests should only be used when scenario tests cannot express the required behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)