### PR TITLE
Rename --allowed-path flag to --allowed-paths

### DIFF
--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -104,7 +104,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	cmd.Flags().StringVarP(&command, "command", "c", "", "shell command string to execute")
 	cmd.Flags().MarkHidden("command") //nolint:errcheck // flag is guaranteed to exist
-	cmd.Flags().StringVarP(&allowedPaths, "allowed-path", "p", "", "comma-separated list of directories the shell is allowed to access")
+	cmd.Flags().StringVarP(&allowedPaths, "allowed-paths", "p", "", "comma-separated list of directories the shell is allowed to access")
 	cmd.Flags().StringVar(&allowedCommands, "allowed-commands", "", "comma-separated list of namespaced commands (e.g. rshell:cat,rshell:find)")
 	cmd.Flags().BoolVar(&allowAllCmds, "allow-all-commands", false, "allow execution of all commands (builtins and external)")
 

--- a/cmd/rshell/main_test.go
+++ b/cmd/rshell/main_test.go
@@ -118,7 +118,7 @@ func TestAllowedPathCommaSeparated(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		extraDir = filepath.ToSlash(extraDir)
 	}
-	code, stdout, _ := runCLI(t, "--allow-all-commands", "-c", `cat `+filePath, "--allowed-path", dir+","+extraDir)
+	code, stdout, _ := runCLI(t, "--allow-all-commands", "-c", `cat `+filePath, "--allowed-paths", dir+","+extraDir)
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout, "hello from testfile")
 }
@@ -138,7 +138,7 @@ func TestVariableExpansion(t *testing.T) {
 func TestHelp(t *testing.T) {
 	code, stdout, _ := runCLI(t, "--help")
 	assert.Equal(t, 0, code)
-	assert.Contains(t, stdout, "--allowed-path")
+	assert.Contains(t, stdout, "--allowed-paths")
 	assert.Contains(t, stdout, "--allowed-commands")
 	assert.Contains(t, stdout, "--allow-all-commands")
 	assert.NotContains(t, stdout, "--command", "-c/--command should be hidden from help")


### PR DESCRIPTION
## Summary
- Rename the `--allowed-path` CLI flag to `--allowed-paths` for consistency with `--allowed-commands` and because the flag accepts a comma-separated list of directories
- Update corresponding tests to use the new flag name

## Test plan
- [x] `go build ./cmd/rshell` succeeds
- [x] `TestAllowedPathGrantsAccess`, `TestAllowedPathCommaSeparated`, `TestHelp`, `TestFileArgWithAllowedPath` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)