### PR TITLE
Support files in AllowedPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Every access path is default-deny:
 |----------------------|-------------------------------------|----------------------------------------------|
 | Command execution    | All commands blocked (exit code 127)| `AllowedCommands` with namespaced command list (e.g. `rshell:cat`), or `AllowAllCommands` |
 | External commands    | Blocked (exit code 127)             | Provide an `ExecHandler`                     |
-| Filesystem access    | Blocked                             | Configure `AllowedPaths` with directory list |
+| Filesystem access    | Blocked                             | Configure `AllowedPaths` with directory or file list |
 | Environment variables| Empty (no host env inherited)       | Pass variables via the `Env` option          |
 | Output redirections  | Only `/dev/null` allowed (exit code 2 for other targets) | `>/dev/null`, `2>/dev/null`, `&>/dev/null`, `2>&1` |
 
 **AllowedCommands** restricts which commands (builtins or external) the interpreter may execute. Commands must be specified with the `rshell:` namespace prefix (e.g. `rshell:cat`, `rshell:echo`). If not set, no commands are allowed. Use `AllowAllCommands` to permit all commands (useful for testing).
 
-**AllowedPaths** restricts all file operations to specified directories using Go's `os.Root` API (`openat` syscalls), making it immune to symlink traversal, TOCTOU races, and `..` escape attacks.
+**AllowedPaths** restricts all file operations to specified directories or individual files using Go's `os.Root` API (`openat` syscalls), making it immune to symlink traversal, TOCTOU races, and `..` escape attacks. Directory entries grant access to all files within; file entries grant access to that single file only.
 
 **ProcPath** (Linux-only) overrides the proc filesystem root used by the `ps` builtin (default `/proc`). This is a privileged option set at runner construction time by trusted caller code — scripts cannot influence it. Access to the proc path is intentionally not subject to `AllowedPaths` restrictions, since proc is a read-only virtual filesystem that does not expose host data under the normal file hierarchy.
 

--- a/SHELL_FEATURES.md
+++ b/SHELL_FEATURES.md
@@ -97,7 +97,7 @@ Blocked features are rejected before execution with exit code 2.
 
 - ✅ AllowedCommands — restricts which commands (builtins or external) may be executed; commands require the `rshell:` namespace prefix (e.g. `rshell:cat`); if not set, no commands are allowed
 - ✅ AllowAllCommands — permits any command (testing convenience)
-- ✅ AllowedPaths filesystem sandboxing — restricts all file access to specified directories
+- ✅ AllowedPaths filesystem sandboxing — restricts all file access to specified directories or individual files
 - ✅ ProcPath — overrides the proc filesystem path used by `ps` (default `/proc`; Linux-only; useful for testing/container environments)
 - ❌ External commands — blocked by default; requires an ExecHandler to be configured and the binary to be within AllowedPaths
 - ❌ Background execution: `cmd &`

