### PR TITLE
fix(skills): match codex bot in GraphQL author.login filters

### DIFF
--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -120,8 +120,11 @@ while true; do
       }
     }
   ' -f owner="{owner}" -f repo="{repo}" -F pr={pr-number} -f after="$cursor")
+  # NOTE: GraphQL's author.login returns the bare bot login ("chatgpt-codex-connector"),
+  # while REST returns it suffixed with "[bot]". Match both forms so this query stays
+  # correct if GitHub ever changes the convention.
   echo "$page" | jq --arg me "$MY_LOGIN" \
-    '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")'
+    '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector" or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")'
   [ "$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')" = "true" ] || break
   cursor=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
 done

--- a/.claude/skills/review-fix-loop/SKILL.md
+++ b/.claude/skills/review-fix-loop/SKILL.md
@@ -227,8 +227,11 @@ Check **two** signals for remaining issues:
          }
        }
      ' -f owner="{owner}" -f repo="{repo}" -F pr={pr-number} -f after="$cursor")
+     # NOTE: GraphQL's author.login returns the bare bot login ("chatgpt-codex-connector"),
+     # while REST returns it suffixed with "[bot]". Match both forms so this query stays
+     # correct if GitHub ever changes the convention.
      unresolved=$((unresolved + $(echo "$page" | jq --arg me "$MY_LOGIN" \
-       '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")] | length')))
+       '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector" or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")] | length')))
      [ "$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')" = "true" ] || break
      cursor=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
    done
@@ -311,8 +314,11 @@ Run a final verification regardless of how the loop exited:
          }
        }
      ' -f owner="{owner}" -f repo="{repo}" -F pr={pr-number} -f after="$cursor")
+     # NOTE: GraphQL's author.login returns the bare bot login ("chatgpt-codex-connector"),
+     # while REST returns it suffixed with "[bot]". Match both forms so this query stays
+     # correct if GitHub ever changes the convention.
      unresolved=$((unresolved + $(echo "$page" | jq --arg me "$MY_LOGIN" \
-       '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")] | length')))
+       '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector" or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")] | length')))
      [ "$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')" = "true" ] || break
      cursor=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
    done


### PR DESCRIPTION
## Summary

GitHub's GraphQL API returns Bot author logins in their **bare form** (`chatgpt-codex-connector`) while the REST API returns them **suffixed** (`chatgpt-codex-connector[bot]`). Three GraphQL `select()` clauses in `review-fix-loop` and `address-pr-comments` filter on the REST-suffixed literal only, so every codex-authored review thread was silently dropped from the unresolved count.

## Impact

Surfaced today on PR #226: a codex P2 thread ([`#discussion_r3189543903`](https://github.com/DataDog/rshell/pull/226#discussion_r3189543903), "Require non-empty command descriptions") sat unresolved through **four** "clean" review-fix-loop iterations because Step 2E and Step 3's GraphQL queries never saw it. `SUCCESS_COUNT` reached 5 and the loop declared the PR clean while a real P2 was open. The bug was visible to a human inspecting the PR but invisible to the loop.

## Fix

Extend the GraphQL `select()` clauses at three sites to accept either form:

```diff
- select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")
+ select(.comments.nodes[0].author.login == $me or .comments.nodes[0].author.login == "chatgpt-codex-connector" or .comments.nodes[0].author.login == "chatgpt-codex-connector[bot]")
```

Sites changed:
- `.claude/skills/review-fix-loop/SKILL.md:234` (Step 2E unresolved-thread check)
- `.claude/skills/review-fix-loop/SKILL.md:321` (Step 3 verify check)
- `.claude/skills/address-pr-comments/SKILL.md:127` (resolved-thread filter)

A short `# NOTE:` comment is added above each query explaining the REST-vs-GraphQL discrepancy so future edits don't regress.

## Why both forms

Keeping the `[bot]` form alongside the bare form means the filter stays correct if GitHub ever standardises on the suffixed login in GraphQL. Cheap forward-compatibility.

## Not changed

- `fix-ci-tests/SKILL.md:227` and `address-pr-comments/SKILL.md:66, 77` use the **REST** API path, which already returns `chatgpt-codex-connector[bot]` correctly. Left untouched.

## Test plan

- [x] Verified with the live API on PR #226: GraphQL `author.login` returns `chatgpt-codex-connector` for the bot's threads (typename `Bot`); REST returns `chatgpt-codex-connector[bot]`.
- [ ] Future review-fix-loop runs against any PR with a codex thread should surface them in the unresolved count.