### PR TITLE
fix(interp): restore prior value for same-name inline-command vars

### DIFF
--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -101,6 +101,7 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			vr   expand.Variable
 		}
 		var restores []restoreVar
+		seenRestore := map[string]bool{}
 
 		for _, as := range cm.Assigns {
 			name := as.Name.Value
@@ -110,7 +111,13 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			// Inline command vars are always exported.
 			vr.Exported = true
 
-			restores = append(restores, restoreVar{name, prev})
+			// Only the first prev for a given name is the true
+			// pre-command value; later ones capture the intermediate
+			// assigned by an earlier iteration of this loop.
+			if !seenRestore[name] {
+				restores = append(restores, restoreVar{name, prev})
+				seenRestore[name] = true
+			}
 
 			r.setVar(name, vr)
 		}

--- a/tests/scenarios/shell/inline_var/same_name_multi_assign_restores_prior_value.yaml
+++ b/tests/scenarios/shell/inline_var/same_name_multi_assign_restores_prior_value.yaml
@@ -1,0 +1,21 @@
+description: |
+  vuln-hunt F-2 (2026-05-18-initial-audit, inline_var P3): when the same
+  variable name appears multiple times in an inline-command-var prefix
+  (e.g. `A=v1 A=v2 cmd`), the variable must be restored to its true
+  pre-command value, not to an intermediate value captured between
+  assignments. Covers both the two-assignment and three-assignment cases.
+input:
+  script: |+
+    A=orig
+    A=v1 A=v2 echo two-assign
+    echo "out=[$A]"
+    A=v1 A=v2 A=v3 echo three-assign
+    echo "out=[$A]"
+expect:
+  stdout: |+
+    two-assign
+    out=[orig]
+    three-assign
+    out=[orig]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/inline_var/same_name_multi_assign_restores_prior_value.yaml
+++ b/tests/scenarios/shell/inline_var/same_name_multi_assign_restores_prior_value.yaml
@@ -26,5 +26,5 @@ expect:
     interleaved=[orig][]
     never-set
     never-set=[]
-  stderr: ""
+  stderr: |+
   exit_code: 0

--- a/tests/scenarios/shell/inline_var/same_name_multi_assign_restores_prior_value.yaml
+++ b/tests/scenarios/shell/inline_var/same_name_multi_assign_restores_prior_value.yaml
@@ -3,7 +3,8 @@ description: |
   variable name appears multiple times in an inline-command-var prefix
   (e.g. `A=v1 A=v2 cmd`), the variable must be restored to its true
   pre-command value, not to an intermediate value captured between
-  assignments. Covers both the two-assignment and three-assignment cases.
+  assignments. Covers the two-assignment, three-assignment, interleaved
+  same/different-name, and never-set-before cases.
 input:
   script: |+
     A=orig
@@ -11,11 +12,19 @@ input:
     echo "out=[$A]"
     A=v1 A=v2 A=v3 echo three-assign
     echo "out=[$A]"
+    A=v1 B=vb A=v2 echo interleaved
+    echo "interleaved=[$A][$B]"
+    C=v1 C=v2 echo never-set
+    echo "never-set=[$C]"
 expect:
   stdout: |+
     two-assign
     out=[orig]
     three-assign
     out=[orig]
+    interleaved
+    interleaved=[orig][]
+    never-set
+    never-set=[]
   stderr: ""
   exit_code: 0


### PR DESCRIPTION
## Summary
- Fix vuln-hunt F-2 (`inline_var`, P3): `A=v1 A=v2 cmd` was leaving `A=v1` in the parent shell instead of restoring A's true pre-command value.
- Root cause: each iteration recaptured `prev` *after* the previous assignment took effect, so the 2nd restore entry held the intermediate. The forward-order defer then applied the stale restore last.
- Fix: dedupe the restore list by name — only the first `prev` per name is recorded, matching bash semantics.
- Regression scenario added covering the 2- and 3-assignment cases.

## Test plan
- [x] `go test ./interp/... ./tests/` passes locally
- [x] New scenario `same_name_multi_assign_restores_prior_value.yaml` passes (and is asserted against bash by default in CI)
- [x] Verified bash output of the scenario matches expectation by running the script directly in `debian:bookworm-slim`
- [ ] CI bash-comparison suite (`RSHELL_BASH_TEST=1`) green

## Reference
- Finding doc: [DataDog/rshell-vuln-hunt — 2026-05-18-initial-audit / findings / inline_var.md](https://github.com/DataDog/rshell-vuln-hunt/blob/main/vuln-hunt/campaigns/2026-05-18-initial-audit/findings/inline_var.md)
