### PR TITLE
docs(agents): scope RULES.md under Builtin Implementation section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-@docs/RULES.md
-
 # Restricted Shell Interpreter
 
 ## Overview
@@ -38,6 +36,10 @@ The shell is supported on Linux, Windows and macOS.
 
 - **ALWAYS prioritise fixing the shell implementation to match bash behaviour over changing tests to match the current (incorrect) shell output.** Never "fix" a failing test by updating its expected output to match broken shell behaviour — fix the shell instead.
 - Only deviate from bash behaviour when the shell is intentionally different (e.g. sandbox restrictions, blocked commands, readonly enforcement).
+
+## Builtin Implementation
+
+@docs/RULES.md
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ The shell is supported on Linux, Windows and macOS.
 - **ALWAYS prioritise fixing the shell implementation to match bash behaviour over changing tests to match the current (incorrect) shell output.** Never "fix" a failing test by updating its expected output to match broken shell behaviour — fix the shell instead.
 - Only deviate from bash behaviour when the shell is intentionally different (e.g. sandbox restrictions, blocked commands, readonly enforcement).
 
-## Builtin Implementation
+## Builtin Implementation Rules
 
 @docs/RULES.md
 


### PR DESCRIPTION
## Summary
- Move `@docs/RULES.md` out of the top-of-file (global) slot in `AGENTS.md` and into a new `## Builtin Implementation` section placed just before `## Testing`.
- RULES.md covers builtin-specific guidance (flag parsing, file access via `OpenFile`, memory/testing rules), so scoping it under a dedicated section is a better fit than importing it as project-wide context.

## Test plan
- [x] `AGENTS.md` renders with `## Builtin Implementation` section containing the `@docs/RULES.md` import
- [x] No content removed; only relocated