### PR TITLE
fix(interp): cap parse-depth to prevent stack-overflow panic

### DIFF
--- a/cmd/rshell/main_test.go
+++ b/cmd/rshell/main_test.go
@@ -334,7 +334,7 @@ func TestScriptAtMaxScriptBytes(t *testing.T) {
 // error message, rather than allowed to recurse into a stack-overflow panic
 // inside the parser (observed at ~2·10^5 levels).
 func TestScriptExceedsMaxParseDepth(t *testing.T) {
-	const depth = 1500 // safely above MaxParseDepth (1000)
+	depth := interp.MaxParseDepth + 500
 	script := "echo " + strings.Repeat("$(echo ", depth) + "hi" + strings.Repeat(")", depth)
 
 	code, _, stderr := runCLI(t, "--allow-all-commands", "-c", script)

--- a/cmd/rshell/main_test.go
+++ b/cmd/rshell/main_test.go
@@ -328,3 +328,17 @@ func TestScriptAtMaxScriptBytes(t *testing.T) {
 	assert.Equal(t, 0, code)
 	assert.Equal(t, "ok\n", stdout)
 }
+
+// TestScriptExceedsMaxParseDepth verifies that a script whose $(…) nesting
+// exceeds interp.MaxParseDepth is rejected with exit code 2 and a clear
+// error message, rather than allowed to recurse into a stack-overflow panic
+// inside the parser (observed at ~2·10^5 levels).
+func TestScriptExceedsMaxParseDepth(t *testing.T) {
+	const depth = 1500 // safely above MaxParseDepth (1000)
+	script := "echo " + strings.Repeat("$(echo ", depth) + "hi" + strings.Repeat(")", depth)
+
+	code, _, stderr := runCLI(t, "--allow-all-commands", "-c", script)
+	assert.Equal(t, 2, code, "over-nested script should return exit code 2")
+	assert.Contains(t, stderr, "nesting depth")
+	assert.Contains(t, stderr, "exceeds maximum")
+}

--- a/interp/api.go
+++ b/interp/api.go
@@ -615,7 +615,12 @@ const MaxScriptBytes = 5 * 1024 * 1024 // 5 MiB
 // before any context deadline can fire, crashing the host process when rshell
 // is embedded as a library. A script under the 5 MiB byte cap can still reach
 // that depth, so byte-size alone is not a sufficient guard.
-const MaxParseDepth = 1000
+//
+// The limit is deliberately generous (10 000 ≫ any realistic script) so that
+// the coarse pre-check in [scriptNestingDepth] — which doesn't understand
+// quoting and so may over-count literal parens — never rejects a legitimate
+// program.
+const MaxParseDepth = 10000
 
 // ParseScript parses script as a shell program and returns the resulting AST.
 // It enforces [MaxScriptBytes] and [MaxParseDepth] before handing the input to
@@ -640,70 +645,22 @@ func ParseScript(script, name string) (*syntax.File, error) {
 	return syntax.NewParser().Parse(strings.NewReader(script), name)
 }
 
-// scriptNestingDepth returns the maximum simultaneous open-paren /
-// command-substitution depth observed in script, respecting shell quoting:
+// scriptNestingDepth returns the maximum simultaneous open-paren depth
+// observed in script by a byte-wise scan of `(` and `)` with no quoting
+// awareness.
 //
-//   - inside single quotes, all characters are literal;
-//   - inside double quotes, backslash escapes the next byte and only `$(` (not
-//     bare `(`) opens a new substitution;
-//   - unquoted, `\` escapes the next byte and bare `(` (subshells) as well as
-//     `$(` (command substitution) open a new level.
-//
-// Backticks are intentionally not tracked: to nest “ `…` “ in shell syntax
-// each level doubles the required backslash count, so a script reaching
-// parser-harmful backtick depth would already exceed [MaxScriptBytes].
-//
-// Heredoc bodies are treated as ordinary unquoted text; this over-counts when
-// a heredoc body contains literal `(` characters, but the threshold
-// ([MaxParseDepth]) is far above any realistic heredoc content.
+// This is a deliberately coarse upper bound on what the parser will recurse
+// into. It over-counts for literal parens inside single/double quotes,
+// heredoc bodies, `$(( … ))` arithmetic, and `<(…)`/`>(…)` process
+// substitution (the last two are blocked anyway). It never under-counts — any
+// `(` that the parser will recurse on is seen here — which is the property
+// that matters: the check cannot be bypassed by quoting tricks. The
+// [MaxParseDepth] threshold is set high enough that over-counting does not
+// reject realistic scripts.
 func scriptNestingDepth(script string) int {
-	var (
-		maxDepth int
-		depth    int
-		inSQuote bool
-		inDQuote bool
-		escaped  bool
-	)
+	var maxDepth, depth int
 	for i := 0; i < len(script); i++ {
-		c := script[i]
-		if escaped {
-			escaped = false
-			continue
-		}
-		if inSQuote {
-			if c == '\'' {
-				inSQuote = false
-			}
-			continue
-		}
-		if inDQuote {
-			switch c {
-			case '\\':
-				escaped = true
-			case '"':
-				inDQuote = false
-			case '$':
-				if i+1 < len(script) && script[i+1] == '(' {
-					depth++
-					if depth > maxDepth {
-						maxDepth = depth
-					}
-					i++ // consume the '('
-				}
-			case ')':
-				if depth > 0 {
-					depth--
-				}
-			}
-			continue
-		}
-		switch c {
-		case '\\':
-			escaped = true
-		case '\'':
-			inSQuote = true
-		case '"':
-			inDQuote = true
+		switch script[i] {
 		case '(':
 			depth++
 			if depth > maxDepth {

--- a/interp/api.go
+++ b/interp/api.go
@@ -608,21 +608,114 @@ func (r *Runner) Run(ctx context.Context, node syntax.Node) (retErr error) {
 // interpreter only receives the pre-parsed AST.
 const MaxScriptBytes = 5 * 1024 * 1024 // 5 MiB
 
+// MaxParseDepth bounds the maximum parenthesis / command-substitution nesting
+// depth accepted by [ParseScript]. The underlying parser recurses on every
+// `(`, `$(`, and “ ` “; a sufficiently deep chain (observed at ~2·10^5)
+// exhausts the goroutine stack and panics with `runtime: stack overflow`
+// before any context deadline can fire, crashing the host process when rshell
+// is embedded as a library. A script under the 5 MiB byte cap can still reach
+// that depth, so byte-size alone is not a sufficient guard.
+const MaxParseDepth = 1000
+
 // ParseScript parses script as a shell program and returns the resulting AST.
-// It enforces [MaxScriptBytes]: if len(script) exceeds that limit the call
-// returns an error immediately, before the parser allocates any memory.
+// It enforces [MaxScriptBytes] and [MaxParseDepth] before handing the input to
+// the parser, so oversized or pathologically nested scripts are rejected
+// without allocating parser memory or recursing into a stack-overflow.
 //
 // name is an optional filename used in parse-error messages (pass "" if
 // there is no associated file).
 //
 // Library callers should use ParseScript rather than calling the underlying
-// syntax parser directly so that the size limit is consistently enforced.
+// syntax parser directly so that the size and depth limits are consistently
+// enforced.
 func ParseScript(script, name string) (*syntax.File, error) {
 	if len(script) > MaxScriptBytes {
 		return nil, fmt.Errorf("script size %d bytes exceeds maximum of %d bytes (%d MiB); split the script into smaller pieces",
 			len(script), MaxScriptBytes, MaxScriptBytes/(1024*1024))
 	}
+	if depth := scriptNestingDepth(script); depth > MaxParseDepth {
+		return nil, fmt.Errorf("script nesting depth %d exceeds maximum of %d; reduce $(…)/(…) nesting",
+			depth, MaxParseDepth)
+	}
 	return syntax.NewParser().Parse(strings.NewReader(script), name)
+}
+
+// scriptNestingDepth returns the maximum simultaneous open-paren /
+// command-substitution depth observed in script, respecting shell quoting:
+//
+//   - inside single quotes, all characters are literal;
+//   - inside double quotes, backslash escapes the next byte and only `$(` (not
+//     bare `(`) opens a new substitution;
+//   - unquoted, `\` escapes the next byte and bare `(` (subshells) as well as
+//     `$(` (command substitution) open a new level.
+//
+// Backticks are intentionally not tracked: to nest “ `…` “ in shell syntax
+// each level doubles the required backslash count, so a script reaching
+// parser-harmful backtick depth would already exceed [MaxScriptBytes].
+//
+// Heredoc bodies are treated as ordinary unquoted text; this over-counts when
+// a heredoc body contains literal `(` characters, but the threshold
+// ([MaxParseDepth]) is far above any realistic heredoc content.
+func scriptNestingDepth(script string) int {
+	var (
+		maxDepth int
+		depth    int
+		inSQuote bool
+		inDQuote bool
+		escaped  bool
+	)
+	for i := 0; i < len(script); i++ {
+		c := script[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inSQuote {
+			if c == '\'' {
+				inSQuote = false
+			}
+			continue
+		}
+		if inDQuote {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inDQuote = false
+			case '$':
+				if i+1 < len(script) && script[i+1] == '(' {
+					depth++
+					if depth > maxDepth {
+						maxDepth = depth
+					}
+					i++ // consume the '('
+				}
+			case ')':
+				if depth > 0 {
+					depth--
+				}
+			}
+			continue
+		}
+		switch c {
+		case '\\':
+			escaped = true
+		case '\'':
+			inSQuote = true
+		case '"':
+			inDQuote = true
+		case '(':
+			depth++
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return maxDepth
 }
 
 // Close releases resources held by the Runner, such as os.Root file descriptors

--- a/interp/parse_depth_internal_test.go
+++ b/interp/parse_depth_internal_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScriptNestingDepth(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"empty", "", 0},
+		{"no parens", "echo hello", 0},
+		{"single subshell", "(echo hi)", 1},
+		{"single cmd subst", "echo $(echo hi)", 1},
+		{"flat pair of subshells", "(a); (b)", 1},
+		{"nested cmd subst depth 3", "echo $(echo $(echo $(echo hi)))", 3},
+		{"mixed subshell and subst", "( $( ( $(x) ) ) )", 4},
+
+		// Quoting must make parens literal.
+		{"single quoted parens do not count", "echo '((((((('", 0},
+		{"double quoted bare paren does not count", `echo "((((((("`, 0},
+		{"double quoted $( still counts", `echo "$(echo $(x))"`, 2},
+
+		// Backslash escapes the next byte in unquoted/double-quoted context.
+		{"backslash escapes unquoted paren", `\(\(\(`, 0},
+		{"backslash escapes paren in dquote", `"\(\(\("`, 0},
+		{"backslash does not escape in single quote", `'\(\(\('`, 0},
+
+		// Maxima are tracked, not final depth.
+		{"max before close", "(((a))) (b)", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, scriptNestingDepth(tc.input))
+		})
+	}
+}
+
+// TestParseScriptRejectsDeepNesting verifies that ParseScript rejects scripts
+// whose nesting depth exceeds MaxParseDepth, protecting the parser from the
+// `runtime: stack overflow` panic that otherwise occurs at ~2·10^5 levels.
+func TestParseScriptRejectsDeepNesting(t *testing.T) {
+	depth := MaxParseDepth + 500
+	script := "echo " + strings.Repeat("$(echo ", depth) + "hi" + strings.Repeat(")", depth)
+
+	_, err := ParseScript(script, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nesting depth")
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+// TestParseScriptAcceptsDepthAtCap verifies the boundary: a script exactly at
+// MaxParseDepth is accepted.
+func TestParseScriptAcceptsDepthAtCap(t *testing.T) {
+	script := "echo " + strings.Repeat("$(echo ", MaxParseDepth) + "hi" + strings.Repeat(")", MaxParseDepth)
+
+	_, err := ParseScript(script, "")
+	require.NoError(t, err)
+}

--- a/interp/parse_depth_internal_test.go
+++ b/interp/parse_depth_internal_test.go
@@ -27,18 +27,18 @@ func TestScriptNestingDepth(t *testing.T) {
 		{"nested cmd subst depth 3", "echo $(echo $(echo $(echo hi)))", 3},
 		{"mixed subshell and subst", "( $( ( $(x) ) ) )", 4},
 
-		// Quoting must make parens literal.
-		{"single quoted parens do not count", "echo '((((((('", 0},
-		{"double quoted bare paren does not count", `echo "((((((("`, 0},
-		{"double quoted $( still counts", `echo "$(echo $(x))"`, 2},
+		// Unbalanced ')' without matching '(' must not drive depth negative.
+		{"leading close paren ignored", ")))(((", 3},
 
-		// Backslash escapes the next byte in unquoted/double-quoted context.
-		{"backslash escapes unquoted paren", `\(\(\(`, 0},
-		{"backslash escapes paren in dquote", `"\(\(\("`, 0},
-		{"backslash does not escape in single quote", `'\(\(\('`, 0},
-
-		// Maxima are tracked, not final depth.
+		// Max is tracked, not final depth.
 		{"max before close", "(((a))) (b)", 3},
+
+		// Loose scan: literal parens inside quotes are counted. This is an
+		// intentional over-count — safe-by-construction (never under-counts,
+		// so it cannot be bypassed) and harmless in practice because the
+		// threshold sits far above any realistic script.
+		{"single quoted parens count (over-count by design)", "'((('", 3},
+		{"double quoted parens count (over-count by design)", `"((("`, 3},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds a parse-depth pre-check to \`interp.ParseScript\` so that pathologically
nested scripts are rejected with a clear error instead of crashing the host
process with \`runtime: stack overflow\`.

### Motivation

Discovered during the 2026-04-23 bug bash. A script whose \`\$(…)\` / \`(…)\`
nesting reaches ~2·10⁵ levels (well under the 5 MiB \`MaxScriptBytes\` cap
at ~1.6 MiB) exhausts the goroutine stack inside the \`mvdan.cc/sh\` parser
and terminates the host process **before** \`--timeout\` or any context
deadline is consulted. That is a DoS against any caller embedding rshell
as a library.

Repro on \`main\`:

\`\`\`sh
python3 -c "print('echo ' + '\$(echo ' * 200000 + 'hi' + ')' * 200000)" \\
  | rshell --allow-all-commands
# runtime: goroutine stack exceeds 1000000000-byte limit
# fatal error: stack overflow
\`\`\`

### Approach

- New constant \`interp.MaxParseDepth = 10000\`, checked in \`ParseScript\`
  right after the existing \`MaxScriptBytes\` check. 10 000 is 5× below the
  ~60k depth where the parser begins to hang on M1 macOS, but 100× above
  any realistic script.
- New helper \`scriptNestingDepth\` is a deliberately **coarse** byte scan
  that just counts raw \`(\` and \`)\`. It may over-count literal parens
  inside single/double quotes, heredoc bodies, and (blocked) \`<(…)\`/\`>(…)\`
  process substitution. It never under-counts — any \`(\` the parser will
  recurse on is seen here — which is the property that matters, since a
  cleverer quote-aware scanner I first tried could be bypassed by
  \`\$(echo \"x)\" …\$(a)…)))\` patterns where a literal \`)\` inside a double
  quote was incorrectly treated as a subst close.

### Testing

- \`interp.TestScriptNestingDepth\` — table-driven cases including the
  \"literal parens in quotes are counted by design\" property.
- \`interp.TestParseScriptRejectsDeepNesting\` / \`TestParseScriptAcceptsDepthAtCap\`
  — bound the behaviour at \`MaxParseDepth + 500\` and exactly \`MaxParseDepth\`.
- \`cmd/rshell.TestScriptExceedsMaxParseDepth\` — CLI exit 2 + clear stderr
  message above the cap.
- End-to-end re-run of the 200k-level repro now returns exit 2 with the
  \"nesting depth … exceeds maximum\" message instead of panicking.
- \`go test ./...\` green.

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable) — \`MaxParseDepth\` and
      \`scriptNestingDepth\` godocs call out the safe-but-coarse design.