### PR TITLE
fix(help): remove unconditional AllowedCommands bypass for help builtin

### DIFF
--- a/builtins/tests/help/help_pentest_test.go
+++ b/builtins/tests/help/help_pentest_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package help_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+)
+
+// TestHelpBypassAllowedCommandsFileRead verifies the fix for the pentest
+// finding: help must not be usable to read files via $(<file) when all
+// commands are blocked. Previously help was hardcoded to bypass AllowedCommands,
+// making `help "$(<secret.txt)"` a universal file-read gadget. The fix removes
+// that carve-out so help is blocked along with every other command.
+func TestHelpBypassAllowedCommandsFileRead(t *testing.T) {
+	dir := t.TempDir()
+	secretContent := "my-secret-api-key-12345"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte(secretContent+"\n"), 0644))
+
+	// No commands are allowed. help must be blocked, so $(<secret.txt) is
+	// never evaluated as an argument and the file content never leaks.
+	_, stderr, code := runScript(t, `help "$(<secret.txt)"`, dir,
+		interp.AllowedCommands([]string{}),
+		interp.AllowedPaths([]string{dir}),
+	)
+
+	assert.Equal(t, 127, code)
+	assert.Contains(t, stderr, "command not allowed")
+	assert.NotContains(t, stderr, secretContent,
+		"file content must not leak via help error message when all commands are blocked")
+}
+
+// TestHelpBypassAllowedCommandsEnvVar verifies the fix for the pentest
+// finding: help must not be usable to exfiltrate env vars when all commands
+// are blocked. Previously `help $MY_SECRET` would leak the value through
+// help's error message.
+func TestHelpBypassAllowedCommandsEnvVar(t *testing.T) {
+	secretValue := "TOP_SECRET_VALUE"
+
+	_, stderr, code := runScript(t, `help $MY_SECRET`, "",
+		interp.AllowedCommands([]string{}),
+		interp.Env("MY_SECRET="+secretValue),
+	)
+
+	assert.Equal(t, 127, code)
+	assert.Contains(t, stderr, "command not allowed")
+	assert.NotContains(t, stderr, secretValue,
+		"env var value must not leak via help error message when all commands are blocked")
+}

--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -167,20 +167,20 @@ func TestHelpColumnsAligned(t *testing.T) {
 
 func TestHelpRestrictedShowsOnlyAllowed(t *testing.T) {
 	stdout, stderr, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"rshell:echo"}))
+		interp.AllowedCommands([]string{"rshell:echo", "rshell:help"}))
 	assert.Equal(t, 0, code)
 	assert.Empty(t, stderr)
 	assert.Contains(t, stdout, "echo")
-	assert.Contains(t, stdout, "help") // help is always listed
+	assert.Contains(t, stdout, "help")
 	assert.NotContains(t, stdout, "cat")
 	assert.NotContains(t, stdout, "grep")
 	assert.NotContains(t, stdout, "ls")
 }
 
 func TestHelpRestrictedSingleCommand(t *testing.T) {
-	// Only "ls" is explicitly allowed; help should still appear.
+	// Both "ls" and "help" are explicitly allowed.
 	stdout, _, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"rshell:ls"}))
+		interp.AllowedCommands([]string{"rshell:ls", "rshell:help"}))
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout, "help")
 	assert.Contains(t, stdout, "ls")
@@ -188,10 +188,10 @@ func TestHelpRestrictedSingleCommand(t *testing.T) {
 }
 
 func TestHelpRestrictedAlignmentAdjusts(t *testing.T) {
-	// With "wc" (2-char) and "strings" (7-char) plus implicit "help" (4-char),
+	// With "wc" (2-char), "strings" (7-char), and "help" (4-char),
 	// the column width should match the longest allowed name.
 	stdout, _, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"rshell:wc", "rshell:strings"}))
+		interp.AllowedCommands([]string{"rshell:wc", "rshell:strings", "rshell:help"}))
 	assert.Equal(t, 0, code)
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
@@ -210,10 +210,11 @@ func TestHelpRestrictedAlignmentAdjusts(t *testing.T) {
 	}
 }
 
