### PR TITLE
fix: use io.Discard instead of os.Stderr as panic fallback in interp

### DIFF
--- a/allowedsymbols/symbols_interp.go
+++ b/allowedsymbols/symbols_interp.go
@@ -41,7 +41,6 @@ var interpAllowedSymbols = []string{
 	"os.O_RDONLY",          // read-only file flag constant; pure constant.
 	"os.PathError",         // error type wrapping path and operation; pure type.
 	"os.Pipe",              // creates an OS pipe pair; needed for shell pipelines.
-	"os.Stderr",            // standard error file; fallback output for panic recovery when runner stderr is nil.
 	"runtime.GOOS",         // current OS name constant; pure constant, no I/O.
 	"strconv.Itoa",         // int-to-string conversion; pure function, no I/O.
 	"strings.Builder",      // efficient string concatenation; pure in-memory buffer, no I/O.

--- a/interp/api.go
+++ b/interp/api.go
@@ -339,12 +339,9 @@ func (s ExitStatus) Error() string { return fmt.Sprintf("exit status %d", s) }
 func (r *Runner) Run(ctx context.Context, node syntax.Node) (retErr error) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			var panicOut io.Writer
-			if r != nil {
+			panicOut := io.Writer(io.Discard)
+			if r != nil && r.stderr != nil {
 				panicOut = r.stderr
-			}
-			if panicOut == nil {
-				panicOut = os.Stderr
 			}
 			func() {
 				defer func() { recover() }()

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -139,9 +139,9 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			go func() {
 				defer func() {
 					if rec := recover(); rec != nil {
-						panicOut := rLeft.stderr
-						if panicOut == nil {
-							panicOut = os.Stderr
+						panicOut := io.Writer(io.Discard)
+						if rLeft.stderr != nil {
+							panicOut = rLeft.stderr
 						}
 						func() {
 							defer func() { recover() }()


### PR DESCRIPTION
## Summary

- The panic recovery handlers in `interp/api.go` and `interp/runner_exec.go` (added in #85) fell back to `os.Stderr` when the runner had no stderr configured
- This causes rshell to write directly to the process stderr, which is undesirable for embedders (e.g. datadog-agent)
- Replace the fallback with `io.Discard` — the caller still receives `"internal error"` via the returned error
- Also drops the `runtime/debug.Stack()` call added in #85, which would have leaked internal implementation details

## Test plan

- [x] `TestInterpAllowedSymbols` passes (no new allowlist entries needed)
- [x] `TestVerificationInterpCleanPass` passes
- [x] Full `allowedsymbols` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)