### PR TITLE
security: document IFS mutability as a known security boundary

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -306,6 +306,12 @@ func (r *Runner) Reset() {
 	}
 	r.writeEnv = &overlayEnviron{parent: r.Env}
 	r.setVarString("PWD", r.Dir)
+	// IFS is intentionally mutable: scripts may set it to customise field splitting,
+	// which is standard POSIX behaviour. Callers that provide a custom ExecHandler
+	// should be aware that a script can set IFS to a non-whitespace value (e.g.
+	// IFS=/) to manipulate how unquoted variable expansions are split before being
+	// passed to executed commands (argument smuggling). The default noExecHandler
+	// blocks all external execution, limiting the practical impact of this vector.
 	r.setVarString("IFS", " \t\n")
 	r.setVarString("OPTIND", "1")
 


### PR DESCRIPTION
## Summary
- `IFS` is intentionally mutable for POSIX compatibility, but this was undocumented as a security consideration
- Adds an explicit inline comment documenting the argument-smuggling risk: callers providing a custom `ExecHandler` should be aware that scripts can set `IFS` to non-whitespace values to influence field splitting
- Notes that the default `noExecHandler` limits practical impact

## Security finding
`SECURITY_FINDINGS.md` — IFS not marked readonly (MEDIUM). The finding itself states "This is intentional behavior but represents a security boundary worth documenting" — this PR implements the documentation fix.

## Test plan
- [ ] All existing tests pass (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)