### PR TITLE
feat(interp): improve error messages for blocked and unknown commands

### DIFF
--- a/interp/allowed_paths_internal_test.go
+++ b/interp/allowed_paths_internal_test.go
@@ -84,7 +84,7 @@ func TestAllowedPathsExecBlocked(t *testing.T) {
 		AllowedPaths(append([]string{dir}, systemExecAllowedPaths(t)...)),
 	)
 	assert.Equal(t, 127, exitCode)
-	assert.Contains(t, stderr, "command not found")
+	assert.Contains(t, stderr, "unknown command")
 }
 
 func TestAllowedPathsExecNonexistent(t *testing.T) {
@@ -93,7 +93,7 @@ func TestAllowedPathsExecNonexistent(t *testing.T) {
 		AllowedPaths(append([]string{dir}, systemExecAllowedPaths(t)...)),
 	)
 	assert.Equal(t, 127, exitCode)
-	assert.Contains(t, stderr, "command not found")
+	assert.Contains(t, stderr, "unknown command")
 }
 
 func TestAllowedPathsExecViaPathLookup(t *testing.T) {
@@ -146,7 +146,7 @@ func TestAllowedPathsExecSymlinkEscape(t *testing.T) {
 		AllowedPaths([]string{dir}),
 	)
 	assert.Equal(t, 127, exitCode)
-	assert.Contains(t, stderr, "command not found")
+	assert.Contains(t, stderr, "unknown command")
 }
 
 func TestRunRecoversPanic(t *testing.T) {
@@ -195,10 +195,10 @@ func TestAllowedPathsExecDefaultBlocksAll(t *testing.T) {
 	dir := t.TempDir()
 	// No AllowedPaths option — default noExecHandler blocks all external commands.
 	// With AllowAllCommands (set by runScriptInternal), the command reaches the
-	// exec handler which returns "command not found" via noExecHandler.
+	// exec handler which returns "unknown command" via noExecHandler.
 	_, stderr, exitCode := runScriptInternal(t, `/bin/echo hello`, dir)
 	assert.Equal(t, 127, exitCode)
-	assert.Contains(t, stderr, "command not found")
+	assert.Contains(t, stderr, "unknown command")
 }
 
 // TestHostPrefixAfterAllowedPaths verifies that HostPrefix applied after

--- a/interp/api.go
+++ b/interp/api.go
@@ -403,10 +403,10 @@ func (r *Runner) Reset() {
 			r.readDirHandler = func(ctx context.Context, path string) ([]os.DirEntry, error) {
 				return r.sandbox.ReadDirForGlob(path, HandlerCtx(ctx).Dir)
 			}
-			r.execHandler = noExecHandler()
+			r.execHandler = noExecHandler(r.allowAllCommands || r.allowedCommands["help"])
 		}
 		if r.execHandler == nil {
-			r.execHandler = noExecHandler()
+			r.execHandler = noExecHandler(r.allowAllCommands || r.allowedCommands["help"])
 		}
 	}
 	// Reset only the mutable state; config is preserved.

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -86,15 +86,19 @@ type ReadDirHandlerFunc func(ctx context.Context, path string) ([]fs.DirEntry, e
 type ExecHandlerFunc func(ctx context.Context, args []string) error
 
 // noExecHandler returns an [ExecHandlerFunc] that rejects all commands.
-// It prints "<cmd>: command not found" to stderr and returns exit code 127,
-// without ever searching PATH or executing host binaries.
-func noExecHandler() ExecHandlerFunc {
+// It prints "rshell: <cmd>: unknown command" to stderr and returns exit
+// code 127, without ever searching PATH or executing host binaries.
+// When helpAvailable is true, a hint directing the user to 'help' is appended.
+func noExecHandler(helpAvailable bool) ExecHandlerFunc {
 	return func(ctx context.Context, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("exec handler called with no arguments")
 		}
 		hc := HandlerCtx(ctx)
-		fmt.Fprintf(hc.Stderr, "%s: command not found\n", args[0])
+		fmt.Fprintf(hc.Stderr, "rshell: %s: unknown command\n", args[0])
+		if helpAvailable {
+			fmt.Fprintf(hc.Stderr, "Run 'help' to see available commands.\n")
+		}
 		return ExitStatus(127)
 	}
 }

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -257,7 +257,10 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	name := args[0]
 
 	if !r.allowAllCommands && !r.allowedCommands[name] {
-		r.errf("%s: command not allowed\n", name)
+		r.errf("rshell: %s: command not allowed\n", name)
+		if r.allowedCommands["help"] {
+			r.errf("Run 'help' to see allowed commands.\n")
+		}
 		r.exit.code = 127
 		return
 	}
@@ -266,11 +269,11 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 		var runCmd func(context.Context, string, string, []string) (uint8, error)
 		runCmd = func(ctx context.Context, dir string, cmdName string, cmdArgs []string) (uint8, error) {
 			if !r.allowAllCommands && !r.allowedCommands[cmdName] {
-				return 127, fmt.Errorf("%s: command not allowed", cmdName)
+				return 127, fmt.Errorf("rshell: %s: command not allowed", cmdName)
 			}
 			cmdFn, ok := builtins.Lookup(cmdName)
 			if !ok {
-				return 127, fmt.Errorf("%s: command not found", cmdName)
+				return 127, fmt.Errorf("rshell: %s: unknown command", cmdName)
 			}
 			child := &builtins.CallContext{
 				Stdout:     r.stdout,

--- a/tests/scenarios/cmd/unknown_cmd/basic/after_echo.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/after_echo.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: An unknown command after a successful echo still fails.
 input:
   script: |+
@@ -6,5 +8,5 @@ input:
 expect:
   stdout: |+
     hello
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/basic/before_echo.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/before_echo.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: An unknown command before echo on the next line does not stop execution.
 input:
   script: |+
@@ -6,5 +8,5 @@ input:
 expect:
   stdout: |+
     hello
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/basic/multiple_consecutive.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/multiple_consecutive.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Multiple unknown commands on separate lines all execute and report errors.
 input:
   script: |+
@@ -6,5 +8,5 @@ input:
     baz
 expect:
   stdout: ""
-  stderr_contains: ["foo", "bar", "baz", "command not found"]
+  stderr_contains: ["foo", "bar", "baz", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/basic/multiword_name.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/multiword_name.yaml
@@ -1,8 +1,10 @@
-description: An unknown command with a multi-word-like name (with hyphens) prints "command not found".
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: An unknown command with a multi-word-like name (with hyphens) prints "unknown command".
 input:
   script: |+
     my-unknown-command
 expect:
   stdout: ""
-  stderr_contains: ["my-unknown-command", "command not found"]
+  stderr_contains: ["my-unknown-command", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/basic/simple.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/simple.yaml
@@ -1,8 +1,10 @@
-description: A simple unknown command prints "command not found" to stderr.
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: A simple unknown command prints "unknown command" to stderr.
 input:
   script: |+
     foo
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/basic/stderr_separate_from_stdout.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/stderr_separate_from_stdout.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command error goes to stderr while stdout remains clean.
 input:
   script: |+
@@ -10,5 +12,5 @@ expect:
     after
   stderr_contains:
     - "nonexistent_cmd"
-    - "command not found"
+    - "unknown command"
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/basic/underscore_name.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/basic/underscore_name.yaml
@@ -1,8 +1,10 @@
-description: An unknown command with underscores in the name prints "command not found".
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: An unknown command with underscores in the name prints "unknown command".
 input:
   script: |+
     my_unknown_command
 expect:
   stdout: ""
-  stderr_contains: ["my_unknown_command", "command not found"]
+  stderr_contains: ["my_unknown_command", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/bash.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/bash.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    bash: command not found
+    rshell: bash: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/chmod.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/chmod.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    chmod: command not found
+    rshell: chmod: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/cp.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/cp.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    cp: command not found
+    rshell: cp: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/curl.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/curl.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    curl: command not found
+    rshell: curl: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/mv.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/mv.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    mv: command not found
+    rshell: mv: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/python.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/python.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    python: command not found
+    rshell: python: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/rm.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/rm.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    rm: command not found
+    rshell: rm: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/sh.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/sh.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    sh: command not found
+    rshell: sh: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/common_progs/wget.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/common_progs/wget.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    wget: command not found
+    rshell: wget: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/control_flow/or_chain_with_unknown.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/control_flow/or_chain_with_unknown.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command in logical OR chain falls through to the next command.
 input:
   script: |+
@@ -9,5 +11,5 @@ expect:
     0
   stderr_contains:
     - "nonexistent_cmd"
-    - "command not found"
+    - "unknown command"
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/and_operator_skips.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/and_operator_skips.yaml
@@ -1,8 +1,10 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: The && operator skips the next command after an unknown command.
 input:
   script: |+
     foo && echo should_not_run
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/and_or_chain.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/and_or_chain.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Mixed && and || operators work correctly with unknown commands.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     yes
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/exit_code_127.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/exit_code_127.yaml
@@ -1,8 +1,10 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: An unknown command sets exit code 127.
 input:
   script: |+
     nonexistent
 expect:
   stdout: ""
-  stderr_contains: ["nonexistent", "command not found"]
+  stderr_contains: ["nonexistent", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/exit_code_captured.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/exit_code_captured.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: The exit code of an unknown command is captured by $? when using semicolons.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     127
-  stderr_contains: ["nonexistent", "command not found"]
+  stderr_contains: ["nonexistent", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/or_chain.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/or_chain.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: A chain of unknown commands with || reaches the first valid command.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     reached
-  stderr_contains: ["foo", "bar", "command not found"]
+  stderr_contains: ["foo", "bar", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/or_operator_continues.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/or_operator_continues.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: The || operator runs the next command after an unknown command.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     fallback
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/exit_code/semicolon_continues.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/exit_code/semicolon_continues.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: A semicolon separator allows execution to continue after an unknown command.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     after
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/cmd/unknown_cmd/with_args/args.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/with_args/args.yaml
@@ -1,8 +1,10 @@
-description: An unknown command with arguments still prints "command not found" for the command name.
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: An unknown command with arguments still prints "unknown command" for the command name.
 input:
   script: |+
     foo arg1 arg2 arg3
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/with_args/flags.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/with_args/flags.yaml
@@ -1,8 +1,10 @@
-description: An unknown command with flag-like arguments still prints "command not found".
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: An unknown command with flag-like arguments still prints "unknown command".
 input:
   script: |+
     foo --verbose -n 5
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/with_args/quoted_args.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/with_args/quoted_args.yaml
@@ -1,8 +1,10 @@
-description: An unknown command with quoted arguments still prints "command not found".
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: An unknown command with quoted arguments still prints "unknown command".
 input:
   script: |+
     foo "hello world" 'single quoted'
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/cmd/unknown_cmd/with_args/variable_arg.yaml
+++ b/tests/scenarios/cmd/unknown_cmd/with_args/variable_arg.yaml
@@ -1,9 +1,11 @@
-description: An unknown command with a variable-expanded argument still prints "command not found".
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: An unknown command with a variable-expanded argument still prints "unknown command".
 input:
   script: |+
     MY_VAR=hello
     foo $MY_VAR
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/shell/allowed_commands/allowed_after_blocked.yaml
+++ b/tests/scenarios/shell/allowed_commands/allowed_after_blocked.yaml
@@ -10,5 +10,5 @@ expect:
   stdout: |+
     after
   stderr: |+
-    cat: command not allowed
+    rshell: cat: command not allowed
   exit_code: 0

--- a/tests/scenarios/shell/allowed_commands/disallowed_command_blocked.yaml
+++ b/tests/scenarios/shell/allowed_commands/disallowed_command_blocked.yaml
@@ -8,5 +8,5 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    cat: command not allowed
+    rshell: cat: command not allowed
   exit_code: 127

--- a/tests/scenarios/shell/allowed_commands/no_commands_allowed.yaml
+++ b/tests/scenarios/shell/allowed_commands/no_commands_allowed.yaml
@@ -7,5 +7,5 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    echo: command not allowed
+    rshell: echo: command not allowed
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/blocked_eval.yaml
+++ b/tests/scenarios/shell/blocked_commands/blocked_eval.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    eval: command not found
+    rshell: eval: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/alias.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/alias.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    alias: command not found
+    rshell: alias: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/cd.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/cd.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    cd: command not found
+    rshell: cd: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/command.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/command.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    command: command not found
+    rshell: command: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/dot_source.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/dot_source.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    .: command not found
+    rshell: .: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/exec.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/exec.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    exec: command not found
+    rshell: exec: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/getopts.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/getopts.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    getopts: command not found
+    rshell: getopts: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/read.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/read.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    read: command not found
+    rshell: read: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/return.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/return.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    return: command not found
+    rshell: return: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/set.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/set.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    set: command not found
+    rshell: set: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/shift.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/shift.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    shift: command not found
+    rshell: shift: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/trap.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/trap.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    trap: command not found
+    rshell: trap: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/umask.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/umask.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    umask: command not found
+    rshell: umask: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/unset.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/unset.yaml
@@ -8,5 +8,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    unset: command not found
+    rshell: unset: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/blocked_commands/builtins_and_features/wait.yaml
+++ b/tests/scenarios/shell/blocked_commands/builtins_and_features/wait.yaml
@@ -7,5 +7,6 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    wait: command not found
+    rshell: wait: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/cmd_separator/exit_code/unknown_command_continues.yaml
+++ b/tests/scenarios/shell/cmd_separator/exit_code/unknown_command_continues.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: An unknown command does not prevent subsequent commands from running.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     after
-  stderr_contains: ["nonexistent_cmd", "command not found"]
+  stderr_contains: ["nonexistent_cmd", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/shell/errors/command_not_found.yaml
+++ b/tests/scenarios/shell/errors/command_not_found.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command returns exit code 127.
 input:
   script: |+
@@ -6,5 +8,5 @@ expect:
   stdout: ""
   stderr_contains:
     - "no_such_command_xyz"
-    - "command not found"
+    - "unknown command"
   exit_code: 127

--- a/tests/scenarios/shell/errors/command_not_found_exit_code.yaml
+++ b/tests/scenarios/shell/errors/command_not_found_exit_code.yaml
@@ -8,6 +8,8 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    unknown_cmd_1: command not found
-    unknown_cmd_2: command not found
+    rshell: unknown_cmd_1: unknown command
+    Run 'help' to see available commands.
+    rshell: unknown_cmd_2: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/errors/command_not_found_in_if.yaml
+++ b/tests/scenarios/shell/errors/command_not_found_in_if.yaml
@@ -6,5 +6,5 @@ input:
     if notacmd; then echo yes; else echo no; fi
 expect:
   stdout: "no\n"
-  stderr: "notacmd: command not found\n"
+  stderr: "rshell: notacmd: unknown command\nRun 'help' to see available commands.\n"
   exit_code: 0

--- a/tests/scenarios/shell/errors/command_not_found_in_pipeline.yaml
+++ b/tests/scenarios/shell/errors/command_not_found_in_pipeline.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command in a pipeline produces error but pipeline continues.
 input:
   script: |+
@@ -6,5 +8,5 @@ expect:
   stdout: ""
   stderr_contains:
     - "unknown_filter_cmd"
-    - "command not found"
+    - "unknown command"
   exit_code: 127

--- a/tests/scenarios/shell/errors/error_exit_code_propagation.yaml
+++ b/tests/scenarios/shell/errors/error_exit_code_propagation.yaml
@@ -9,5 +9,6 @@ expect:
   stdout: |+
     127
   stderr: |+
-    nonexistent_cmd_xyz: command not found
+    rshell: nonexistent_cmd_xyz: unknown command
+    Run 'help' to see available commands.
   exit_code: 0

--- a/tests/scenarios/shell/errors/multiple_command_not_found.yaml
+++ b/tests/scenarios/shell/errors/multiple_command_not_found.yaml
@@ -9,7 +9,10 @@ input:
 expect:
   stdout: ""
   stderr: |+
-    notacmd1: command not found
-    notacmd2: command not found
-    notacmd3: command not found
+    rshell: notacmd1: unknown command
+    Run 'help' to see available commands.
+    rshell: notacmd2: unknown command
+    Run 'help' to see available commands.
+    rshell: notacmd3: unknown command
+    Run 'help' to see available commands.
   exit_code: 127

--- a/tests/scenarios/shell/errors/syntax_error_kills_shell.yaml
+++ b/tests/scenarios/shell/errors/syntax_error_kills_shell.yaml
@@ -11,5 +11,6 @@ expect:
     before
     after
   stderr: |+
-    no_such_cmd_abc: command not found
+    rshell: no_such_cmd_abc: unknown command
+    Run 'help' to see available commands.
   exit_code: 0

--- a/tests/scenarios/shell/errors/valid_after_error.yaml
+++ b/tests/scenarios/shell/errors/valid_after_error.yaml
@@ -11,5 +11,6 @@ expect:
     first
     third
   stderr: |+
-    nonexistent_cmd: command not found
+    rshell: nonexistent_cmd: unknown command
+    Run 'help' to see available commands.
   exit_code: 0

--- a/tests/scenarios/shell/for_clause/exit_code/unknown_cmd_in_body.yaml
+++ b/tests/scenarios/shell/for_clause/exit_code/unknown_cmd_in_body.yaml
@@ -1,8 +1,10 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command in for loop body produces error on stderr.
 input:
   script: |+
     for i in a; do nonexistent_cmd; done
 expect:
   stdout: ""
-  stderr_contains: ["nonexistent_cmd", "command not found"]
+  stderr_contains: ["nonexistent_cmd", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/shell/negation/basic/negate_unknown_cmd.yaml
+++ b/tests/scenarios/shell/negation/basic/negate_unknown_cmd.yaml
@@ -1,9 +1,11 @@
-description: Negating a command-not-found (exit 127) produces exit code 0.
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: Negating an unknown command (exit 127) produces exit code 0.
 input:
   script: |+
     ! nonexistent_command_xyz
 expect:
   stdout: ""
   stderr_contains:
-    - "command not found"
+    - "unknown command"
   exit_code: 0

--- a/tests/scenarios/shell/pipe/errors/left.yaml
+++ b/tests/scenarios/shell/pipe/errors/left.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command on left side of pipe sends error to stderr; right side still runs.
 input:
   script: |+
@@ -5,5 +7,5 @@ input:
 expect:
   stdout: |+
     ok
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 0

--- a/tests/scenarios/shell/pipe/errors/right.yaml
+++ b/tests/scenarios/shell/pipe/errors/right.yaml
@@ -1,8 +1,10 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: Unknown command on right side of pipe sets exit code 127.
 input:
   script: |+
     echo ok | foo
 expect:
   stdout: ""
-  stderr_contains: ["foo", "command not found"]
+  stderr_contains: ["foo", "unknown command"]
   exit_code: 127

--- a/tests/scenarios/shell/simple_command/basic/command_not_found.yaml
+++ b/tests/scenarios/shell/simple_command/basic/command_not_found.yaml
@@ -1,9 +1,11 @@
-description: Unknown command produces not found error.
+# skip: error message format differs from bash
+skip_assert_against_bash: true
+description: Unknown command produces unknown command error.
 input:
   script: |+
     nosuchcommand
 expect:
   stdout: ""
   stderr_contains:
-    - "command not found"
+    - "unknown command"
   exit_code: 127

--- a/tests/scenarios/shell/var_expand/special_variables/status_after_unknown_cmd.yaml
+++ b/tests/scenarios/shell/var_expand/special_variables/status_after_unknown_cmd.yaml
@@ -1,3 +1,5 @@
+# skip: error message format differs from bash
+skip_assert_against_bash: true
 description: The $? variable is 127 after an unknown command.
 input:
   script: |+
@@ -7,5 +9,5 @@ expect:
   stdout: |+
     127
   stderr_contains:
-    - "not found"
+    - "unknown command"
   exit_code: 0


### PR DESCRIPTION
## Summary

- All error messages now prefixed with `rshell:` to clearly identify the source shell (follows the `bash: cmd: error` convention)
- "Command not allowed" (policy block) and "unknown command" (doesn't exist) use **distinct wording** so LLMs and users can immediately tell the difference
- A contextual `Run 'help' to see allowed/available commands.` hint is appended **only when `help` is in the allowed commands list** — avoids suggesting a command that would itself be blocked

## Before / After

### 1. Command not allowed — `help` IS in allowed list

```
./rshell --allowed-commands "rshell:echo,rshell:help,rshell:ls" -c 'cat'
```

**Before:**
```
cat: command not allowed
```

**After:**
```
rshell: cat: command not allowed
Run 'help' to see allowed commands.
```

### 2. Command not allowed — `help` NOT in allowed list

```
./rshell --allowed-commands "rshell:echo,rshell:ls" -c 'cat'
```

**Before:**
```
cat: command not allowed
```

**After:**
```
rshell: cat: command not allowed
```

No hint is shown because `help` itself is not allowed — suggesting it would produce a confusing follow-up error.

### 3. Unknown command — `help` IS in allowed list

```
./rshell --allowed-commands "rshell:echo,rshell:help,rshell:ls" -c 'foo'
```

**Before:**
```
foo: command not allowed
```

**After:**
```
rshell: foo: command not allowed
Run 'help' to see allowed commands.
```

Note: `foo` is not in the allowed list, so the allow check fires before the builtin lookup. The "unknown command" path is only reached when a command passes the allow check but isn't a known builtin (e.g., with `--allow-all-commands`).

### 4. Unknown command — `help` NOT in allowed list

```
./rshell --allowed-commands "rshell:echo,rshell:ls" -c 'foo'
```

**Before:**
```
foo: command not allowed
```

**After:**
```
rshell: foo: command not allowed
```

### 5. Unknown command with `--allow-all-commands` (the "unknown command" path)

```
./rshell --allow-all-commands -c 'foo'
```

**Before:**
```
foo: command not found
```

**After:**
```
rshell: foo: unknown command
Run 'help' to see available commands.
```

## Design decisions

- **`rshell:` prefix** — Follows the `shell: cmd: error` convention used by bash/zsh. Helps LLMs and log parsers identify which shell produced the error.
- **"command not allowed" vs "unknown command"** — Distinct wording prevents confusion between "exists but blocked by policy" and "doesn't exist in this shell at all".
- **Conditional hint** — The `Run 'help' ...` hint only appears when `help` is in the allowed commands set. This avoids a frustrating UX where following the hint produces another error (`rshell: help: command not allowed`). The check uses `r.allowedCommands["help"]` for the "not allowed" path, and a pre-computed `helpAvailable` bool captured at runner creation for the exec handler path.
- **No version in error messages** — `help` output already shows the rshell version (via #181), keeping errors concise.

## Depends on

- #181 (`feat(help): show version, command counts, and allowed/not-allowed builtins`) — The `Run 'help' ...` hint is most useful when `help` shows the version header, allowed/not-allowed builtin lists, and the `--all` flag.

## Test plan

- [x] All 65 modified scenario + Go tests passing (`go test ./...` — 0 failures)
- [x] Manual verification of all 5 cases above
- [x] Conditional hint verified: appears only when `help` is allowed
- [x] `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)