### PR TITLE
fix(cat): suppress broken-pipe error when piped into head

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -7,11 +7,13 @@ package builtins
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"sort"
+	"syscall"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -197,6 +199,14 @@ func (c *CallContext) Outf(format string, a ...any) {
 // Errf writes a formatted string to stderr.
 func (c *CallContext) Errf(format string, a ...any) {
 	fmt.Fprintf(c.Stderr, format, a...)
+}
+
+// IsBrokenPipe reports whether err is a broken-pipe (EPIPE) error,
+// which occurs when writing to a pipe whose read end has been closed.
+// In bash this triggers SIGPIPE which silently terminates the writer;
+// builtins should use this to suppress error messages on pipe closure.
+func IsBrokenPipe(err error) bool {
+	return err != nil && errors.Is(err, syscall.EPIPE)
 }
 
 // FileID is a comparable file identity for cycle detection.

--- a/builtins/cat/cat.go
+++ b/builtins/cat/cat.go
@@ -162,6 +162,9 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 				err = catRaw(ctx, callCtx, file)
 			}
 			if err != nil {
+				if builtins.IsBrokenPipe(err) {
+					break
+				}
 				name := file
 				if file == "-" {
 					name = "standard input"

--- a/tests/scenarios/shell/pipe/basic/cat_head_no_broken_pipe.yaml
+++ b/tests/scenarios/shell/pipe/basic/cat_head_no_broken_pipe.yaml
@@ -1,0 +1,26 @@
+description: cat piped into head must not emit a broken-pipe error on stderr.
+setup:
+  files:
+    - path: big.txt
+      content: |+
+        line 1
+        line 2
+        line 3
+        line 4
+        line 5
+        line 6
+        line 7
+        line 8
+        line 9
+        line 10
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    cat big.txt | head -n 3
+expect:
+  stdout: |+
+    line 1
+    line 2
+    line 3
+  stderr: |+
+  exit_code: 0


### PR DESCRIPTION
## Summary

- Fixes #163 — `cat file | head -n 3` was printing `cat: file: write |1: broken pipe` to stderr
- Adds `builtins.IsBrokenPipe()` helper to detect EPIPE errors (the Go equivalent of SIGPIPE in bash)
- Updates `cat` to silently exit on broken pipe instead of printing an error, matching bash behavior
- Adds a regression test scenario for `cat | head` piping

## Before
```
❯ make build
go build -o rshell ./cmd/rshell

❯ ./rshell --allow-all-commands --allowed-paths /tmp -c 'cat /tmp/rshell_test_bigfile.txt | head -n 3'
line 0: this is a test log line with some content to make it longer
line 1: this is a test log line with some content to make it longer
line 2: this is a test log line with some content to make it longer
cat: /tmp/rshell_test_bigfile.txt: write |1: broken pipe

❯ bash -c 'cat /tmp/rshell_test_bigfile.txt | head -n 3'
line 0: this is a test log line with some content to make it longer
line 1: this is a test log line with some content to make it longer
line 2: this is a test log line with some content to make it longer
```

## After
```
❯ make build
go build -o rshell ./cmd/rshell

❯ ./rshell --allow-all-commands --allowed-paths /tmp -c 'cat /tmp/rshell_test_bigfile.txt | head -n 3'
line 0: this is a test log line with some content to make it longer
line 1: this is a test log line with some content to make it longer
line 2: this is a test log line with some content to make it longer

❯ bash -c 'cat /tmp/rshell_test_bigfile.txt | head -n 3'
line 0: this is a test log line with some content to make it longer
line 1: this is a test log line with some content to make it longer
line 2: this is a test log line with some content to make it longer
```

## Test plan

- [x] `go run cmd/rshell/main.go --allow-all-commands --allowed-paths /tmp -c 'cat bigfile | head -n 3'` — no stderr output
- [x] `cat -n` (line-processing path) also suppresses broken pipe silently
- [x] All existing cat tests pass (`go test ./builtins/cat/`)
- [x] Full test suite passes (`go test ./...`)
- [x] New scenario test `cat_head_no_broken_pipe.yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)