### PR TITLE
fix(analysis): audit all non-exempt top-level builtins/ files

### DIFF
--- a/analysis/signal_handling_vuln_hunt_test.go
+++ b/analysis/signal_handling_vuln_hunt_test.go
@@ -77,10 +77,10 @@ func TestVulnHuntSubsystemSignalHandling_NoOsSignalSymbolsInAllowlists(t *testin
 // TestVulnHuntSubsystemSignalHandling_NoSignalNotifyInProductionCode is a
 // belt-and-braces grep-style check that no non-test .go file under interp/
 // or builtins/ contains the literal text "signal.Notify" or imports
-// "os/signal". The symbol allowlist already enforces this, but the F-1
-// finding (collectSubdirGoFiles subdir-only filter) showed that two files
-// (builtins/proc_provider.go and builtins/features.go) are exempt from
-// that allowlist; this test catches a regression in those exempt files.
+// "os/signal". The symbol allowlist already enforces this. The collector
+// gap that originally motivated this fallback (vuln-hunt F-1: top-level
+// builtins/ files bypassing the allowlist) has since been closed, so this
+// test now serves purely as defense-in-depth against future regressions.
 //
 // Note: the function name slug uses "OsSignal" rather than the more
 // natural "os/signal" because slashes in test names cause subtest pathing

--- a/analysis/symbols_builtins_test.go
+++ b/analysis/symbols_builtins_test.go
@@ -19,8 +19,10 @@ func builtinsCheckConfig() allowedSymbolsConfig {
 		TargetDir: "builtins",
 		CollectFiles: func(dir string) ([]string, error) {
 			// "internal" has its own dedicated check (TestInternalAllowedSymbols).
-			return collectSubdirGoFiles(dir, map[string]bool{"testutil": true, "internal": true}, func(rel string) bool {
-				// builtins.go is the package framework and is exempt.
+			return collectGoFilesRecursive(dir, map[string]bool{"testutil": true, "internal": true}, func(rel string) bool {
+				// builtins.go is the package framework and is exempt. Every
+				// other top-level file (e.g. proc_provider.go, features.go) is
+				// audited against builtinAllowedSymbols.
 				return rel == "builtins.go"
 			})
 		},
@@ -71,7 +73,7 @@ func internalCheckConfig() allowedSymbolsConfig {
 		Symbols:   internalAllowedSymbols,
 		TargetDir: "builtins/internal",
 		CollectFiles: func(dir string) ([]string, error) {
-			return collectSubdirGoFiles(dir, nil, nil)
+			return collectGoFilesRecursive(dir, nil, nil)
 		},
 		ExemptImport: func(importPath string) bool {
 			return importPath == "github.com/DataDog/rshell/builtins"

--- a/analysis/symbols_builtins_verification_test.go
+++ b/analysis/symbols_builtins_verification_test.go
@@ -156,6 +156,27 @@ func TestVerificationBuiltinsSkipsTopLevel(t *testing.T) {
 	}
 }
 
+// TestVerificationBuiltinsChecksNonExemptTopLevel confirms that top-level
+// files in builtins/ other than builtins.go are audited. This guards against
+// regression of the vuln-hunt F-1 finding (2026-05-18-initial-audit /
+// builtin-import-allowlist), where a subdir-only filter in the collector
+// silently excluded proc_provider.go and features.go from the allowlist check.
+func TestVerificationBuiltinsChecksNonExemptTopLevel(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "builtins"), filepath.Join(tmp, "builtins"))
+
+	target := filepath.Join(tmp, "builtins", "proc_provider.go")
+	injectImport(t, target, `"os/exec"`, "var _ = exec.Command")
+
+	var errs []string
+	checkAllowedSymbols(t, builtinsVerifyCfg(tmp, &errs))
+
+	if !errContains(errs, "permanently banned") || !errContains(errs, "os/exec") {
+		t.Errorf("expected 'permanently banned' error for os/exec in proc_provider.go, got: %v", errs)
+	}
+}
+
 func TestVerificationBuiltinsSkipsTestutilDir(t *testing.T) {
 	root := repoRoot(t)
 	tmp := t.TempDir()

--- a/analysis/symbols_test.go
+++ b/analysis/symbols_test.go
@@ -250,10 +250,11 @@ func checkPerBuiltinAllowedSymbols(t *testing.T, cfg perBuiltinConfig) {
 	}
 }
 
-// collectSubdirGoFiles walks a directory tree and returns all non-test .go
-// files that are inside subdirectories (not at the top level). Optionally
-// skips directories by name.
-func collectSubdirGoFiles(dir string, skipDirs map[string]bool, skipTopLevel func(rel string) bool) ([]string, error) {
+// collectGoFilesRecursive walks a directory tree and returns all non-test .go
+// files, including those at the top level. Directories named in skipDirs are
+// pruned. Top-level files (rel has no separator) are excluded only when
+// skipTopLevel is non-nil and returns true for their relative path.
+func collectGoFilesRecursive(dir string, skipDirs map[string]bool, skipTopLevel func(rel string) bool) ([]string, error) {
 	var files []string
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -270,10 +271,6 @@ func collectSubdirGoFiles(dir string, skipDirs map[string]bool, skipTopLevel fun
 		}
 		rel, _ := filepath.Rel(dir, path)
 		if skipTopLevel != nil && skipTopLevel(rel) {
-			return nil
-		}
-		// Only check files inside subdirectories.
-		if !strings.Contains(rel, string(filepath.Separator)) {
 			return nil
 		}
 		files = append(files, path)


### PR DESCRIPTION
## Summary
- Closes vuln-hunt F-1 ([builtin-import-allowlist.md](https://github.com/DataDog/rshell-vuln-hunt/blob/main/vuln-hunt/campaigns/2026-05-18-initial-audit/findings/builtin-import-allowlist.md)): `collectSubdirGoFiles` had an unconditional subdir-only filter that shadowed the `skipTopLevel` callback, silently excluding `builtins/proc_provider.go` and `builtins/features.go` from the symbol allowlist. Banned imports (`os/exec`, `net/*`, `plugin`, `reflect`) could land in either file undetected.
- Rename `collectSubdirGoFiles` → `collectGoFilesRecursive`, drop the shadowing filter, so `skipTopLevel` solely controls top-level exemption. `builtins.go` stays exempt via the existing callback; `proc_provider.go` and `features.go` are now audited (their current imports already comply).
- Add `TestVerificationBuiltinsChecksNonExemptTopLevel` regression test that injects `os/exec` into `proc_provider.go` and asserts the analyzer flags it. Update the stale F-1 reference comment in `signal_handling_vuln_hunt_test.go` (kept as defense-in-depth).

## Test plan
- [x] `go test ./analysis/... -count=1`
- [x] `TestBuiltinAllowedSymbols`, `TestBuiltinPerCommandSymbols`, `TestVerificationBuiltinsCleanPass`, `TestVerificationBuiltinsSkipsTopLevel`, `TestVerificationBuiltinsChecksNonExemptTopLevel` all pass
- [x] `make fmt` clean
