### PR TITLE
fix(ip): fix CI failures in fuzz test and bash comparison tests

### DIFF
--- a/builtins/tests/ip/ip_fuzz_test.go
+++ b/builtins/tests/ip/ip_fuzz_test.go
@@ -154,7 +154,7 @@ func FuzzIPSubcommand(f *testing.F) {
 		if code == -1 {
 			return // shell/parse error before the builtin ran — not our bug
 		}
-		if code != 0 && code != 1 {
+		if code != 0 && code != 1 && code != 255 {
 			t.Errorf("ip %q: unexpected exit code %d", subcmd, code)
 		}
 		if timedOut {

--- a/builtins/tests/ip/testdata/fuzz/FuzzIPSubcommand/ffdc891dc1bd740f
+++ b/builtins/tests/ip/testdata/fuzz/FuzzIPSubcommand/ffdc891dc1bd740f
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("route 0")

--- a/tests/scenarios/cmd/ip/errors/route_unknown_subcmd.yaml
+++ b/tests/scenarios/cmd/ip/errors/route_unknown_subcmd.yaml
@@ -1,5 +1,6 @@
 # ip route <unknown> exits 255 with iproute2-compatible "unknown" message.
 description: ip route with an unknown subcommand exits 255.
+skip_assert_against_bash: true # ip is a rshell builtin; bash does not have it
 input:
   script: |+
     ip route unknowncmd

--- a/tests/scenarios/cmd/ip/route_case_insensitive/get_uppercase.yaml
+++ b/tests/scenarios/cmd/ip/route_case_insensitive/get_uppercase.yaml
@@ -1,6 +1,7 @@
 # ip route GET (uppercase) is rejected — subcommand parsing is case-sensitive,
 # matching real iproute2 behavior.
 description: ip route uppercase subcommand (GET) is rejected (case-sensitive, matches iproute2).
+skip_assert_against_bash: true # ip is a rshell builtin; bash does not have it
 input:
   script: |+
     ip route GET


### PR DESCRIPTION
## Summary

Fixes two CI failures introduced alongside the `ip route show/get` implementation (#135):

- **`Fuzz (ip)` failure**: `FuzzIPSubcommand` incorrectly only allowed exit codes 0 and 1, but `ip route <unknown>` legitimately exits with 255 (matching real iproute2 behavior). Updated the allowed exit codes and added regression corpus entry `ffdc891dc1bd740f` (`route 0`).
- **`Test against Bash (Docker)` failures**: `route_unknown_subcmd` and `get_uppercase` scenarios were missing `skip_assert_against_bash: true`. Since `ip` is a rshell builtin not present in bash, running these against bash returns exit 127 with "ip: command not found" instead of the expected rshell error.

## Test plan

- [ ] `Fuzz (ip)` CI job passes (corpus entry `ffdc891dc1bd740f` now accepted with exit 255)
- [ ] `Test against Bash (Docker)` CI job passes (both ip route error scenarios skip bash assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)