--- a/allowedpaths/sandbox.go
+++ b/allowedpaths/sandbox.go
@@ -24,9 +24,12 @@ import (
 const MaxGlobEntries = 100_000
 
 // root pairs an absolute directory path with its opened os.Root handle.
+// When file is non-empty, only the named file within the root is accessible
+// (the parent directory itself is not exposed for listing or traversal).
 type root struct {
 	absPath string
 	root    *os.Root
+	file    string
 }
 
 // Sandbox restricts filesystem access to a set of allowed directories.
@@ -38,26 +41,38 @@ type Sandbox struct {
 
 // New validates paths and eagerly opens os.Root handles so the
 // allowed directories are pinned before the caller can modify them between
-// construction and the first run.
+// construction and the first run. Each path may be a directory (granting
+// access to all files within) or a regular file (granting access to that
+// single file only).
 func New(paths []string) (*Sandbox, error) {
 	roots := make([]root, len(paths))
+	cleanup := func(upTo int) {
+		for _, prev := range roots[:upTo] {
+			if prev.root != nil {
+				prev.root.Close()
+			}
+		}
+	}
 	for i, p := range paths {
 		abs, err := filepath.Abs(p)
 		if err != nil {
+			cleanup(i)
 			return nil, fmt.Errorf("AllowedPaths: cannot resolve %q: %w", p, err)
 		}
 		r, err := os.OpenRoot(abs)
 		if err != nil {
-			for _, prev := range roots[:i] {
-				if prev.root != nil {
-					prev.root.Close()
-				}
-			}
-
 			info, statErr := os.Stat(abs)
 			if statErr == nil && !info.IsDir() {
-				return nil, fmt.Errorf("AllowedPaths: %q is not a directory", abs)
+				parentDir := filepath.Dir(abs)
+				r, err = os.OpenRoot(parentDir)
+				if err != nil {
+					cleanup(i)
+					return nil, fmt.Errorf("AllowedPaths: cannot open root for file %q: %w", abs, err)
+				}
+				roots[i] = root{absPath: parentDir, root: r, file: filepath.Base(abs)}
+				continue
 			}
+			cleanup(i)
 			return nil, fmt.Errorf("AllowedPaths: cannot open root %q: %w", abs, err)
 		}
 		roots[i] = root{absPath: abs, root: r}
@@ -66,7 +81,8 @@ func New(paths []string) (*Sandbox, error) {
 }
 
 // resolve returns the matching os.Root and the path relative to it for the
-// given absolute path. It returns false if no root matches.
+// given absolute path. It returns false if no root matches. For file-only
+// entries, only the exact file path matches.
 func (s *Sandbox) resolve(absPath string) (*os.Root, string, bool) {
 	if s == nil {
 		return nil, "", false
@@ -77,6 +93,9 @@ func (s *Sandbox) resolve(absPath string) (*os.Root, string, bool) {
 			continue
 		}
 		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if ar.file != "" && rel != ar.file {
 			continue
 		}
 		return ar.root, rel, true
@@ -111,6 +130,9 @@ func (s *Sandbox) Access(path string, cwd string, mode uint32) error {
 			continue
 		}
 		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if ar.file != "" && rel != ar.file {
 			continue
 		}
 

--- a/allowedpaths/sandbox_test.go
+++ b/allowedpaths/sandbox_test.go
@@ -38,6 +38,110 @@ func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (f fakeFileInfo) IsDir() bool        { return false }
 func (f fakeFileInfo) Sys() any           { return nil }
 
+func TestNewAcceptsFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "allowed.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("ok"), 0644))
+
+	sb, err := New([]string{filePath})
+	require.NoError(t, err)
+	defer sb.Close()
+}
+
+func TestFileEntryOpenAllowed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "allowed.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello\n"), 0644))
+
+	sb, err := New([]string{filePath})
+	require.NoError(t, err)
+	defer sb.Close()
+
+	f, err := sb.Open(filePath, dir, os.O_RDONLY, 0)
+	require.NoError(t, err)
+	data, _ := io.ReadAll(f)
+	f.Close()
+	assert.Equal(t, "hello\n", string(data))
+}
+
+func TestFileEntrySiblingBlocked(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "allowed.txt"), []byte("ok"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("secret"), 0644))
+
+	sb, err := New([]string{filepath.Join(dir, "allowed.txt")})
+	require.NoError(t, err)
+	defer sb.Close()
+
+	_, err = sb.Open(filepath.Join(dir, "secret.txt"), dir, os.O_RDONLY, 0)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
+func TestFileEntryParentDirBlocked(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "allowed.txt"), []byte("ok"), 0644))
+
+	sb, err := New([]string{filepath.Join(dir, "allowed.txt")})
+	require.NoError(t, err)
+	defer sb.Close()
+
+	_, err = sb.ReadDir(".", dir)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
+func TestFileEntryStatAllowed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "allowed.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("ok"), 0644))
+
+	sb, err := New([]string{filePath})
+	require.NoError(t, err)
+	defer sb.Close()
+
+	info, err := sb.Stat(filePath, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "allowed.txt", info.Name())
+}
+
+func TestFileEntryStatSiblingBlocked(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "allowed.txt"), []byte("ok"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("secret"), 0644))
+
+	sb, err := New([]string{filepath.Join(dir, "allowed.txt")})
+	require.NoError(t, err)
+	defer sb.Close()
+
+	_, err = sb.Stat(filepath.Join(dir, "secret.txt"), dir)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
+func TestFileEntryMixedWithDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("file"), 0644))
+	subdir := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(subdir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "inner.txt"), []byte("inner"), 0644))
+
+	sb, err := New([]string{filepath.Join(dir, "file.txt"), subdir})
+	require.NoError(t, err)
+	defer sb.Close()
+
+	// File entry works.
+	f, err := sb.Open(filepath.Join(dir, "file.txt"), dir, os.O_RDONLY, 0)
+	require.NoError(t, err)
+	f.Close()
+
+	// Directory entry works.
+	f, err = sb.Open(filepath.Join(subdir, "inner.txt"), subdir, os.O_RDONLY, 0)
+	require.NoError(t, err)
+	f.Close()
+
+	// Sibling of file entry is blocked.
+	_, err = sb.Open(filepath.Join(dir, "other.txt"), dir, os.O_RDONLY, 0)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}
+
 func TestSandboxOpenRejectsWriteFlags(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("data"), 0644))

