### PR TITLE
Enable Datadog merge queue

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -2,3 +2,4 @@
 schema-version: v1
 kind: mergequeue
 enable: true
+merge_method: squash


### PR DESCRIPTION
## Summary
- Add `repository.datadog.yml` to enable merge queue for the repository

## Test plan
- [ ] Verify merge queue is activated after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)