### PR TITLE
fix: correct wc stdin test expectation to match GNU wc

### DIFF
--- a/interp/builtins/wc/wc.go
+++ b/interp/builtins/wc/wc.go
@@ -207,12 +207,8 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		width := fieldWidth(total, opts)
 		// GNU wc uses a minimum column width of 7 for non-regular files
 		// (stdin pipes, directories, devices, etc.) when two or more
-		// columns are printed — whether in default mode or with explicit
-		// multi-column flags (e.g. wc -lw). GNU also applies this minimum
-		// when multiple files are processed (a total line is printed), even
-		// with a single column (e.g. wc -l dir file). When only a single
-		// column is active with a single file, the width is determined
-		// solely by the count values.
+		// columns are printed or when multiple files are processed.
+		// With a single column and single file, no minimum is applied.
 		if hasNonRegular && (opts.numCols() >= 2 || len(files) > 1) && width < nonRegularMinWidth {
 			width = nonRegularMinWidth
 		}

--- a/tests/scenarios/cmd/wc/stdin/no_filename.yaml
+++ b/tests/scenarios/cmd/wc/stdin/no_filename.yaml
@@ -1,10 +1,8 @@
-# skip: wc column width formatting differs from GNU coreutils
-skip_assert_against_bash: true
 description: wc -l from stdin does not show a filename.
 input:
   script: |+
     printf "one\ntwo\nthree\n" | wc -l
 expect:
-  stdout: "      3\n"
+  stdout: "3\n"
   stderr: ""
   exit_code: 0


### PR DESCRIPTION
## Summary
- Fixed `wc` stdin `no_filename` test that expected padded output (`"      3\n"`) but GNU wc outputs unpadded (`"3\n"`) for single-column, single-file stdin
- Removed `skip_assert_against_bash: true` so the scenario now validates against bash
- Simplified the comment on the minimum-width guard to be more accurate

## Test plan
- [x] All tests pass (`go test -race ./interp/... ./tests/...`)
- [x] Verified GNU wc behavior via Docker (`debian:bookworm-slim`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)