### PR TITLE
Remove unnecessary skip_assert_against_bash from head scenarios

### DIFF
--- a/tests/scenarios/cmd/head/bytes/last_flag_wins_bytes.yaml
+++ b/tests/scenarios/cmd/head/bytes/last_flag_wins_bytes.yaml
@@ -1,6 +1,5 @@
 # Derived from GNU coreutils head behavior: last of -n/-c wins
 description: When -n and -c are both given, the last flag wins; here -c wins.
-skip_assert_against_bash: true
 setup:
   files:
     - path: file.txt

--- a/tests/scenarios/cmd/head/bytes/last_flag_wins_lines.yaml
+++ b/tests/scenarios/cmd/head/bytes/last_flag_wins_lines.yaml
@@ -1,6 +1,5 @@
 # Derived from GNU coreutils head behavior: last of -n/-c wins
 description: When -c and -n are both given, the last flag wins; here -n wins.
-skip_assert_against_bash: true
 setup:
   files:
     - path: file.txt

--- a/tests/scenarios/cmd/head/errors/unknown_flag.yaml
+++ b/tests/scenarios/cmd/head/errors/unknown_flag.yaml
@@ -1,6 +1,5 @@
 # Per RULES.md: every dangerous/unsupported flag must have a test verifying rejection
 description: head exits 1 with an error when given an unknown flag.
-skip_assert_against_bash: true
 setup:
   files:
     - path: file.txt

--- a/tests/scenarios/cmd/head/hardening/double_dash_separator.yaml
+++ b/tests/scenarios/cmd/head/hardening/double_dash_separator.yaml
@@ -1,6 +1,5 @@
 # Standard POSIX -- end-of-flags behavior
 description: head treats arguments after -- as file names, even if they look like flags.
-skip_assert_against_bash: true
 setup:
   files:
     - path: -n

--- a/tests/scenarios/cmd/head/hardening/large_count_clamped.yaml
+++ b/tests/scenarios/cmd/head/hardening/large_count_clamped.yaml
@@ -1,6 +1,5 @@
 # Per RULES.md: count values must be clamped to prevent allocation attacks
 description: head accepts very large -n counts by clamping; does not OOM on small files.
-skip_assert_against_bash: true
 setup:
   files:
     - path: small.txt


### PR DESCRIPTION
## Summary

- Five `head` test scenarios were marked `skip_assert_against_bash: true` even though GNU head (coreutils 9.10) produces byte-for-byte identical output
- Verified each case against `ghead` 9.10 locally before removing the flags
- Only `negative_count` and `outside_allowed_paths` genuinely diverge from GNU head behavior and retain their skip flags

## Scenarios fixed

| Scenario | Why skip was incorrect |
|---|---|
| `bytes/last_flag_wins_bytes.yaml` | `ghead -n 2 -c 5` → `alpha` (exit 0) — matches |
| `bytes/last_flag_wins_lines.yaml` | `ghead -c 5 -n 2` → `alpha\nbeta\n` (exit 0) — matches |
| `hardening/double_dash_separator.yaml` | `ghead -- -n` reads file named `-n` — matches |
| `errors/unknown_flag.yaml` | `ghead --follow` exits 1, stderr contains `head:` — matches |
| `hardening/large_count_clamped.yaml` | `ghead -n 9999999999 small.txt` → `tiny\n` (exit 0) — matches |

## Test plan

- [x] go test ./interp/builtins/head/... ./tests/... passes locally
- [x] Each removed skip verified against ghead 9.10 (Homebrew coreutils)
- [ ] Docker bash comparison tests (RSHELL_BASH_TEST=1) — run by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)