### PR TITLE
Add native Go fuzz tests for builtin commands

### DIFF
--- a/interp/builtins/tests/cat/cat_fuzz_test.go
+++ b/interp/builtins/tests/cat/cat_fuzz_test.go
@@ -17,11 +17,6 @@ import (
 	"github.com/DataDog/rshell/interp/builtins/testutil"
 )
 
-func cmdRun(t *testing.T, script, dir string) (string, string, int) {
-	t.Helper()
-	return testutil.RunScript(t, script, dir, interp.AllowedPaths([]string{dir}))
-}
-
 func cmdRunCtx(ctx context.Context, t *testing.T, script, dir string) (string, string, int) {
 	t.Helper()
 	return testutil.RunScriptCtx(ctx, t, script, dir, interp.AllowedPaths([]string{dir}))

--- a/interp/builtins/tests/grep/grep_fuzz_test.go
+++ b/interp/builtins/tests/grep/grep_fuzz_test.go
@@ -13,25 +13,15 @@ import (
 	"testing"
 	"time"
 
+	"unicode/utf8"
+
 	"github.com/DataDog/rshell/interp"
 	"github.com/DataDog/rshell/interp/builtins/testutil"
 )
 
-func cmdRun(t *testing.T, script, dir string) (string, string, int) {
-	t.Helper()
-	return testutil.RunScript(t, script, dir, interp.AllowedPaths([]string{dir}))
-}
-
 func cmdRunCtx(ctx context.Context, t *testing.T, script, dir string) (string, string, int) {
 	t.Helper()
 	return testutil.RunScriptCtx(ctx, t, script, dir, interp.AllowedPaths([]string{dir}))
-}
-
-// safePattern escapes a byte slice into a shell-safe single-quoted string.
-// Single-quoted strings in bash cannot contain single quotes, so we use
-// a simple fixed pattern approach instead.
-func fixedPatterns() []string {
-	return []string{".", "a", "foo", "^$", "[a-z]", ".*"}
 }
 
 // FuzzGrepFileContent fuzzes grep with a fixed pattern and arbitrary file content.
@@ -49,7 +39,14 @@ func FuzzGrepFileContent(f *testing.F) {
 		if len(input) > 1<<20 {
 			return
 		}
-		// Skip patterns that would be problematic in shell quoting
+		// Skip patterns containing non-UTF-8 sequences: the shell parser's
+		// tokenizer rejects them before grep runs, so they exercise the parser
+		// error path rather than the grep builtin.
+		if !utf8.ValidString(pattern) {
+			return
+		}
+		// Skip patterns that would be problematic in shell quoting or cause the
+		// shell parser to fail before grep runs.
 		for _, c := range pattern {
 			if c == '\'' || c == '\x00' || c == '\n' {
 				return

--- a/interp/builtins/tests/head/head_fuzz_test.go
+++ b/interp/builtins/tests/head/head_fuzz_test.go
@@ -19,11 +19,6 @@ import (
 	"github.com/DataDog/rshell/interp/builtins/testutil"
 )
 
-func cmdRun(t *testing.T, script, dir string) (string, string, int) {
-	t.Helper()
-	return testutil.RunScript(t, script, dir, interp.AllowedPaths([]string{dir}))
-}
-
 func cmdRunCtx(ctx context.Context, t *testing.T, script, dir string) (string, string, int) {
 	t.Helper()
 	return testutil.RunScriptCtx(ctx, t, script, dir, interp.AllowedPaths([]string{dir}))

--- a/interp/builtins/tests/tail/tail_fuzz_test.go
+++ b/interp/builtins/tests/tail/tail_fuzz_test.go
@@ -19,11 +19,6 @@ import (
 	"github.com/DataDog/rshell/interp/builtins/testutil"
 )
 
-func cmdRun(t *testing.T, script, dir string) (string, string, int) {
-	t.Helper()
-	return testutil.RunScript(t, script, dir, interp.AllowedPaths([]string{dir}))
-}
-
 func cmdRunCtx(ctx context.Context, t *testing.T, script, dir string) (string, string, int) {
 	t.Helper()
 	return testutil.RunScriptCtx(ctx, t, script, dir, interp.AllowedPaths([]string{dir}))
@@ -154,3 +149,80 @@ func FuzzTailStdin(f *testing.F) {
 		}
 	})
 }
+
+// FuzzTailLinesOffset fuzzes tail -n +N (skip-first-N-lines offset mode).
+func FuzzTailLinesOffset(f *testing.F) {
+	f.Add([]byte("line1\nline2\nline3\n"), int64(1))
+	f.Add([]byte("line1\nline2\nline3\n"), int64(2))
+	f.Add([]byte{}, int64(1))
+	f.Add([]byte("no newline"), int64(1))
+	f.Add([]byte("a\x00b\nc\n"), int64(2))
+	f.Add(bytes.Repeat([]byte("x"), 4097), int64(1))
+	f.Add([]byte("\n\n\n"), int64(5))
+	f.Add([]byte("hello\nworld\n"), int64(100))
+
+	f.Fuzz(func(t *testing.T, input []byte, n int64) {
+		if len(input) > 1<<20 {
+			return
+		}
+		if n < 1 {
+			return
+		}
+		if n > 10000 {
+			n = 10000
+		}
+
+		dir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dir, "input.txt"), input, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, _, code := cmdRunCtx(ctx, t, fmt.Sprintf("tail -n +%d input.txt", n), dir)
+		if code != 0 && code != 1 {
+			t.Errorf("tail -n +%d unexpected exit code %d", n, code)
+		}
+	})
+}
+
+// FuzzTailBytesOffset fuzzes tail -c +N (skip-first-N-bytes offset mode).
+func FuzzTailBytesOffset(f *testing.F) {
+	f.Add([]byte("hello\nworld\n"), int64(1))
+	f.Add([]byte("hello\nworld\n"), int64(6))
+	f.Add([]byte{}, int64(1))
+	f.Add([]byte("no newline"), int64(3))
+	f.Add([]byte("a\x00b\nc\n"), int64(2))
+	f.Add(bytes.Repeat([]byte("x"), 4097), int64(4096))
+	f.Add([]byte("\n\n\n"), int64(2))
+	f.Add([]byte("hello\nworld\n"), int64(100))
+
+	f.Fuzz(func(t *testing.T, input []byte, n int64) {
+		if len(input) > 1<<20 {
+			return
+		}
+		if n < 1 {
+			return
+		}
+		if n > 10000 {
+			n = 10000
+		}
+
+		dir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dir, "input.txt"), input, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, _, code := cmdRunCtx(ctx, t, fmt.Sprintf("tail -c +%d input.txt", n), dir)
+		if code != 0 && code != 1 {
+			t.Errorf("tail -c +%d unexpected exit code %d", n, code)
+		}
+	})
+}
+

--- a/interp/builtins/tests/wc/wc_fuzz_test.go
+++ b/interp/builtins/tests/wc/wc_fuzz_test.go
@@ -17,11 +17,6 @@ import (
 	"github.com/DataDog/rshell/interp/builtins/testutil"
 )
 
-func cmdRun(t *testing.T, script, dir string) (string, string, int) {
-	t.Helper()
-	return testutil.RunScript(t, script, dir, interp.AllowedPaths([]string{dir}))
-}
-
 func cmdRunCtx(ctx context.Context, t *testing.T, script, dir string) (string, string, int) {
 	t.Helper()
 	return testutil.RunScriptCtx(ctx, t, script, dir, interp.AllowedPaths([]string{dir}))


### PR DESCRIPTION
## Summary

- Adds `testing.F` fuzz tests for `head`, `cat`, `wc`, `tail`, and `grep` builtins
- Each fuzz test file lives in `interp/builtins/tests/<cmd>/<cmd>_fuzz_test.go`
- Covers both file-based input and stdin-via-shell-redirection variants

## What's included

For each builtin:
- **head**: `FuzzHeadLines`, `FuzzHeadBytes`, `FuzzHeadStdin` — verifies exit codes 0/1 and that `-n K` produces at most K newlines
- **cat**: `FuzzCat`, `FuzzCatNumberLines`, `FuzzCatStdin` — verifies output exactly matches input for the plain `cat` case
- **wc**: `FuzzWc`, `FuzzWcLines`, `FuzzWcBytes`, `FuzzWcStdin` — verifies exit codes are sane
- **tail**: `FuzzTailLines`, `FuzzTailBytes`, `FuzzTailStdin` — verifies exit codes and output line/byte count invariants
- **grep**: `FuzzGrepFileContent`, `FuzzGrepStdin`, `FuzzGrepFlags` — verifies exit codes 0, 1, or 2

## Seed corpus

Each fuzz function covers edge cases:
- Empty input (`[]byte{}`)
- Input with no trailing newline
- NUL bytes (`[]byte("a\x00b\n")`)
- Buffer boundary: 4097 bytes
- All-newlines input (`[]byte("\n\n\n")`)

## Safety guards

- Inputs > 1 MB are skipped (`return`)
- Numeric params clamped: `n < 0 → return`, `n > 10000 → n = 10000`
- `context.WithTimeout(5s)` on every test to detect hangs
- Exit code assertion: must be 0 or 1 (grep also allows 2 for invalid regex)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./interp/builtins/tests/... -run Fuzz -timeout 60s` — all seed corpus entries pass
- [ ] Optionally run full fuzzing: `go test ./interp/builtins/tests/head/... -fuzz FuzzHeadLines -fuzztime 30s`

---

## Agent context (for resuming work)

**Original prompt:** Research formal testing approaches for rshell builtin implementations. Implement Option 1: native Go fuzz tests using `testing.F`.

**Research findings that shaped this PR:**
- Go 1.18+ provides `testing.F` with `f.Add(seedValue)` for seed corpus and `f.Fuzz(func(t *testing.T, ...))` for the fuzz body. Coverage-guided, persists findings in `testdata/fuzz/<FuncName>/`.
- Running `go test -run '^FuzzXxx'` (no `-fuzz=`) executes only seed corpus entries as regular tests — zero overhead in normal CI.
- Full fuzzing: `go test -fuzz=FuzzXxx -fuzztime=30s ./pkg/` — runs in-process, no external tools needed.
- Property-based invariants are stronger than just "doesn't panic": `head -n 5` must produce ≤5 newlines; `cat` must produce output matching input byte-for-byte; grep exit code must be 0, 1, or 2.
- 1MB input cap prevents slow test runs; without it the fuzzer can generate multi-MB inputs that take seconds each.
- `context.WithTimeout(5s)` catches infinite loops / hangs that would otherwise block the fuzzer indefinitely.
- `n` clamped to 10000 prevents the fuzzer from generating `head -n 99999999` which would be valid but slow.

**Key design decisions:**
- Invariant-based assertions (not just crash detection): stronger than fuzzing for panics alone
- All fuzz tests in `interp/builtins/tests/<cmd>/` alongside existing unit tests, sharing the `cmdRun`/`cmdRunCtx` helper pattern
- `grep` fuzz tests use `FuzzGrepFlags` to explore flag combinations (e.g. `-i`, `-v`, `-c`) — important since grep has the most flag surface area

**Merge note:** This PR and PR #62 (differential fuzz) both write to `interp/builtins/tests/<cmd>/`. Merge one first to avoid conflicts on helper files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)