### PR TITLE
feat(interp): default working dir to first allowed path

### DIFF
--- a/cmd/rshell/main_test.go
+++ b/cmd/rshell/main_test.go
@@ -132,6 +132,34 @@ func TestAllowedPathCommaSeparated(t *testing.T) {
 	assert.Contains(t, stdout, "hello from testfile")
 }
 
+// TestDefaultDirIsFirstAllowedPath verifies that when AllowedPaths is set, the
+// shell starts in the first allowed path so relative file access works without
+// the caller having to chdir first.
+func TestDefaultDirIsFirstAllowedPath(t *testing.T) {
+	dir, _ := setupTestFile(t)
+	// "testfile.txt" is a path relative to the working directory. If the
+	// shell defaults to the first allowed path, this resolves to dir/testfile.txt.
+	code, stdout, stderr := runCLI(t, "--allow-all-commands", "-c", `cat testfile.txt`, "-p", dir)
+	assert.Equal(t, 0, code, "stderr: %s", stderr)
+	assert.Contains(t, stdout, "hello from testfile")
+}
+
+// TestDefaultDirPicksFirstOfMany verifies that the shell starts in the *first*
+// allowed path when several are configured, not a later one.
+func TestDefaultDirPicksFirstOfMany(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(first, "marker.txt"), []byte("first"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(second, "marker.txt"), []byte("second"), 0o644))
+	if runtime.GOOS == "windows" {
+		first = filepath.ToSlash(first)
+		second = filepath.ToSlash(second)
+	}
+	code, stdout, stderr := runCLI(t, "--allow-all-commands", "-c", `cat marker.txt`, "-p", first+","+second)
+	assert.Equal(t, 0, code, "stderr: %s", stderr)
+	assert.Equal(t, "first", stdout, "should read marker.txt from the first allowed path")
+}
+
 func TestMultipleStatements(t *testing.T) {
 	code, stdout, _ := runCLI(t, "--allow-all-commands", "-c", "echo first\necho second")
 	assert.Equal(t, 0, code)

--- a/interp/allowed_paths_test.go
+++ b/interp/allowed_paths_test.go
@@ -87,6 +87,39 @@ func TestAllowedPathsOption(t *testing.T) {
 	})
 }
 
+func TestDefaultDirFromAllowedPaths(t *testing.T) {
+	t.Run("defaults to first allowed path when Dir is unset", func(t *testing.T) {
+		first := t.TempDir()
+		second := t.TempDir()
+		runner, err := interp.New(
+			interp.AllowedPaths([]string{first, second}),
+		)
+		require.NoError(t, err)
+		defer runner.Close()
+		assert.Equal(t, first, runner.Dir, "Dir should default to the first allowed path")
+	})
+
+	t.Run("falls back to os.Getwd when no allowed paths configured", func(t *testing.T) {
+		runner, err := interp.New()
+		require.NoError(t, err)
+		defer runner.Close()
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		assert.Equal(t, cwd, runner.Dir, "Dir should fall back to os.Getwd() when no sandbox is configured")
+	})
+
+	t.Run("falls back to os.Getwd when all allowed paths are skipped", func(t *testing.T) {
+		runner, err := interp.New(
+			interp.AllowedPaths([]string{"/nonexistent/path/that/does/not/exist"}),
+		)
+		require.NoError(t, err)
+		defer runner.Close()
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		assert.Equal(t, cwd, runner.Dir, "Dir should fall back to os.Getwd() when all paths are skipped")
+	})
+}
+
 func TestAllowedPathsCatInside(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello world\n"), 0644))

--- a/interp/api.go
+++ b/interp/api.go
@@ -280,11 +280,15 @@ func New(opts ...RunnerOption) (*Runner, error) {
 		r.Env = expand.ListEnviron()
 	}
 	if r.Dir == "" {
-		dir, err := os.Getwd()
-		if err != nil {
-			return nil, fmt.Errorf("could not get current dir: %w", err)
+		if paths := r.sandbox.Paths(); len(paths) > 0 {
+			r.Dir = paths[0]
+		} else {
+			dir, err := os.Getwd()
+			if err != nil {
+				return nil, fmt.Errorf("could not get current dir: %w", err)
+			}
+			r.Dir = dir
 		}
-		r.Dir = dir
 	}
 	if r.stdout == nil || r.stderr == nil {
 		StdIO(r.stdin, r.stdout, r.stderr)(r)


### PR DESCRIPTION
## Summary
- When `AllowedPaths` is configured but `Runner.Dir` isn't explicitly set, the shell now starts in the first allowed path instead of `os.Getwd()`.
- Avoids landing the shell in a directory outside the sandbox (where most operations would immediately fail).
- Falls back to `os.Getwd()` when no allowed paths are configured, or when all configured paths failed to open — preserving previous behaviour for unsandboxed runs.
- Explicit `Runner.Dir` assignments are still respected, even if outside the allowlist.

## Test plan
- [x] `go test ./interp/...` passes
- [x] Manual CLI check:
  - `rshell -p /tmp -c 'pwd'` → `/tmp`
  - `rshell -p /var,/tmp -c 'pwd'` → `/var` (first entry)
  - `rshell -c 'pwd'` (no `-p`) → `os.Getwd()` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)