-func TestHelpAlwaysAvailable(t *testing.T) {
-	// help is not in the allowed list, but should still run.
+func TestHelpRequiresExplicitAllowedCommand(t *testing.T) {
+	// help must be explicitly listed in AllowedCommands; it is no longer
+	// unconditionally available.
 	stdout, stderr, code := runScript(t, "help", "",
-		interp.AllowedCommands([]string{"rshell:echo", "rshell:ls"}))
+		interp.AllowedCommands([]string{"rshell:echo", "rshell:ls", "rshell:help"}))
 	assert.Equal(t, 0, code)
 	assert.Empty(t, stderr)
 	assert.Contains(t, stdout, "help")
@@ -222,15 +223,12 @@ func TestHelpAlwaysAvailable(t *testing.T) {
 	assert.NotContains(t, stdout, "cat")
 }
 
-func TestHelpAlwaysAvailableNoCommands(t *testing.T) {
-	// Even with an empty allowed list, help should work.
-	stdout, stderr, code := runScript(t, "help", "",
+func TestHelpBlockedWhenNotInAllowedCommands(t *testing.T) {
+	// When help is not in AllowedCommands it must be rejected like any other command.
+	_, stderr, code := runScript(t, "help", "",
 		interp.AllowedCommands([]string{}))
-	assert.Equal(t, 0, code)
-	assert.Empty(t, stderr)
-	// Only help itself should be listed.
-	assert.Contains(t, stdout, "help")
-	assert.NotContains(t, stdout, "echo")
+	assert.Equal(t, 127, code)
+	assert.Contains(t, stderr, "command not allowed")
 }
 
 // --- Error handling ---

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -256,9 +256,8 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	}
 	name := args[0]
 
-	// Check whether the command is allowed. "help" is always permitted so
-	// users can discover available commands regardless of the active policy.
-	if !r.allowAllCommands && name != "help" && !r.allowedCommands[name] {
+	// Check whether the command is allowed.
+	if !r.allowAllCommands && !r.allowedCommands[name] {
 		r.errf("%s: command not allowed\n", name)
 		r.exit.code = 127
 		return
@@ -267,7 +266,7 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	if fn, ok := builtins.Lookup(name); ok {
 		var runCmd func(context.Context, string, string, []string) (uint8, error)
 		runCmd = func(ctx context.Context, dir string, cmdName string, cmdArgs []string) (uint8, error) {
-			if !r.allowAllCommands && cmdName != "help" && !r.allowedCommands[cmdName] {
+			if !r.allowAllCommands && !r.allowedCommands[cmdName] {
 				return 127, fmt.Errorf("%s: command not allowed", cmdName)
 			}
 			cmdFn, ok := builtins.Lookup(cmdName)
@@ -324,7 +323,7 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 					return builtins.FileID{Dev: dev, Ino: ino}, true
 				},
 				CommandAllowed: func(n string) bool {
-					return r.allowAllCommands || n == "help" || r.allowedCommands[n]
+					return r.allowAllCommands || r.allowedCommands[n]
 				},
 			}
 			if r.stdin != nil {
@@ -386,7 +385,7 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 				return builtins.FileID{Dev: dev, Ino: ino}, true
 			},
 			CommandAllowed: func(cmdName string) bool {
-				return r.allowAllCommands || cmdName == "help" || r.allowedCommands[cmdName]
+				return r.allowAllCommands || r.allowedCommands[cmdName]
 			},
 			RunCommand: runCmd,
 			Proc:       r.proc,


### PR DESCRIPTION
## Summary

- Pentest finding: `help` was hardcoded to bypass `AllowedCommands` in `runner_exec.go` (three `name != "help"` / `n == "help"` carve-outs), making it a universal exfiltration gadget — `help "$(<secret.txt)"` read files and `help $VAR` leaked env vars even with an empty allowed-command list.
- Fix: removed all three carve-outs so `help` is subject to `AllowedCommands` like every other builtin. Operators must now explicitly include `rshell:help` to make it available.
- Tests: existing tests updated to include `rshell:help`; two "always available" tests rewritten to assert the corrected (blocked) behaviour; new `help_pentest_test.go` added with proof-of-concept tests for both attack vectors.

## Test plan

- [ ] `go test ./builtins/tests/help/ ./interp/...` passes locally
- [ ] `TestHelpBypassAllowedCommandsFileRead` — asserts `help "$(<secret.txt)"` is blocked (exit 127) when no commands are allowed
- [ ] `TestHelpBypassAllowedCommandsEnvVar` — asserts `help $MY_SECRET` is blocked (exit 127) when no commands are allowed
- [ ] `TestHelpBlockedWhenNotInAllowedCommands` — asserts `help` returns 127 + "command not allowed" when not in AllowedCommands
- [ ] `TestHelpRequiresExplicitAllowedCommand` — asserts `help` works normally when `rshell:help` is explicitly allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)