--- a/allowedsymbols/symbols_allowedpaths.go
+++ b/allowedsymbols/symbols_allowedpaths.go
@@ -42,6 +42,8 @@ var allowedpathsAllowedSymbols = []string{
 	"os.Root",                            // 🟠 sandboxed directory root type; core of the filesystem sandbox.
 	"os.Stat",                            // 🟠 returns file info for a path; needed for sandbox path validation.
 	"path/filepath.Abs",                  // 🟢 returns absolute path; pure path computation.
+	"path/filepath.Base",                 // 🟢 returns the last element of a path; pure function, no I/O.
+	"path/filepath.Dir",                  // 🟢 returns the directory portion of a path; pure function, no I/O.
 	"path/filepath.IsAbs",                // 🟢 checks if path is absolute; pure function, no I/O.
 	"path/filepath.Join",                 // 🟢 joins path elements; pure function, no I/O.
 	"path/filepath.Rel",                  // 🟢 returns relative path; pure path computation.

--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -106,7 +106,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	cmd.Flags().StringVarP(&command, "command", "c", "", "shell command string to execute")
 	cmd.Flags().MarkHidden("command") //nolint:errcheck // flag is guaranteed to exist
-	cmd.Flags().StringVarP(&allowedPaths, "allowed-paths", "p", "", "comma-separated list of directories the shell is allowed to access")
+	cmd.Flags().StringVarP(&allowedPaths, "allowed-paths", "p", "", "comma-separated list of directories or files the shell is allowed to access")
 	cmd.Flags().StringVar(&allowedCommands, "allowed-commands", "", "comma-separated list of namespaced commands (e.g. rshell:cat,rshell:find)")
 	cmd.Flags().BoolVar(&allowAllCmds, "allow-all-commands", false, "allow execution of all commands (builtins and external)")
 	cmd.Flags().StringVar(&procPath, "proc-path", "", "path to the proc filesystem used by ps (default \"/proc\")")

--- a/interp/allowed_paths_test.go
+++ b/interp/allowed_paths_test.go
@@ -64,15 +64,15 @@ func TestAllowedPathsOption(t *testing.T) {
 		assert.Contains(t, err.Error(), "AllowedPaths")
 	})
 
