### PR TITLE
test(help): make help tests resilient to new builtins

### DIFF
--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -123,18 +123,26 @@ func TestHelpHeaderRestrictedShowsCount(t *testing.T) {
 // --- Output content ---
 
 func TestHelpListsAllCommands(t *testing.T) {
+	// Drive registration so builtins.Names()/Meta() are populated.
+	r, err := interp.New()
+	require.NoError(t, err)
+	r.Close()
+
 	stdout, _, code := runScript(t, "help", "", interpoption.AllowAllCommands().(interp.RunnerOption))
 	assert.Equal(t, 0, code)
 
-	// Every registered command should appear in the output.
-	expected := []string{
-		"[", "break", "cat", "continue", "cut", "echo", "exit",
-		"false", "find", "grep", "head", "help", "ip", "ls", "ping",
-		"printf", "ps", "sed", "sort", "ss", "strings", "tail", "test",
-		"tr", "true", "uname", "uniq", "wc",
-	}
-	for _, cmd := range expected {
-		assert.Contains(t, stdout, cmd, "help output should list %q", cmd)
+	// Drive the inventory check off the registry itself so adding a builtin
+	// never requires editing this test (or a YAML scenario) — registering the
+	// command is what makes it expected.
+	names := builtins.Names()
+	require.NotEmpty(t, names, "registry should not be empty")
+	for _, name := range names {
+		meta, ok := builtins.Meta(name)
+		require.True(t, ok, "Meta(%q) should exist", name)
+		// Match the rendered table row so we don't get false positives from
+		// short names (e.g. "[") appearing elsewhere in the output.
+		assert.Contains(t, stdout, meta.Description,
+			"help output should describe %q", name)
 	}
 }
 

--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -139,10 +140,12 @@ func TestHelpListsAllCommands(t *testing.T) {
 	for _, name := range names {
 		meta, ok := builtins.Meta(name)
 		require.True(t, ok, "Meta(%q) should exist", name)
-		// Match the rendered table row so we don't get false positives from
-		// short names (e.g. "[") appearing elsewhere in the output.
-		assert.Contains(t, stdout, meta.Description,
-			"help output should describe %q", name)
+		// Match the rendered table row (name, ≥2 spaces of column padding,
+		// then description) so missing rows are caught even when descriptions
+		// repeat across builtins (e.g. "[" and "test" both describe
+		// "evaluate conditional expression").
+		rowRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s+` + regexp.QuoteMeta(meta.Description) + `$`)
+		assert.Regexp(t, rowRe, stdout, "help output should render row for %q", name)
 	}
 }
 

--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -140,6 +140,11 @@ func TestHelpListsAllCommands(t *testing.T) {
 	for _, name := range names {
 		meta, ok := builtins.Meta(name)
 		require.True(t, ok, "Meta(%q) should exist", name)
+		// Every registered builtin must carry a non-empty Description so it
+		// shows up in `help`. Without this guard the row regex below would
+		// collapse to `^name\s+$` and silently match the blank padded row
+		// that printCommandTable emits when Description is empty.
+		require.NotEmpty(t, meta.Description, "builtin %q must set a non-empty Description", name)
 		// Match the rendered table row (name, ≥2 spaces of column padding,
 		// then description) so missing rows are caught even when descriptions
 		// repeat across builtins (e.g. "[" and "test" both describe

--- a/tests/scenarios/cmd/help/restricted.yaml
+++ b/tests/scenarios/cmd/help/restricted.yaml
@@ -1,36 +1,19 @@
-description: Help lists rshell features, unsupported functionality, and only commands allowed by the active policy.
+description: Help with a restricted allowed_commands set shows only allowed commands in the table and surfaces a compact disabled-commands list. Uses stdout_contains so the test does not need editing each time a new builtin is added — exact registry coverage lives in builtins/tests/help/help_test.go.
 skip_assert_against_bash: true
 input:
   allowed_commands: ["rshell:echo", "rshell:help"]
   script: |+
     help
 expect:
-  stdout: |+
-    rshell (dev) — 2 of 30 commands enabled
-
-    Features:
-    commands            Registered commands run inside the interpreter; no unregistered commands without an external handler.
-    variables           Assignments, expansion, inline env, command substitution; no arrays/arithmetic/advanced params.
-    control-flow        for/if/&&/||/!/groups/subshells; no while/case/select/functions.
-    pipes-redirections  Pipes, stdin/heredocs, /dev/null redirects, fd dup; no arbitrary file writes.
-    quoting-expansion   Quotes, globbing, continuations, comments; no extglob/tilde/process substitution.
-    execution           AllowedCommands, AllowedPaths, timeouts, ProcPath; no background jobs/coprocs/time.
-    environment         Empty by default, caller Env, IFS/ALLOWED_PATHS; no host env inheritance/export.
-    bash-divergences    Intentional bash differences captured here. Currently: one shared time reference per Run().
-
-    Not supported:
-      - Expansions: arithmetic $((...)), arrays, advanced ${...} operations, tilde expansion, process substitution, extended globbing.
-      - Control flow: while/until, case, select, C-style for ((...)), and shell functions.
-      - Execution: external commands by default, background jobs, coprocesses, time, [[...]], ((...)), declare/export/local/readonly/let.
-      - I/O and environment: arbitrary output file redirects, |&, herestrings, read-write redirects, input fd duplication, host env inheritance.
-
-    Commands:
-    echo  write arguments to stdout
-    help  display help for features and commands
-
-    Disabled commands: [, break, cat, continue, cut, du, exit, false, find, grep, head, ip, ls, ping,
-      printf, ps, pwd, sed, sort, ss, strings, tail, test, tr, true, uname, uniq, wc
-
-    Run 'help <feature|command>' for more information on a specific topic.
+  stdout_contains:
+    - "rshell"
+    - "commands enabled"
+    - "Features:"
+    - "Not supported:"
+    - "Commands:"
+    - "echo  write arguments to stdout"
+    - "help  display help for features and commands"
+    - "Disabled commands: "
+    - "Run 'help <feature|command>' for more information on a specific topic."
   stderr: ""
   exit_code: 0

--- a/tests/scenarios/cmd/help/restricted_all_flag.yaml
+++ b/tests/scenarios/cmd/help/restricted_all_flag.yaml
@@ -1,63 +1,19 @@
-description: Help --all shows features, unsupported functionality, and allowed/not-allowed commands with descriptions.
+description: Help --all with a restricted allowed_commands set shows allowed commands and a full description table for disabled commands. Uses stdout_contains so the test does not need editing each time a new builtin is added — exact registry coverage lives in builtins/tests/help/help_test.go.
 skip_assert_against_bash: true
 input:
   allowed_commands: ["rshell:echo", "rshell:help"]
   script: |+
     help --all
 expect:
-  stdout: |+
-    rshell (dev) — 2 of 30 commands enabled
-
-    Features:
-    commands            Registered commands run inside the interpreter; no unregistered commands without an external handler.
-    variables           Assignments, expansion, inline env, command substitution; no arrays/arithmetic/advanced params.
-    control-flow        for/if/&&/||/!/groups/subshells; no while/case/select/functions.
-    pipes-redirections  Pipes, stdin/heredocs, /dev/null redirects, fd dup; no arbitrary file writes.
-    quoting-expansion   Quotes, globbing, continuations, comments; no extglob/tilde/process substitution.
-    execution           AllowedCommands, AllowedPaths, timeouts, ProcPath; no background jobs/coprocs/time.
-    environment         Empty by default, caller Env, IFS/ALLOWED_PATHS; no host env inheritance/export.
-    bash-divergences    Intentional bash differences captured here. Currently: one shared time reference per Run().
-
-    Not supported:
-      - Expansions: arithmetic $((...)), arrays, advanced ${...} operations, tilde expansion, process substitution, extended globbing.
-      - Control flow: while/until, case, select, C-style for ((...)), and shell functions.
-      - Execution: external commands by default, background jobs, coprocesses, time, [[...]], ((...)), declare/export/local/readonly/let.
-      - I/O and environment: arbitrary output file redirects, |&, herestrings, read-write redirects, input fd duplication, host env inheritance.
-
-    Commands:
-    echo  write arguments to stdout
-    help  display help for features and commands
-    
-    Disabled commands:
-    [         evaluate conditional expression
-    break     exit from a loop
-    cat       concatenate and print files
-    continue  continue a loop iteration
-    cut       remove sections from each line
-    du        estimate file space usage
-    exit      exit the shell
-    false     return unsuccessful exit status
-    find      search for files in a directory hierarchy
-    grep      print lines that match patterns
-    head      output the first part of files
-    ip        show network interface and routing information
-    ls        list directory contents
-    ping      send ICMP echo requests to a network host
-    printf    format and print data
-    ps        report process status
-    pwd       print working directory
-    sed       stream editor for filtering and transforming text
-    sort      sort lines of text files
-    ss        display socket statistics
-    strings   print printable character sequences
-    tail      output the last part of files
-    test      evaluate conditional expression
-    tr        translate or delete characters
-    true      return successful exit status
-    uname     print system information
-    uniq      report or omit repeated lines
-    wc        print newline, word, and byte counts
-    
-    Run 'help <feature|command>' for more information on a specific topic.
+  stdout_contains:
+    - "rshell"
+    - "commands enabled"
+    - "Features:"
+    - "Not supported:"
+    - "Commands:"
+    - "echo  write arguments to stdout"
+    - "help  display help for features and commands"
+    - "Disabled commands:\n"
+    - "Run 'help <feature|command>' for more information on a specific topic."
   stderr: ""
   exit_code: 0

--- a/tests/scenarios/cmd/help/restricted_all_flag.yaml
+++ b/tests/scenarios/cmd/help/restricted_all_flag.yaml
@@ -14,6 +14,7 @@ expect:
     - "echo  write arguments to stdout"
     - "help  display help for features and commands"
     - "Disabled commands:\n"
+    - "concatenate and print files"
     - "Run 'help <feature|command>' for more information on a specific topic."
   stderr: ""
   exit_code: 0

--- a/tests/scenarios/cmd/help/unrestricted.yaml
+++ b/tests/scenarios/cmd/help/unrestricted.yaml
@@ -1,60 +1,23 @@
-description: Help lists rshell features, unsupported functionality, and all available commands.
+description: Help with no restrictions shows the rshell header, features, the commands table, and the footer hint. Uses stdout_contains so the test does not need editing each time a new builtin is added — exact registry coverage lives in builtins/tests/help/help_test.go.
 skip_assert_against_bash: true
 input:
   script: |+
     help
 expect:
-  stdout: |+
-    rshell (dev) — All 30 commands available
-
-    Features:
-    commands            Registered commands run inside the interpreter; no unregistered commands without an external handler.
-    variables           Assignments, expansion, inline env, command substitution; no arrays/arithmetic/advanced params.
-    control-flow        for/if/&&/||/!/groups/subshells; no while/case/select/functions.
-    pipes-redirections  Pipes, stdin/heredocs, /dev/null redirects, fd dup; no arbitrary file writes.
-    quoting-expansion   Quotes, globbing, continuations, comments; no extglob/tilde/process substitution.
-    execution           AllowedCommands, AllowedPaths, timeouts, ProcPath; no background jobs/coprocs/time.
-    environment         Empty by default, caller Env, IFS/ALLOWED_PATHS; no host env inheritance/export.
-    bash-divergences    Intentional bash differences captured here. Currently: one shared time reference per Run().
-
-    Not supported:
-      - Expansions: arithmetic $((...)), arrays, advanced ${...} operations, tilde expansion, process substitution, extended globbing.
-      - Control flow: while/until, case, select, C-style for ((...)), and shell functions.
-      - Execution: external commands by default, background jobs, coprocesses, time, [[...]], ((...)), declare/export/local/readonly/let.
-      - I/O and environment: arbitrary output file redirects, |&, herestrings, read-write redirects, input fd duplication, host env inheritance.
-
-    Commands:
-    [         evaluate conditional expression
-    break     exit from a loop
-    cat       concatenate and print files
-    continue  continue a loop iteration
-    cut       remove sections from each line
-    du        estimate file space usage
-    echo      write arguments to stdout
-    exit      exit the shell
-    false     return unsuccessful exit status
-    find      search for files in a directory hierarchy
-    grep      print lines that match patterns
-    head      output the first part of files
-    help      display help for features and commands
-    ip        show network interface and routing information
-    ls        list directory contents
-    ping      send ICMP echo requests to a network host
-    printf    format and print data
-    ps        report process status
-    pwd       print working directory
-    sed       stream editor for filtering and transforming text
-    sort      sort lines of text files
-    ss        display socket statistics
-    strings   print printable character sequences
-    tail      output the last part of files
-    test      evaluate conditional expression
-    tr        translate or delete characters
-    true      return successful exit status
-    uname     print system information
-    uniq      report or omit repeated lines
-    wc        print newline, word, and byte counts
-    
-    Run 'help <feature|command>' for more information on a specific topic.
+  stdout_contains:
+    - "rshell"
+    - "commands available"
+    - "Features:"
+    - "commands            Registered commands run inside the interpreter"
+    - "control-flow        for/if/&&/||/!/groups/subshells"
+    - "Not supported:"
+    - "arithmetic $((...))"
+    - "while/until"
+    - "Commands:"
+    - "echo"
+    - "write arguments to stdout"
+    - "help"
+    - "display help for features and commands"
+    - "Run 'help <feature|command>' for more information on a specific topic."
   stderr: ""
   exit_code: 0

--- a/tests/scenarios/cmd/help/unrestricted_all_flag.yaml
+++ b/tests/scenarios/cmd/help/unrestricted_all_flag.yaml
@@ -1,62 +1,20 @@
-description: Help --all with no restrictions shows features, unsupported functionality, all commands, and a confirmation message.
+description: Help --all with no restrictions shows features, the commands table, and a confirmation that all commands are allowed. Uses stdout_contains so the test does not need editing each time a new builtin is added — exact registry coverage lives in builtins/tests/help/help_test.go.
 skip_assert_against_bash: true
 input:
   script: |+
     help --all
 expect:
-  stdout: |+
-    rshell (dev) — All 30 commands available
-
-    Features:
-    commands            Registered commands run inside the interpreter; no unregistered commands without an external handler.
-    variables           Assignments, expansion, inline env, command substitution; no arrays/arithmetic/advanced params.
-    control-flow        for/if/&&/||/!/groups/subshells; no while/case/select/functions.
-    pipes-redirections  Pipes, stdin/heredocs, /dev/null redirects, fd dup; no arbitrary file writes.
-    quoting-expansion   Quotes, globbing, continuations, comments; no extglob/tilde/process substitution.
-    execution           AllowedCommands, AllowedPaths, timeouts, ProcPath; no background jobs/coprocs/time.
-    environment         Empty by default, caller Env, IFS/ALLOWED_PATHS; no host env inheritance/export.
-    bash-divergences    Intentional bash differences captured here. Currently: one shared time reference per Run().
-
-    Not supported:
-      - Expansions: arithmetic $((...)), arrays, advanced ${...} operations, tilde expansion, process substitution, extended globbing.
-      - Control flow: while/until, case, select, C-style for ((...)), and shell functions.
-      - Execution: external commands by default, background jobs, coprocesses, time, [[...]], ((...)), declare/export/local/readonly/let.
-      - I/O and environment: arbitrary output file redirects, |&, herestrings, read-write redirects, input fd duplication, host env inheritance.
-
-    Commands:
-    [         evaluate conditional expression
-    break     exit from a loop
-    cat       concatenate and print files
-    continue  continue a loop iteration
-    cut       remove sections from each line
-    du        estimate file space usage
-    echo      write arguments to stdout
-    exit      exit the shell
-    false     return unsuccessful exit status
-    find      search for files in a directory hierarchy
-    grep      print lines that match patterns
-    head      output the first part of files
-    help      display help for features and commands
-    ip        show network interface and routing information
-    ls        list directory contents
-    ping      send ICMP echo requests to a network host
-    printf    format and print data
-    ps        report process status
-    pwd       print working directory
-    sed       stream editor for filtering and transforming text
-    sort      sort lines of text files
-    ss        display socket statistics
-    strings   print printable character sequences
-    tail      output the last part of files
-    test      evaluate conditional expression
-    tr        translate or delete characters
-    true      return successful exit status
-    uname     print system information
-    uniq      report or omit repeated lines
-    wc        print newline, word, and byte counts
-    
-    All commands are allowed in this session.
-    
-    Run 'help <feature|command>' for more information on a specific topic.
+  stdout_contains:
+    - "rshell"
+    - "commands available"
+    - "Features:"
+    - "Not supported:"
+    - "Commands:"
+    - "echo"
+    - "write arguments to stdout"
+    - "help"
+    - "display help for features and commands"
+    - "All commands are allowed in this session."
+    - "Run 'help <feature|command>' for more information on a specific topic."
   stderr: ""
   exit_code: 0


### PR DESCRIPTION
## Summary

The four help scenarios under `tests/scenarios/cmd/help/` (`restricted.yaml`, `restricted_all_flag.yaml`, `unrestricted.yaml`, `unrestricted_all_flag.yaml`) pinned the full command list and total command count in their expected stdout. Every PR that adds a builtin had to update all four files — same line, same alphabetical ordering — making merge conflicts the default outcome between any two builtin-adding PRs (e.g. the `xargs` PR #224 conflicting with `du` #207).

This PR makes the test setup resilient:

- The four scenarios switch to `stdout_contains` and only assert the stable structural elements: the header, the `Features:` / `Not supported:` / `Commands:` sections, a couple of known-stable command rows (`echo`, `help`), the disabled-commands label form (compact vs. table), and the footer hint.
- The "every registered builtin appears in help" inventory check moves into `builtins/tests/help/help_test.go` (`TestHelpListsAllCommands`), which now drives off `builtins.Names()` / `builtins.Meta()` — registering a builtin is what makes it expected, no test edits required.
- Existing alignment / sorting / format invariants (`TestHelpColumnsAligned`, `TestHelpListsSorted`, `TestHelpFieldOnlyOnNoFlagsCommands`) keep covering rendering quality.

Net effect: a future PR adding a builtin no longer needs to touch any help test — just register the command in the registry.

## Test plan

- [x] `make fmt`
- [x] `go test ./builtins/tests/help/...`
- [x] `go test ./tests/ -run TestShellScenarios -timeout 120s`
- [ ] `RSHELL_BASH_TEST=1 go test ./tests/ -run TestShellScenariosAgainstBash -timeout 120s` (all four files set `skip_assert_against_bash: true`, unchanged)