### PR TITLE
Fix help tests: add rshell: namespace prefix to AllowedCommands

### DIFF
--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -166,7 +166,7 @@ func TestHelpColumnsAligned(t *testing.T) {
 
 func TestHelpRestrictedShowsOnlyAllowed(t *testing.T) {
 	stdout, stderr, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"echo"}))
+		interp.AllowedCommands([]string{"rshell:echo"}))
 	assert.Equal(t, 0, code)
 	assert.Empty(t, stderr)
 	assert.Contains(t, stdout, "echo")
@@ -179,7 +179,7 @@ func TestHelpRestrictedShowsOnlyAllowed(t *testing.T) {
 func TestHelpRestrictedSingleCommand(t *testing.T) {
 	// Only "ls" is explicitly allowed; help should still appear.
 	stdout, _, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"ls"}))
+		interp.AllowedCommands([]string{"rshell:ls"}))
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout, "help")
 	assert.Contains(t, stdout, "ls")
@@ -190,7 +190,7 @@ func TestHelpRestrictedAlignmentAdjusts(t *testing.T) {
 	// With "wc" (2-char) and "strings" (7-char) plus implicit "help" (4-char),
 	// the column width should match the longest allowed name.
 	stdout, _, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"wc", "strings"}))
+		interp.AllowedCommands([]string{"rshell:wc", "rshell:strings"}))
 	assert.Equal(t, 0, code)
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
@@ -212,7 +212,7 @@ func TestHelpRestrictedAlignmentAdjusts(t *testing.T) {
 func TestHelpAlwaysAvailable(t *testing.T) {
 	// help is not in the allowed list, but should still run.
 	stdout, stderr, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"echo", "ls"}))
+		interp.AllowedCommands([]string{"rshell:echo", "rshell:ls"}))
 	assert.Equal(t, 0, code)
 	assert.Empty(t, stderr)
 	assert.Contains(t, stdout, "help")

--- a/tests/scenarios/cmd/help/always_available.yaml
+++ b/tests/scenarios/cmd/help/always_available.yaml
@@ -1,7 +1,7 @@
 description: Help is available even when not in the allowed commands list.
 skip_assert_against_bash: true
 input:
-  allowed_commands: ["echo"]
+  allowed_commands: ["rshell:echo"]
   script: |+
     help
 expect:

--- a/tests/scenarios/cmd/help/restricted_commands.yaml
+++ b/tests/scenarios/cmd/help/restricted_commands.yaml
@@ -1,7 +1,7 @@
 description: Help lists only commands allowed by the active policy, plus itself.
 skip_assert_against_bash: true
 input:
-  allowed_commands: ["echo"]
+  allowed_commands: ["rshell:echo"]
   script: |+
     help
 expect:


### PR DESCRIPTION
## Summary
- Help builtin tests and scenario YAML files were passing bare command names (e.g. `"echo"`) to `AllowedCommands`, but commit 2c579bf added a requirement for the `rshell:` namespace prefix
- Updated all help test fixtures to use `"rshell:echo"`, `"rshell:ls"`, etc.
- Fixes CI failures across all 3 platforms (ubuntu, macOS, Windows)

## Test plan
- [x] `go test -race ./builtins/tests/help/ -run "TestHelpRestricted|TestHelpAlways"` passes
- [x] `go test -race ./tests/ -run "TestShellScenarios/cmd/help"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)