### PR TITLE
Add build target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: test test_all test_against_bash compliance
+.PHONY: build test test_all test_against_bash compliance
+
+build:
+	go build -o rshell ./cmd/rshell
 
 test:
 	go test -v -race ./...


### PR DESCRIPTION
## Summary
- Add `make build` target that compiles `cmd/rshell` into a `rshell` binary in the project root

## Test plan
- [x] Run `make build` and verify the `rshell` binary is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)