### PR TITLE
security: check context cancellation in for-loop iterations

### DIFF
--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -176,6 +176,10 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			}
 
 			for _, field := range items {
+				if err := ctx.Err(); err != nil {
+					r.exit.fatal(err)
+					break
+				}
 				r.setVarString(name, field)
 				if r.loopStmtsBroken(ctx, cm.Do) {
 					// Excess continue at outermost loop: clamp and keep iterating


### PR DESCRIPTION
## Summary
- The `for` loop body had no `ctx.Err()` check — a script iterating over many items would continue even after the context was cancelled, causing CPU exhaustion
- Adds a `ctx.Err()` check at the top of each for-loop iteration
- Calls `r.exit.fatal(err)` and breaks when the context is done

## Security finding
`SECURITY_FINDINGS.md` — Unbounded for-loop iterations (MODERATE)

## Test plan
- [ ] All existing tests pass
- [ ] Context cancellation now reliably terminates long-running for-loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)