-	t.Run("file not directory rejected", func(t *testing.T) {
+	t.Run("file accepted", func(t *testing.T) {
 		tmpFile := filepath.Join(t.TempDir(), "file.txt")
 		require.NoError(t, os.WriteFile(tmpFile, []byte("test"), 0644))
 
-		_, err := interp.New(
+		runner, err := interp.New(
 			interp.AllowedPaths([]string{tmpFile}),
 		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not a directory")
+		require.NoError(t, err)
+		runner.Close()
 	})
 
 	t.Run("valid directory accepted", func(t *testing.T) {
@@ -253,4 +253,45 @@ func TestAllowedPathsClose(t *testing.T) {
 	// Close should not panic, even if called twice
 	require.NoError(t, runner.Close())
 	require.NoError(t, runner.Close())
+}
+
+func TestAllowedPathsFileCatAllowed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "hello.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, "cat "+filePath, dir,
+		interp.AllowedPaths([]string{filePath}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "hello\n", stdout)
+}
+
+func TestAllowedPathsFileSiblingBlocked(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "allowed.txt"), []byte("ok"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("secret"), 0644))
+
+	secretPath := strings.ReplaceAll(filepath.Join(dir, "secret.txt"), `\`, `/`)
+	_, stderr, exitCode := runScript(t, "cat "+secretPath, dir,
+		interp.AllowedPaths([]string{filepath.Join(dir, "allowed.txt")}),
+	)
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "permission denied")
+}
+
+func TestAllowedPathsFileMixedWithDir(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "single.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("single\n"), 0644))
+
+	subdir := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(subdir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "inner.txt"), []byte("inner\n"), 0644))
+
+	stdout, _, exitCode := runScript(t, "cat "+filePath+" "+filepath.Join(subdir, "inner.txt"), dir,
+		interp.AllowedPaths([]string{filePath, subdir}),
+	)
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "single\ninner\n", stdout)
 }

--- a/interp/api.go
+++ b/interp/api.go
@@ -418,9 +418,11 @@ func (r *Runner) Close() error {
 	return r.sandbox.Close()
 }
 
-// AllowedPaths restricts file and directory access to the specified directories.
-// Paths must be absolute directories that exist. When set, only files within
-// these directories can be opened, read, or executed.
+// AllowedPaths restricts file and directory access to the specified paths.
+// Each path may be a directory (granting access to all files within) or a
+// regular file (granting access to that single file only).
+// Paths must exist. When set, only files within these paths can be opened,
+// read, or stat-ed.
 //
 // When not set (default), all file access is blocked.
 // An empty slice also blocks all file access.

--- a/tests/scenarios/shell/allowed_paths/file_entry_cat_allowed.yaml
+++ b/tests/scenarios/shell/allowed_paths/file_entry_cat_allowed.yaml
@@ -1,0 +1,14 @@
+description: Cat can read a file specified directly in allowed_paths
+skip_assert_against_bash: true  # allowed_paths is an rshell-specific feature
+setup:
+  files:
+    - path: data.txt
+      content: "hello\n"
+input:
+  allowed_paths: ["data.txt"]
+  script: |+
+    cat data.txt
+expect:
+  stdout: "hello\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/file_entry_mixed_with_dir.yaml
+++ b/tests/scenarios/shell/allowed_paths/file_entry_mixed_with_dir.yaml
@@ -1,0 +1,17 @@
+description: File and directory entries can be mixed in allowed_paths
+skip_assert_against_bash: true  # allowed_paths is an rshell-specific feature
+setup:
+  files:
+    - path: single.txt
+      content: "single\n"
+    - path: dir/inner.txt
+      content: "inner\n"
+input:
+  allowed_paths: ["single.txt", "dir"]
+  script: |+
+    cat single.txt
+    cat dir/inner.txt
+expect:
+  stdout: "single\ninner\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/file_entry_sibling_blocked.yaml
+++ b/tests/scenarios/shell/allowed_paths/file_entry_sibling_blocked.yaml
@@ -1,0 +1,16 @@
+description: Sibling of a file-level allowed path is blocked
+skip_assert_against_bash: true  # allowed_paths is an rshell-specific feature
+setup:
+  files:
+    - path: allowed.txt
+      content: "ok\n"
+    - path: secret.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed.txt"]
+  script: |+
+    cat secret.txt
+expect:
+  stdout: ""
+  stderr_contains: ["permission denied"]
+  exit_code: 1


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ca7b099e-5c84-4e4f-95b9-70020c3fd0a4","source":"chat","resourceId":"0e2ed55e-8cd0-403c-b128-e5eeee159067","workflowId":"66f13013-584b-403f-8332-3edc928b2202","codeChangeId":"66f13013-584b-403f-8332-3edc928b2202","sourceType":"chat"} -->
### What does this PR do?

Extends `AllowedPaths` to accept individual file paths in addition to directories. When a file is specified, only that exact file is accessible — siblings, parent directory listing, and glob expansion in the parent are all blocked.

### Motivation

Previously, `AllowedPaths` only accepted directories. This made it impossible to grant access to a single file without exposing all other files in the same directory. File-level entries enable least-privilege filesystem access.

### Changes

- `allowedpaths/sandbox.go`: Added `file` field to the `root` struct. `New()` now detects files, opens `os.Root` on the parent directory, and stores the basename. `resolve()` and `Access()` enforce exact-match for file entries.
- `allowedsymbols/symbols_allowedpaths.go`: Added `filepath.Dir` and `filepath.Base` to the allowed symbols list.
- `interp/api.go`: Updated `AllowedPaths` doc comment.
- `cmd/rshell/main.go`: Updated `--allowed-paths` flag description.
- `interp/allowed_paths_test.go`: Changed "file not directory rejected" test to "file accepted", added `TestAllowedPathsFileCatAllowed`, `TestAllowedPathsFileSiblingBlocked`, `TestAllowedPathsFileMixedWithDir`.
- `allowedpaths/sandbox_test.go`: Added 7 unit tests for file entries (open, sibling blocked, parent dir blocked, stat, stat sibling blocked, mixed).
- `tests/scenarios/shell/allowed_paths/`: Added 3 scenario tests (`file_entry_cat_allowed`, `file_entry_sibling_blocked`, `file_entry_mixed_with_dir`).
- `README.md`, `SHELL_FEATURES.md`: Updated documentation to reflect file support.

### Testing

- All new unit tests pass (`go test ./allowedpaths/ ./interp/`)
- All scenario tests pass (`go test ./tests/ -run TestShellScenarios`)
- Allowed symbols verification passes (`go test ./allowedsymbols/`)
- `make fmt` clean

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0e2ed55e-8cd0-403c-b128-e5eeee159067)

Comment @datadog to request changes