### PR TITLE
security: guard against unknown AST node types in validator

### DIFF
--- a/interp/validate.go
+++ b/interp/validate.go
@@ -127,6 +127,22 @@ func validateNode(node syntax.Node) error {
 					}
 				}
 			}
+
+		// Explicitly allowed command-level nodes. These are the only
+		// syntax.Command implementations that safe-shell permits.
+		// Listing them here ensures any new Command type added by a future
+		// version of mvdan.cc/sh/v3 is caught by the catch-all below.
+		// NOTE: *syntax.BinaryCmd and *syntax.ForClause are handled by their
+		// own cases above (with partial restrictions) and must not appear here.
+		case *syntax.CallExpr, *syntax.IfClause, *syntax.Block:
+			// allowed — no action
+
+		// Catch-all for unknown Command types not explicitly listed above.
+		// This guards against new command node types added by upstream
+		// library upgrades silently bypassing validation.
+		case syntax.Command:
+			err = fmt.Errorf("unsupported command type: %T", n)
+			return false
 		}
 		return true
 	})


### PR DESCRIPTION
## Summary
- The `validateNode()` switch had no catch-all for `syntax.Command` — a new Command type added by a future `mvdan.cc/sh/v3` upgrade would silently pass validation
- Adds explicit allowlist cases for the three currently-permitted Command types: `*syntax.CallExpr`, `*syntax.IfClause`, `*syntax.Block`
- Adds `case syntax.Command:` catch-all (placed after all specific cases so concrete types take priority) that rejects any unknown Command implementation

## Security finding
`SECURITY_FINDINGS.md` — Missing default case in AST validator (LOW)

## Test plan
- [ ] All existing tests pass
- [ ] Any new `syntax.Command` type not in the allowlist will be rejected at validation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)