### PR TITLE
Add vuln-hunt regression tests across builtins and shell features

### DIFF
--- a/analysis/callctx_openfile_vuln_hunt_test.go
+++ b/analysis/callctx_openfile_vuln_hunt_test.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Tripwire test added by vuln-hunt campaign 2026-05-19-codex /
+// callctx-openfile.
+
+package analysis
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVulnHuntSubsystemCallctxOpenfile_NoDirectPathFilesystemCallsInBuiltins
+// pins the core filesystem invariant for command implementation files:
+// production builtins must reach the filesystem through CallContext methods
+// rather than direct path-taking os/syscall/unix helpers. Documented kernel
+// pseudo-file readers live under builtins/internal/ and are covered by the
+// internal allowlist instead of this tripwire.
+func TestVulnHuntSubsystemCallctxOpenfile_NoDirectPathFilesystemCallsInBuiltins(t *testing.T) {
+	root := repoRoot(t)
+	builtinsRoot := filepath.Join(root, "builtins")
+
+	banned := map[string]map[string]bool{
+		"os": {
+			"Open": true, "OpenFile": true, "ReadFile": true, "ReadDir": true,
+			"Stat": true, "Lstat": true, "Readlink": true,
+			"Create": true, "CreateTemp": true, "WriteFile": true,
+			"Mkdir": true, "MkdirAll": true, "Remove": true, "RemoveAll": true,
+			"Rename": true, "Symlink": true, "Link": true, "Truncate": true,
+			"Chmod": true, "Chown": true,
+		},
+		"syscall": {
+			"Open": true, "Openat": true, "Stat": true, "Lstat": true,
+			"Fstatat": true, "Readlink": true, "Unlink": true,
+			"Mkdir": true, "Rmdir": true, "Rename": true, "Symlink": true,
+			"Link": true, "Chmod": true, "Chown": true, "Truncate": true,
+		},
+		"golang.org/x/sys/unix": {
+			"Open": true, "Openat": true, "Stat": true, "Lstat": true,
+			"Fstatat": true, "Readlink": true, "Unlink": true,
+			"Mkdir": true, "Rmdir": true, "Rename": true, "Symlink": true,
+			"Link": true, "Chmod": true, "Chown": true, "Truncate": true,
+		},
+	}
+
+	err := filepath.WalkDir(builtinsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "internal", "tests", "testutil":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		localToImport := map[string]string{}
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if _, ok := banned[importPath]; !ok {
+				continue
+			}
+			local := filepath.Base(importPath)
+			if imp.Name != nil {
+				local = imp.Name.Name
+			}
+			if local != "_" && local != "." {
+				localToImport[local] = importPath
+			}
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			id, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			importPath, ok := localToImport[id.Name]
+			if !ok {
+				return true
+			}
+			if banned[importPath][sel.Sel.Name] {
+				pos := fset.Position(sel.Pos())
+				rel, _ := filepath.Rel(root, path)
+				t.Errorf("%s:%d calls %s.%s directly; production builtins must use CallContext filesystem methods unless the documented exception lives under builtins/internal/",
+					rel, pos.Line, id.Name, sel.Sel.Name)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk builtins: %v", err)
+	}
+}

--- a/analysis/signal_handling_vuln_hunt_test.go
+++ b/analysis/signal_handling_vuln_hunt_test.go
@@ -75,8 +75,8 @@ func TestVulnHuntSubsystemSignalHandling_NoOsSignalSymbolsInAllowlists(t *testin
 }
 
 // TestVulnHuntSubsystemSignalHandling_NoSignalNotifyInProductionCode is a
-// belt-and-braces grep-style check that no non-test .go file under interp/
-// or builtins/ contains the literal text "signal.Notify" or imports
+// belt-and-braces grep-style check that no non-test .go file under production
+// directories contains the literal text "signal.Notify" or imports
 // "os/signal". The symbol allowlist already enforces this, but the F-1
 // finding (collectSubdirGoFiles subdir-only filter) showed that two files
 // (builtins/proc_provider.go and builtins/features.go) are exempt from
@@ -87,7 +87,7 @@ func TestVulnHuntSubsystemSignalHandling_NoOsSignalSymbolsInAllowlists(t *testin
 // issues with `go test -run`.
 func TestVulnHuntSubsystemSignalHandling_NoSignalNotifyInProductionCode(t *testing.T) {
 	root := repoRoot(t)
-	for _, dir := range []string{"interp", "builtins"} {
+	for _, dir := range []string{"allowedpaths", "builtins", "cmd", "interp"} {
 		base := filepath.Join(root, dir)
 		err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {

--- a/builtins/cut/cut_unix_vuln_hunt_test.go
+++ b/builtins/cut/cut_unix_vuln_hunt_test.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package cut_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/builtins/testutil"
+	"github.com/DataDog/rshell/interp"
+)
+
+// H17: /dev/zero has no newline, so the scanner must stop at MaxLineBytes
+// instead of reading forever when the operator explicitly allows the device.
+func TestVulnHuntBuiltinSpecialFiles_DevZeroHitsLineCap(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stdout, stderr, code := testutil.RunScriptCtx(ctx, t, "cut -b1 /dev/zero", "",
+		interp.AllowedPaths([]string{"/dev/zero"}))
+
+	require.NoError(t, ctx.Err())
+	assert.NotEqual(t, 0, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "cut:")
+}

--- a/builtins/cut/cut_unix_vuln_hunt_test.go
+++ b/builtins/cut/cut_unix_vuln_hunt_test.go
@@ -1,9 +1,9 @@
-//go:build unix
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
+
+//go:build unix
 
 package cut_test
 

--- a/builtins/cut/cut_vuln_hunt_test.go
+++ b/builtins/cut/cut_vuln_hunt_test.go
@@ -8,16 +8,22 @@
 package cut_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/DataDog/rshell/builtins/testutil"
+	"github.com/DataDog/rshell/internal/interpoption"
 	"github.com/DataDog/rshell/interp"
 )
 
@@ -45,7 +51,7 @@ func TestVulnHuntBuiltinFileAccessBypass_SymlinkOutsideSandbox(t *testing.T) {
 
 // H3: --output-delimiter accepts arbitrary strings. Newlines / NUL bytes /
 // ANSI escapes inside the delimiter pass through to stdout verbatim, but this
-// stays inside the 1MB output cap and therefore inside the sandbox.
+// stays inside the global stdout cap and therefore inside the sandbox.
 // Regression: confirm the value is forwarded as-is (so callers can't smuggle
 // metacharacters back into a re-parsing shell — but the rshell child never
 // re-parses cut output, so the boundary is observational only).
@@ -80,6 +86,40 @@ func TestVulnHuntBuiltinResourceExhaustion_LineExceedsMaxLineBytes(t *testing.T)
 	assert.True(t,
 		strings.Contains(stderr, "cut:") || strings.Contains(stderr, "too long"),
 		"stderr should report the cap, got %q", stderr)
+}
+
+// H7/H12: many disjoint ranges plus a large output delimiter can amplify
+// output from a small input, but the interpreter-level stdout cap must stop it.
+func TestVulnHuntBuiltinResourceExhaustion_OutputLimitStopsDelimiterAmplification(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "input.txt"),
+		[]byte(strings.Repeat("a", 1200)+"\n"), 0644))
+
+	rangeParts := make([]string, 0, 600)
+	for i := 1; i <= 1200; i += 2 {
+		rangeParts = append(rangeParts, strconv.Itoa(i))
+	}
+	delimiter := strings.Repeat("x", 20000)
+	script := "cut -b" + strings.Join(rangeParts, ",") + " --output-delimiter='" + delimiter + "' input.txt"
+
+	prog, err := syntax.NewParser().Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	runner, err := interp.New(
+		interp.StdIO(nil, &stdout, &stderr),
+		interpoption.AllowAllCommands().(interp.RunnerOption),
+		interp.AllowedPaths([]string{dir}),
+	)
+	require.NoError(t, err)
+	defer runner.Close()
+	runner.Dir = dir
+
+	err = runner.Run(context.Background(), prog)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, interp.ErrOutputLimitExceeded), "got %v", err)
+	assert.LessOrEqual(t, stdout.Len(), 10*1024*1024)
+	assert.Empty(t, stderr.String())
 }
 
 // H8: -b range with a value that overflows strconv.Atoi must be rejected.

--- a/builtins/du/du_coverage_test.go
+++ b/builtins/du/du_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -132,6 +133,23 @@ func TestDuDetectsSymlinkLoopWithL(t *testing.T) {
 	_, stderr, code := cmdRunCtx(ctx, t, "du -L .", dir)
 	assert.Equal(t, 1, code)
 	assert.Contains(t, stderr, "File system loop detected")
+}
+
+// TestDuFifoOperandDoesNotBlock ensures du treats FIFOs as metadata-only leaf
+// entries. Opening a FIFO with no writer would block, so this guards the
+// special-file invariant that du must use Stat/Lstat rather than OpenFile for
+// non-directory operands.
+func TestDuFifoOperandDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, syscall.Mkfifo(filepath.Join(dir, "pipe"), 0o600))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	stdout, stderr, code := cmdRunCtx(ctx, t, "du -b pipe", dir)
+	require.NoError(t, ctx.Err())
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "0\tpipe\n", stdout)
 }
 
 // --- humanSize edge values ---

--- a/builtins/du/du_vuln_hunt_test.go
+++ b/builtins/du/du_vuln_hunt_test.go
@@ -46,3 +46,23 @@ func TestVulnHuntBuiltinSpecialFiles_SymlinkCycleDetected(t *testing.T) {
 	_ = code
 	_ = stderr
 }
+
+// H1: -L must not turn an allowed symlink into an AllowedPaths escape. The
+// StatFile wrapper follows links, but the sandbox must reject targets outside
+// the configured root before du can report their metadata.
+func TestVulnHuntBuiltinFileAccessBypass_DereferenceSymlinkOutsideAllowedPathsBlocked(t *testing.T) {
+	if !canSymlink() {
+		t.Skip("symlinks unavailable")
+	}
+	allowed := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret-data\n"), 0o600))
+	require.NoError(t, os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(allowed, "escape")))
+
+	stdout, stderr, code := cmdRun(t, "du -L -b escape", allowed)
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "du: cannot access 'escape'")
+	assert.NotContains(t, stdout+stderr, "secret-data")
+	assert.NotContains(t, stdout+stderr, outside)
+}

--- a/builtins/du/du_vuln_hunt_test.go
+++ b/builtins/du/du_vuln_hunt_test.go
@@ -54,14 +54,24 @@ func TestVulnHuntBuiltinFileAccessBypass_DereferenceSymlinkOutsideAllowedPathsBl
 	if !canSymlink() {
 		t.Skip("symlinks unavailable")
 	}
-	allowed := t.TempDir()
-	outside := t.TempDir()
+	base := t.TempDir()
+	allowed := filepath.Join(base, "allowed")
+	outside := filepath.Join(base, "outside")
+	require.NoError(t, os.Mkdir(allowed, 0o700))
+	require.NoError(t, os.Mkdir(outside, 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret-data\n"), 0o600))
 	require.NoError(t, os.Mkdir(filepath.Join(outside, "secret-dir"), 0o700))
 	require.NoError(t, os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(allowed, "escape")))
 	require.NoError(t, os.Symlink(filepath.Join(outside, "secret-dir"), filepath.Join(allowed, "escape-dir")))
 
-	stdout, stderr, code := cmdRun(t, "du -L -b escape", allowed)
+	stdout, stderr, code := cmdRun(t, "du -b ../outside/secret.txt", allowed)
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "du: cannot access '../outside/secret.txt'")
+	assert.NotContains(t, stdout+stderr, "secret-data")
+	assert.NotContains(t, stdout+stderr, outside)
+
+	stdout, stderr, code = cmdRun(t, "du -L -b escape", allowed)
 	assert.Equal(t, 1, code)
 	assert.Empty(t, stdout)
 	assert.Contains(t, stderr, "du: cannot access 'escape'")

--- a/builtins/du/du_vuln_hunt_test.go
+++ b/builtins/du/du_vuln_hunt_test.go
@@ -57,12 +57,20 @@ func TestVulnHuntBuiltinFileAccessBypass_DereferenceSymlinkOutsideAllowedPathsBl
 	allowed := t.TempDir()
 	outside := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret-data\n"), 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(outside, "secret-dir"), 0o700))
 	require.NoError(t, os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(allowed, "escape")))
+	require.NoError(t, os.Symlink(filepath.Join(outside, "secret-dir"), filepath.Join(allowed, "escape-dir")))
 
 	stdout, stderr, code := cmdRun(t, "du -L -b escape", allowed)
 	assert.Equal(t, 1, code)
 	assert.Empty(t, stdout)
 	assert.Contains(t, stderr, "du: cannot access 'escape'")
 	assert.NotContains(t, stdout+stderr, "secret-data")
+	assert.NotContains(t, stdout+stderr, outside)
+
+	stdout, stderr, code = cmdRun(t, "du -L -b escape-dir", allowed)
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "du: cannot access 'escape-dir'")
 	assert.NotContains(t, stdout+stderr, outside)
 }

--- a/builtins/exit/exit_vuln_hunt_test.go
+++ b/builtins/exit/exit_vuln_hunt_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package exit_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/rshell/builtins/testutil"
+	"github.com/DataDog/rshell/interp"
+)
+
+// Campaign: vuln-hunt/2026-05-19-codex. These are public-safe blocked-attack
+// regressions for exit.
+
+func TestVulnHuntBuiltinFileAccessBypass_PathOperandsAreNumericData(t *testing.T) {
+	dir := t.TempDir()
+	stdout, stderr, code := testutil.RunScript(t,
+		"exit /etc/passwd", dir,
+		interp.AllowedPaths([]string{dir}))
+
+	assert.Equal(t, 2, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "/etc/passwd: numeric argument required")
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_HugeInvalidNumericOperand(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	arg := strings.Repeat("9", 64*1024)
+	stdout, stderr, code := testutil.RunScriptCtx(ctx, t,
+		"exit "+arg, dir,
+		interp.AllowedPaths([]string{dir}))
+
+	assert.Equal(t, 2, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "numeric argument required")
+	assert.LessOrEqual(t, len(stderr), len(arg)+64)
+}

--- a/builtins/false/false_vuln_hunt_test.go
+++ b/builtins/false/false_vuln_hunt_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Vuln-hunt campaign: 2026-05-19-codex.
+package falsecmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/rshell/builtins"
+)
+
+type panicReader struct{}
+
+func (panicReader) Read([]byte) (int, error) {
+	panic("false must not read stdin")
+}
+
+type panicWriter struct {
+	name string
+}
+
+func (w panicWriter) Write([]byte) (int, error) {
+	panic(fmt.Sprintf("false must not write %s", w.name))
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_InertFailureInputs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	callCtx := &builtins.CallContext{
+		Stdin:  panicReader{},
+		Stdout: panicWriter{name: "stdout"},
+		Stderr: panicWriter{name: "stderr"},
+		OpenFile: func(context.Context, string, int, os.FileMode) (io.ReadWriteCloser, error) {
+			t.Fatal("false must not open files")
+			return nil, nil
+		},
+	}
+
+	hugeNumericOperand := strings.Repeat("9", 64*1024)
+	got := run(ctx, callCtx, []string{"--help", "--unknown", "--", hugeNumericOperand})
+	want := builtins.Result{Code: 1}
+	if got != want {
+		t.Fatalf("false returned %+v, want %+v", got, want)
+	}
+}

--- a/builtins/grep/grep_vuln_hunt_test.go
+++ b/builtins/grep/grep_vuln_hunt_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package grep_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// vuln-hunt 2026-05-19-codex: overflowing numeric flags must fail during
+// parsing instead of wrapping into small or negative limits.
+func TestVulnHuntBuiltinIntegerOverflow_NumericFlagOverflowRejected(t *testing.T) {
+	dir := t.TempDir()
+	pentestWriteFile(t, dir, "file.txt", "foo\n")
+	huge := strings.Repeat("9", 128)
+
+	for _, flag := range []string{"-m", "-A", "-B", "-C"} {
+		t.Run(flag, func(t *testing.T) {
+			_, stderr, code := grepRun(t, "grep "+flag+" "+huge+" foo file.txt", dir)
+			assert.Equal(t, 1, code)
+			assert.Contains(t, stderr, "grep:")
+		})
+	}
+}
+
+// vuln-hunt 2026-05-19-codex: if /dev/zero is explicitly allowed, grep still
+// must not block forever on an infinite source without newline delimiters.
+func TestVulnHuntBuiltinSpecialFiles_DevZeroBounded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/dev/zero is Unix-specific")
+	}
+
+	dir := t.TempDir()
+	mustNotHang(t, func() {
+		_, stderr, code := grepRun(t, "grep x /dev/zero", dir, "/dev")
+		assert.Equal(t, 2, code)
+		assert.Contains(t, stderr, "grep:")
+	})
+}

--- a/builtins/internal/diskstats/diskstats_linux_vuln_hunt_test.go
+++ b/builtins/internal/diskstats/diskstats_linux_vuln_hunt_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package diskstats
+
+import (
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntSubsystemDfMountEnumeration_MountInfoPathHardcoded(t *testing.T) {
+	if mountInfoPath != "/proc/self/mountinfo" {
+		t.Fatalf("mountInfoPath = %q, want /proc/self/mountinfo", mountInfoPath)
+	}
+	if strings.Contains(mountInfoPath, "..") {
+		t.Fatalf("mountInfoPath must not contain traversal components: %q", mountInfoPath)
+	}
+}

--- a/builtins/internal/procnetroute/procnetroute_linux_vuln_hunt_test.go
+++ b/builtins/internal/procnetroute/procnetroute_linux_vuln_hunt_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package procnetroute
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeProcNetRouteFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	netDir := filepath.Join(dir, "net")
+	if err := os.MkdirAll(netDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(netDir, "route"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestVulnHuntSubsystemResourceLimitBypass_RouteLineLengthCap(t *testing.T) {
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		strings.Repeat("A", MaxLineBytes+1) + "\n"
+	dir := writeProcNetRouteFile(t, content)
+
+	_, err := ReadRoutes(context.Background(), dir)
+	if err == nil {
+		t.Fatalf("expected overlong route line to fail")
+	}
+	if !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("expected scanner token-too-long error, got %v", err)
+	}
+}
+
+func TestVulnHuntSubsystemResourceLimitBypass_RouteMaxTotalLines(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n")
+	for range MaxTotalLines + 1 {
+		b.WriteString("malformed\n")
+	}
+	dir := writeProcNetRouteFile(t, b.String())
+
+	_, err := ReadRoutes(context.Background(), dir)
+	if !errors.Is(err, ErrMaxTotalLines) {
+		t.Fatalf("expected ErrMaxTotalLines, got %v", err)
+	}
+}
+
+func TestVulnHuntSubsystemResourceLimitBypass_RouteMaxRoutes(t *testing.T) {
+	const row = "eth0\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
+	var b strings.Builder
+	b.WriteString("Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n")
+	for range MaxRoutes + 1 {
+		b.WriteString(row)
+	}
+	dir := writeProcNetRouteFile(t, b.String())
+
+	_, err := ReadRoutes(context.Background(), dir)
+	if !errors.Is(err, ErrMaxRoutes) {
+		t.Fatalf("expected ErrMaxRoutes, got %v", err)
+	}
+}

--- a/builtins/internal/procnetroute/procnetroute_other_vuln_hunt_test.go
+++ b/builtins/internal/procnetroute/procnetroute_other_vuln_hunt_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !linux
+
+package procnetroute
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestVulnHuntSubsystemPlatformDivergence_NonLinuxRouteReaderDoesNotOpenProc(t *testing.T) {
+	_, err := ReadRoutes(context.Background(), DefaultProcPath)
+	if err == nil {
+		t.Fatalf("expected non-Linux platform error")
+	}
+	if !strings.Contains(err.Error(), "not supported on this platform") {
+		t.Fatalf("expected platform error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "open ") {
+		t.Fatalf("non-Linux route reader attempted direct open: %v", err)
+	}
+}

--- a/builtins/internal/procnetroute/procnetroute_vuln_hunt_test.go
+++ b/builtins/internal/procnetroute/procnetroute_vuln_hunt_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package procnetroute
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntSubsystemInvariantViolation_RejectsTraversalProcPath(t *testing.T) {
+	paths := []string{
+		"/proc/../tmp",
+		"../proc",
+		"/tmp/proc..backup",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			_, err := ReadRoutes(context.Background(), path)
+			if err == nil {
+				t.Fatalf("expected unsafe procPath error")
+			}
+			if !strings.Contains(err.Error(), "unsafe procPath") {
+				t.Fatalf("expected unsafe procPath error, got %v", err)
+			}
+			if strings.Contains(err.Error(), "open ") {
+				t.Fatalf("unsafe procPath reached open path: %v", err)
+			}
+		})
+	}
+}
+
+func TestVulnHuntSubsystemThreatModelCoverage_DefaultProcPathIsCanonicalProc(t *testing.T) {
+	if DefaultProcPath != "/proc" {
+		t.Fatalf("DefaultProcPath = %q, want /proc", DefaultProcPath)
+	}
+}

--- a/builtins/internal/procnetsocket/procnetsocket_linux_vuln_hunt_test.go
+++ b/builtins/internal/procnetsocket/procnetsocket_linux_vuln_hunt_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package procnetsocket
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeProcNetSocketFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	netDir := filepath.Join(dir, "net")
+	if err := os.MkdirAll(netDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(netDir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestVulnHuntSubsystemResourceLimitBypass_SocketLineLengthCap(t *testing.T) {
+	content := "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n" +
+		strings.Repeat("A", MaxLineBytes+1) + "\n"
+	dir := writeProcNetSocketFile(t, "tcp", content)
+
+	_, err := ReadTCP4(context.Background(), dir)
+	if err == nil {
+		t.Fatalf("expected overlong socket line to fail")
+	}
+	if !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("expected scanner token-too-long error, got %v", err)
+	}
+}
+
+func TestVulnHuntSubsystemResourceLimitBypass_SocketMaxTotalLines(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n")
+	for range MaxTotalLines + 1 {
+		b.WriteString("malformed\n")
+	}
+	dir := writeProcNetSocketFile(t, "tcp", b.String())
+
+	_, err := ReadTCP4(context.Background(), dir)
+	if !errors.Is(err, ErrMaxTotalLines) {
+		t.Fatalf("expected ErrMaxTotalLines, got %v", err)
+	}
+}
+
+func TestVulnHuntSubsystemResourceLimitBypass_SocketMaxEntries(t *testing.T) {
+	const row = "0: 0100007F:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 12345 1 0000000000000000 100 0 0 10 0\n"
+	var b strings.Builder
+	b.WriteString("  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n")
+	for range MaxEntries + 1 {
+		b.WriteString(row)
+	}
+	dir := writeProcNetSocketFile(t, "tcp", b.String())
+
+	_, err := ReadTCP4(context.Background(), dir)
+	if !errors.Is(err, ErrMaxEntries) {
+		t.Fatalf("expected ErrMaxEntries, got %v", err)
+	}
+}

--- a/builtins/internal/procnetsocket/procnetsocket_other_vuln_hunt_test.go
+++ b/builtins/internal/procnetsocket/procnetsocket_other_vuln_hunt_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !linux
+
+package procnetsocket
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestVulnHuntSubsystemPlatformDivergence_NonLinuxReadersDoNotOpenProc(t *testing.T) {
+	readers := []struct {
+		name string
+		fn   func(context.Context, string) ([]SocketEntry, error)
+	}{
+		{"tcp4", ReadTCP4},
+		{"tcp6", ReadTCP6},
+		{"udp4", ReadUDP4},
+		{"udp6", ReadUDP6},
+		{"unix", ReadUnix},
+	}
+
+	for _, reader := range readers {
+		t.Run(reader.name, func(t *testing.T) {
+			_, err := reader.fn(context.Background(), DefaultProcPath)
+			if err == nil {
+				t.Fatalf("expected non-Linux platform error")
+			}
+			if !strings.Contains(err.Error(), "not supported on this platform") {
+				t.Fatalf("expected platform error, got %v", err)
+			}
+			if strings.Contains(err.Error(), "open ") {
+				t.Fatalf("non-Linux reader attempted direct open: %v", err)
+			}
+		})
+	}
+}

--- a/builtins/internal/procnetsocket/procnetsocket_vuln_hunt_test.go
+++ b/builtins/internal/procnetsocket/procnetsocket_vuln_hunt_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package procnetsocket
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntSubsystemInvariantViolation_RejectsTraversalProcPath(t *testing.T) {
+	ctx := context.Background()
+	readers := []struct {
+		name string
+		fn   func(context.Context, string) ([]SocketEntry, error)
+	}{
+		{"tcp4", ReadTCP4},
+		{"tcp6", ReadTCP6},
+		{"udp4", ReadUDP4},
+		{"udp6", ReadUDP6},
+		{"unix", ReadUnix},
+	}
+	paths := []string{
+		"/proc/../tmp",
+		"../proc",
+		"/tmp/proc..backup",
+	}
+
+	for _, reader := range readers {
+		for _, path := range paths {
+			t.Run(reader.name+"/"+path, func(t *testing.T) {
+				_, err := reader.fn(ctx, path)
+				if err == nil {
+					t.Fatalf("expected unsafe procPath error")
+				}
+				if !strings.Contains(err.Error(), "unsafe procPath") {
+					t.Fatalf("expected unsafe procPath error, got %v", err)
+				}
+				if strings.Contains(err.Error(), "open ") {
+					t.Fatalf("unsafe procPath reached open path: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestVulnHuntSubsystemThreatModelCoverage_DefaultProcPathIsCanonicalProc(t *testing.T) {
+	if DefaultProcPath != "/proc" {
+		t.Fatalf("DefaultProcPath = %q, want /proc", DefaultProcPath)
+	}
+	clean, err := validateProcPath(DefaultProcPath)
+	if err != nil {
+		t.Fatalf("default proc path rejected: %v", err)
+	}
+	if clean != "/proc" {
+		t.Fatalf("validateProcPath(%q) = %q, want /proc", DefaultProcPath, clean)
+	}
+}

--- a/builtins/internal/procnetsocket/procnetsocket_vuln_hunt_test.go
+++ b/builtins/internal/procnetsocket/procnetsocket_vuln_hunt_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package procnetsocket
 
 import (

--- a/builtins/internal/procsyskernel/procsyskernel_fifo_vuln_hunt_test.go
+++ b/builtins/internal/procsyskernel/procsyskernel_fifo_vuln_hunt_test.go
@@ -40,7 +40,7 @@ func TestVulnHuntUnameProcReaderRejectsFIFOWithoutBlocking(t *testing.T) {
 		if !strings.Contains(err.Error(), "not a regular file") {
 			t.Fatalf("expected regular-file rejection, got %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("ReadFile blocked on FIFO")
 	}
 }

--- a/builtins/internal/procsyskernel/procsyskernel_fifo_vuln_hunt_test.go
+++ b/builtins/internal/procsyskernel/procsyskernel_fifo_vuln_hunt_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !windows
+
+package procsyskernel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestVulnHuntUnameProcReaderRejectsFIFOWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	kernelDir := filepath.Join(dir, "sys", "kernel")
+	if err := os.MkdirAll(kernelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(kernelDir, "hostname"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ReadFile(dir, "hostname")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected FIFO to be rejected")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("expected regular-file rejection, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ReadFile blocked on FIFO")
+	}
+}

--- a/builtins/internal/procsyskernel/procsyskernel_vuln_hunt_test.go
+++ b/builtins/internal/procsyskernel/procsyskernel_vuln_hunt_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package procsyskernel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntUnameProcReaderRejectsTraversalProcPath(t *testing.T) {
+	paths := []string{
+		"/proc/../tmp",
+		"../proc",
+		filepath.Join(t.TempDir(), "proc..backup"),
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			_, err := ReadFile(path, "ostype")
+			if err == nil {
+				t.Fatalf("expected unsafe procPath error")
+			}
+			if !strings.Contains(err.Error(), "unsafe procPath") {
+				t.Fatalf("expected unsafe procPath error, got %v", err)
+			}
+			if strings.Contains(err.Error(), "open ") {
+				t.Fatalf("unsafe procPath reached open path: %v", err)
+			}
+		})
+	}
+}
+
+func TestVulnHuntUnameProcReaderRejectsPathLikeKernelNames(t *testing.T) {
+	procPath := t.TempDir()
+	names := []string{
+		"../hostname",
+		"sys/kernel/hostname",
+		"host..name",
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			_, err := ReadFile(procPath, name)
+			if err == nil {
+				t.Fatalf("expected unsafe name error")
+			}
+			if !strings.Contains(err.Error(), "unsafe name") {
+				t.Fatalf("expected unsafe name error, got %v", err)
+			}
+			if strings.Contains(err.Error(), "open ") {
+				t.Fatalf("unsafe name reached open path: %v", err)
+			}
+		})
+	}
+}
+
+func TestVulnHuntUnameProcReaderCapsKernelFileReads(t *testing.T) {
+	dir := t.TempDir()
+	kernelDir := filepath.Join(dir, "sys", "kernel")
+	if err := os.MkdirAll(kernelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := strings.Repeat("A", 8192)
+	if err := os.WriteFile(filepath.Join(kernelDir, "hostname"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFile(dir, "hostname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 4096 {
+		t.Fatalf("ReadFile returned %d bytes, want 4096", len(got))
+	}
+	if got != strings.Repeat("A", 4096) {
+		t.Fatalf("ReadFile returned unexpected truncated content")
+	}
+}

--- a/builtins/ping/builtin_ping_pentest_test.go
+++ b/builtins/ping/builtin_ping_pentest_test.go
@@ -64,6 +64,42 @@ func TestPingPentestRecordRouteRejected(t *testing.T) {
 	assert.Contains(t, stderr, "ping:")
 }
 
+func TestPingPentestDangerousLongFlagsRejected(t *testing.T) {
+	tests := []string{
+		"ping --flood 127.0.0.1",
+		"ping --broadcast 255.255.255.255",
+		"ping --size=65507 localhost",
+		"ping --interface=lo localhost",
+		"ping --pattern=ff localhost",
+		"ping --record-route localhost",
+	}
+	for _, script := range tests {
+		t.Run(script, func(t *testing.T) {
+			_, stderr, code := cmdRun(t, script)
+			assert.Equal(t, 1, code)
+			assert.Contains(t, stderr, "ping:")
+			assert.Contains(t, stderr, "unrecognized option")
+		})
+	}
+}
+
+func TestPingPentestClusteredDangerousFlagsRejected(t *testing.T) {
+	tests := []string{
+		"ping -fb 127.0.0.1",
+		"ping -qf 127.0.0.1",
+		"ping -4f 127.0.0.1",
+		"ping -R4 127.0.0.1",
+	}
+	for _, script := range tests {
+		t.Run(script, func(t *testing.T) {
+			_, stderr, code := cmdRun(t, script)
+			assert.Equal(t, 1, code)
+			assert.Contains(t, stderr, "ping:")
+			assert.Contains(t, stderr, "invalid option")
+		})
+	}
+}
+
 // ============================================================================
 // Integer overflow / boundary inputs
 // ============================================================================
@@ -94,12 +130,26 @@ func TestPingPentestCountOverflow(t *testing.T) {
 	assert.NoError(t, ctx.Err(), "large count should not hang (clamped + DNS fails fast)")
 }
 
+func TestPingPentestCountParseOverflowRejected(t *testing.T) {
+	_, stderr, code := cmdRun(t, "ping -c 999999999999999999999 no-such-host-xyzzy.invalid")
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "ping:")
+	assert.Contains(t, stderr, "invalid argument")
+}
+
 func TestPingPentestIntervalTooShort(t *testing.T) {
 	// Interval below 200ms floor; should not hang.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, _, _ = runScriptCtx(ctx, t, "ping -c 1 -i 1ns no-such-host-xyzzy.invalid")
 	assert.NoError(t, ctx.Err())
+}
+
+func TestPingPentestSubNanosecondDurationsClamped(t *testing.T) {
+	_, stderr, code := cmdRun(t, "ping -c 1 -W 0.0000000001 -i 0.0000000001 no-such-host-xyzzy.invalid")
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "ping: warning: -W 0s out of range")
+	assert.Contains(t, stderr, "ping: warning: -i 0s out of range")
 }
 
 // ============================================================================
@@ -123,6 +173,32 @@ func TestPingPentestLongHostname(t *testing.T) {
 	_, _, code := runScriptCtx(ctx, t, "ping -c 1 -- "+host)
 	assert.Equal(t, 1, code, "long hostname should fail with exit 1")
 	assert.NoError(t, ctx.Err(), "should not hang on long hostname")
+}
+
+func TestPingPentestPathLikeHostsDoNotReadFiles(t *testing.T) {
+	tests := []string{
+		"@/etc/passwd",
+		"/etc/passwd",
+		"../../etc/passwd",
+		"/dev/null",
+	}
+	for _, host := range tests {
+		t.Run(host, func(t *testing.T) {
+			stdout, stderr, code := cmdRun(t, "ping -c 1 -- "+host)
+			assert.Equal(t, 1, code)
+			assert.Empty(t, stdout)
+			assert.Contains(t, stderr, "ping:")
+			assert.NotContains(t, stdout+stderr, "root:")
+		})
+	}
+}
+
+func TestPingPentestDoubleDashPreservesFlagLikeHost(t *testing.T) {
+	stdout, stderr, code := cmdRun(t, "ping -c 1 -- -f")
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "ping:")
+	assert.NotContains(t, stderr, "invalid option")
 }
 
 func TestPingPentestEmptyHostname(t *testing.T) {

--- a/builtins/printf/printf_vuln_hunt_test.go
+++ b/builtins/printf/printf_vuln_hunt_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package printf_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/rshell/internal/interpoption"
+	"github.com/DataDog/rshell/interp"
+)
+
+// Campaign: vuln-hunt/2026-05-19-codex. These tests pin adversarial
+// printf surfaces that should remain public-safe blocked-attack regressions.
+
+func TestVulnHuntBuiltinResourceExhaustion_LiteralWidthOverflowDoesNotAllocate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	format := "%" + strings.Repeat("9", 2048) + "s\\n"
+	stdout, _, code := runScriptCtx(ctx, t, "printf '"+format+"' x", "")
+
+	assert.Equal(t, 0, code)
+	assert.Less(t, len(stdout), 1024)
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_LiteralPrecisionOverflowDoesNotAllocate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	format := "%." + strings.Repeat("9", 2048) + "f\\n"
+	stdout, _, code := runScriptCtx(ctx, t, "printf '"+format+"' 3.14", "")
+
+	assert.Equal(t, 0, code)
+	assert.Less(t, len(stdout), 1024)
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_OutputLimitStopsLargeFormatReuse(t *testing.T) {
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(`printf "%10000s\n"`+strings.Repeat(" x", 1200)), "")
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	runner, err := interp.New(
+		interp.StdIO(nil, &stdout, &stderr),
+		interpoption.AllowAllCommands().(interp.RunnerOption),
+	)
+	require.NoError(t, err)
+	defer runner.Close()
+
+	err = runner.Run(context.Background(), prog)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, interp.ErrOutputLimitExceeded), "got %v", err)
+	assert.LessOrEqual(t, stdout.Len(), 10*1024*1024)
+	assert.Empty(t, stderr.String())
+}

--- a/builtins/ps/ps_procpath_linux_test.go
+++ b/builtins/ps/ps_procpath_linux_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/rshell/builtins/internal/procinfo"
 	"github.com/stretchr/testify/require"
 	"mvdan.cc/sh/v3/syntax"
 
@@ -198,6 +199,23 @@ func TestProcPathFakeProcByPID(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "1") {
 		t.Errorf("expected PID 1 in output; got:\n%s", stdout)
+	}
+}
+
+func TestProcPathFakeProcLongCmdlineTruncated(t *testing.T) {
+	procPath := writeFakeProc(t, 1, "fakeinit")
+	longCmd := strings.Repeat("a", procinfo.MaxCmdLen+1024)
+	require.NoError(t, os.WriteFile(filepath.Join(procPath, "1", "cmdline"), []byte(longCmd+"\x00"), 0o644))
+
+	stdout, stderr, code := runScriptWithProcPath(t, "ps -p 1", procPath)
+	if code != 0 {
+		t.Fatalf("ps -p 1 with long fake cmdline exited %d; stderr: %s", code, stderr)
+	}
+	if strings.Contains(stdout, strings.Repeat("a", procinfo.MaxCmdLen+1)) {
+		t.Fatalf("cmdline was not truncated to MaxCmdLen; output length=%d", len(stdout))
+	}
+	if !strings.Contains(stdout, strings.Repeat("a", 128)) {
+		t.Fatalf("expected truncated command content in output, got:\n%s", stdout)
 	}
 }
 

--- a/builtins/ps/ps_test.go
+++ b/builtins/ps/ps_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"mvdan.cc/sh/v3/syntax"
 
@@ -255,6 +256,61 @@ func TestPSUnknownFlag(t *testing.T) {
 	_, _, code := runScript(t, "ps --unknownflag")
 	if code != 1 {
 		t.Errorf("expected exit code 1 for unknown flag, got %d", code)
+	}
+}
+
+func TestPSPentestUnsupportedDisclosureFlagsRejected(t *testing.T) {
+	tests := []string{
+		"ps -o pid",
+		"ps --forest",
+		"ps --sort pid",
+		"ps --cols 200",
+		"ps aux",
+	}
+	for _, script := range tests {
+		t.Run(script, func(t *testing.T) {
+			_, stderr, code := runScript(t, script)
+			if code != 1 {
+				t.Fatalf("expected %q to exit 1, got %d", script, code)
+			}
+			if !strings.Contains(stderr, "ps:") {
+				t.Fatalf("expected ps error for %q, got stderr=%q", script, stderr)
+			}
+		})
+	}
+}
+
+func TestPSPentestLargePIDListDoesNotHang(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("ps -p ")
+	for pid := 1_000_000; pid < 1_005_000; pid++ {
+		if pid > 1_000_000 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.Itoa(pid))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(b.String()), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outBuf, errBuf bytes.Buffer
+	runner, err := interp.New(interp.StdIO(nil, &outBuf, &errBuf), interpoption.AllowAllCommands().(interp.RunnerOption))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runner.Close()
+	runErr := runner.Run(ctx, prog)
+	if ctx.Err() != nil {
+		t.Fatalf("large PID list did not finish before context deadline: %v", ctx.Err())
+	}
+	var es interp.ExitStatus
+	if !errors.As(runErr, &es) || int(es) != 1 {
+		t.Fatalf("expected missing PID list to exit 1, got err=%v stdout=%q stderr=%q", runErr, outBuf.String(), errBuf.String())
 	}
 }
 

--- a/builtins/read/read_vuln_hunt_test.go
+++ b/builtins/read/read_vuln_hunt_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// vuln-hunt campaign: 2026-05-19-codex
+// Target: read (builtin)
+
+package read
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+type infiniteByteReader struct {
+	b byte
+}
+
+func (r infiniteByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_BackslashContinuationConsumedCap(t *testing.T) {
+	input := strings.Repeat("\\\n", MaxReadBytes/2+2)
+	line, eof, err := readInput(context.Background(), strings.NewReader(input), '\n', false, -1, false, false)
+	if err == nil {
+		t.Fatalf("expected consumed-input cap error, got line length=%d eof=%v", len(line), eof)
+	}
+	if got, want := err.Error(), fmt.Sprintf("input exceeds maximum of %d bytes", MaxReadBytes); got != want {
+		t.Fatalf("got err=%q, want %q", got, want)
+	}
+	if line != "" {
+		t.Fatalf("continuation-only input should not append data, got %q", line)
+	}
+}
+
+func TestVulnHuntBuiltinSpecialFiles_NULStreamConsumedCap(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		line, eof, err := readInput(ctx, infiniteByteReader{b: 0}, '\n', true, -1, false, false)
+		if line != "" {
+			done <- fmt.Errorf("NUL-only stream should not append data, got %q", line)
+			return
+		}
+		if eof {
+			done <- errors.New("infinite stream unexpectedly returned EOF")
+			return
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected consumed-input cap or context error")
+		}
+		want := fmt.Sprintf("input exceeds maximum of %d bytes", MaxReadBytes)
+		if err.Error() != want && !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("readInput did not return for an infinite NUL stream")
+	}
+}

--- a/builtins/sed/sed_vuln_hunt_test.go
+++ b/builtins/sed/sed_vuln_hunt_test.go
@@ -8,11 +8,21 @@
 package sed_test
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/DataDog/rshell/builtins/testutil"
+	"github.com/DataDog/rshell/internal/interpoption"
 	"github.com/DataDog/rshell/interp"
 )
 
@@ -60,4 +70,62 @@ func TestVulnHuntBuiltinIntegerOverflow_LargeAddress(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Campaign: vuln-hunt/2026-05-19-codex. These are public-safe
+// blocked-attack regressions for sed.
+
+func TestVulnHuntBuiltinFileAccessBypass_SymlinkOperandOutsideAllowedPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires platform-specific privileges on Windows")
+	}
+
+	allowed := t.TempDir()
+	secret := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(secret, "secret.txt"), []byte("secret words\n"), 0644))
+	require.NoError(t, os.Symlink(filepath.Join(secret, "secret.txt"), filepath.Join(allowed, "escape_link")))
+
+	stdout, stderr, code := testutil.RunScript(t,
+		"sed 's/secret/public/' escape_link", allowed,
+		interp.AllowedPaths([]string{allowed}))
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "sed:")
+	assert.NotContains(t, stdout+stderr, "secret words")
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_OutputLimitStopsPrintAmplification(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.txt"), []byte(strings.Repeat("x\n", 3_000_000)), 0644))
+
+	prog, err := syntax.NewParser().Parse(strings.NewReader("sed p big.txt"), "")
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	runner, err := interp.New(
+		interp.StdIO(nil, &stdout, &stderr),
+		interpoption.AllowAllCommands().(interp.RunnerOption),
+		interp.AllowedPaths([]string{dir}),
+	)
+	require.NoError(t, err)
+	defer runner.Close()
+	runner.Dir = dir
+
+	err = runner.Run(context.Background(), prog)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, interp.ErrOutputLimitExceeded), "got %v", err)
+	assert.LessOrEqual(t, stdout.Len(), 10*1024*1024)
+	assert.Empty(t, stderr.String())
+}
+
+func TestVulnHuntBuiltinIntegerOverflow_GroupDepthCap(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "input.txt"), []byte("x\n"), 0644))
+	script := strings.Repeat("{", 300) + "p" + strings.Repeat("}", 300)
+
+	_, stderr, code := testutil.RunScript(t,
+		"sed '"+script+"' input.txt", dir,
+		interp.AllowedPaths([]string{dir}))
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "group nesting depth limit exceeded")
 }

--- a/builtins/ss/ss_vuln_hunt_test.go
+++ b/builtins/ss/ss_vuln_hunt_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package ss_test
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntSubsystemInvariantViolation_SSPathLikeOperandsNotOpened(t *testing.T) {
+	pathOperand := filepath.Join(t.TempDir(), "attacker-controlled-proc-root")
+	stdout, stderr, code := cmdRun(t, "ss -- "+strconv.Quote(pathOperand))
+
+	assert.True(t, code == 0 || code == 1, "unexpected exit code %d", code)
+	assert.NotContains(t, stdout, pathOperand)
+	assert.NotContains(t, stderr, pathOperand)
+	assert.NotContains(t, stderr, "attacker-controlled-proc-root")
+}

--- a/builtins/ss/ss_vuln_hunt_test.go
+++ b/builtins/ss/ss_vuln_hunt_test.go
@@ -24,3 +24,26 @@ func TestVulnHuntSubsystemInvariantViolation_SSPathLikeOperandsNotOpened(t *test
 	assert.NotContains(t, stderr, pathOperand)
 	assert.NotContains(t, stderr, "attacker-controlled-proc-root")
 }
+
+func TestVulnHuntBuiltinFlagDrivenExploit_DangerousFlagsWithArgumentsRejected(t *testing.T) {
+	cases := []string{
+		"ss --filter=/etc/passwd",
+		"ss -F/etc/passwd",
+		"ss --net=/proc/1/ns/net",
+		"ss -N/proc/1/ns/net",
+		"ss --processes",
+		"ss --kill",
+		"ss --events",
+		"ss --resolve",
+		"ss --bpf",
+	}
+
+	for _, script := range cases {
+		t.Run(script, func(t *testing.T) {
+			stdout, stderr, code := cmdRun(t, script)
+			assert.Equal(t, 1, code)
+			assert.Empty(t, stdout)
+			assert.Contains(t, stderr, "ss:")
+		})
+	}
+}

--- a/builtins/strings_cmd/strings_cmd_vuln_hunt_test.go
+++ b/builtins/strings_cmd/strings_cmd_vuln_hunt_test.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package strings_cmd_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/rshell/internal/interpoption"
+	"github.com/DataDog/rshell/interp"
+)
+
+// Campaign: vuln-hunt/2026-05-19-codex. These are public-safe
+// blocked-attack regressions for strings_cmd.
+
+func TestVulnHuntBuiltinIntegerOverflow_MinLenBounds(t *testing.T) {
+	dir := t.TempDir()
+	writeFileBytes(t, dir, "data.bin", []byte("secret_data\n"))
+
+	for _, script := range []string{
+		"strings -n -1 data.bin",
+		"strings --bytes=-1 data.bin",
+		"strings -n 2147483648 data.bin",
+	} {
+		stdout, stderr, code := runStrings(t, script, dir)
+		assert.Equal(t, 1, code, script)
+		assert.Empty(t, stdout, script)
+		assert.Contains(t, stderr, "strings:", script)
+	}
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_OutputLimitStopsSeparatorAmplification(t *testing.T) {
+	dir := t.TempDir()
+	var input bytes.Buffer
+	for range 1200 {
+		input.WriteString("a")
+		input.WriteByte(0)
+	}
+	writeFileBytes(t, dir, "input.bin", input.Bytes())
+
+	separator := strings.Repeat("x", 10_000)
+	script := "strings -n 1 -s '" + separator + "' input.bin"
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	runner, err := interp.New(
+		interp.StdIO(nil, &stdout, &stderr),
+		interpoption.AllowAllCommands().(interp.RunnerOption),
+		interp.AllowedPaths([]string{dir}),
+	)
+	require.NoError(t, err)
+	defer runner.Close()
+	runner.Dir = dir
+
+	err = runner.Run(context.Background(), prog)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, interp.ErrOutputLimitExceeded), "got %v", err)
+	assert.LessOrEqual(t, stdout.Len(), 10*1024*1024)
+	assert.Empty(t, stderr.String())
+}
+
+func TestVulnHuntBuiltinFileAccessBypass_DirectorySymlinkDoesNotLeakMetadata(t *testing.T) {
+	allowed := t.TempDir()
+	secret := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(secret, "secret_dir"), 0755))
+	require.NoError(t, os.Symlink(filepath.Join(secret, "secret_dir"), filepath.Join(allowed, "dir_link")))
+
+	stdout, stderr, code := runStrings(t, "strings dir_link", allowed)
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "strings:")
+	assert.NotContains(t, stderr, "is a directory")
+}

--- a/builtins/testcmd/testcmd_vuln_hunt_test.go
+++ b/builtins/testcmd/testcmd_vuln_hunt_test.go
@@ -1,0 +1,193 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package testcmd_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/rshell/internal/interpoption"
+	"github.com/DataDog/rshell/interp"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func runTestcmdScriptErr(t *testing.T, ctx context.Context, script, dir string, opts ...interp.RunnerOption) (stdout, stderr string, exitCode int, runErr error) {
+	t.Helper()
+
+	prog, err := syntax.NewParser().Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	var outBuf, errBuf bytes.Buffer
+	allOpts := append([]interp.RunnerOption{interp.StdIO(nil, &outBuf, &errBuf)}, opts...)
+	runner, err := interp.New(allOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { runner.Close() })
+	if dir != "" {
+		runner.Dir = dir
+	}
+
+	runErr = runner.Run(ctx, prog)
+	if runErr != nil {
+		var es interp.ExitStatus
+		if errors.As(runErr, &es) {
+			exitCode = int(es)
+		} else {
+			exitCode = -1
+		}
+	}
+	return outBuf.String(), errBuf.String(), exitCode, runErr
+}
+
+func TestVulnHuntGTFOBinsKnown_TestcmdCannotCreateFilesWithRedirect(t *testing.T) {
+	dir := t.TempDir()
+
+	stdout, stderr, code := runScript(t,
+		"test -n x > created.txt\n",
+		dir,
+		interp.AllowedPaths([]string{dir}),
+	)
+	assert.Equal(t, 2, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "> file redirection is not supported")
+	_, err := os.Stat(filepath.Join(dir, "created.txt"))
+	assert.True(t, errors.Is(err, os.ErrNotExist), "created.txt should not exist, stat err=%v", err)
+}
+
+func TestVulnHuntFileRead_TestcmdSymlinkEscapeDoesNotFollowOutsideAllowedPaths(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(allowed, 0o755))
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	writeFile(t, outside, "secret.txt", "classified\n")
+	if err := os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(allowed, "link.txt")); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+
+	stdout, stderr, code := runScript(t,
+		"test -f link.txt; echo f=$?\n"+
+			"test -e link.txt; echo e=$?\n"+
+			"test -h link.txt; echo h=$?\n",
+		allowed,
+		interp.AllowedPaths([]string{allowed}),
+	)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "f=1\ne=1\nh=0\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestVulnHuntFileRead_TestcmdOutsideFileComparisonsDoNotLeakExistence(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(allowed, 0o755))
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	writeFile(t, allowed, "inside.txt", "inside\n")
+	writeFile(t, outside, "outside.txt", "outside\n")
+
+	existingOutside := filepath.Join(outside, "outside.txt")
+	missingOutside := filepath.Join(outside, "missing.txt")
+	script := "test inside.txt -nt " + existingOutside + "; echo existing_right=$?\n" +
+		"test inside.txt -nt " + missingOutside + "; echo missing_right=$?\n" +
+		"test " + existingOutside + " -nt inside.txt; echo existing_left=$?\n" +
+		"test " + missingOutside + " -nt inside.txt; echo missing_left=$?\n" +
+		"test " + existingOutside + " -ot inside.txt; echo existing_left_ot=$?\n" +
+		"test " + missingOutside + " -ot inside.txt; echo missing_left_ot=$?\n"
+
+	stdout, stderr, code := runScript(t, script, allowed, interp.AllowedPaths([]string{allowed}))
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Equal(t,
+		"existing_right=0\n"+
+			"missing_right=0\n"+
+			"existing_left=1\n"+
+			"missing_left=1\n"+
+			"existing_left_ot=0\n"+
+			"missing_left_ot=0\n",
+		stdout)
+}
+
+func TestVulnHuntFlagAbuse_TestcmdFlagLikeValuesRemainOperands(t *testing.T) {
+	stdout, stderr, code := runScript(t,
+		"test --no-such-flag; echo unknown=$?\n"+
+			"test --; echo dashdash=$?\n"+
+			`test "-f" = "-f"; echo flagstring=$?`+"\n",
+		"",
+	)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "unknown=0\ndashdash=0\nflagstring=0\n", stdout)
+}
+
+func TestVulnHuntStdinAbuse_TestcmdIgnoresPipeInput(t *testing.T) {
+	stdout, stderr, code := runScript(t,
+		`printf "classified\n" | test -n ok; echo pipe_true=$?`+"\n"+
+			`printf "classified\n" | test; echo pipe_empty=$?`+"\n",
+		"",
+	)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "pipe_true=0\npipe_empty=1\n", stdout)
+}
+
+func TestVulnHuntParserConfusion_TestcmdBangDisambiguationEdges(t *testing.T) {
+	stdout, stderr, code := runScript(t,
+		"test a -a !; echo literal_bang=$?\n"+
+			"test -n x -a !; echo missing_negand=$?\n"+
+			"test ! = !; echo bang_compare=$?\n",
+		"",
+	)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stderr, "test: missing argument")
+	assert.Equal(t, "literal_bang=0\nmissing_negand=2\nbang_compare=0\n", stdout)
+}
+
+func TestVulnHuntResourceExhaustion_TestcmdDeepNegationRejected(t *testing.T) {
+	script := "test " + strings.Repeat("! ", 200) + `"x"`
+	_, stderr, code := runScript(t, script, "")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "too deeply nested")
+}
+
+func TestVulnHuntSignalContext_PreCanceledTestcmdDoesNotDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stdout, stderr, _, err := runTestcmdScriptErr(t, ctx, "test -n SHOULD_NOT_RUN\n", "", interpoption.AllowAllCommands().(interp.RunnerOption))
+	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestVulnHuntCompositionAttack_ExpandedOutsidePathStaysSandboxed(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(allowed, 0o755))
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	writeFile(t, outside, "secret.txt", "classified\n")
+
+	stdout, stderr, code := runScript(t,
+		"target="+filepath.ToSlash(filepath.Join(outside, "secret.txt"))+"\n"+
+			`test -f "$target"; echo expanded=$?`+"\n"+
+			`[ -f "$target" ]; echo bracket=$?`+"\n",
+		allowed,
+		interp.AllowedPaths([]string{allowed}),
+	)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "expanded=1\nbracket=1\n", stdout)
+}

--- a/builtins/tests/ip/ip_vuln_hunt_linux_test.go
+++ b/builtins/tests/ip/ip_vuln_hunt_linux_test.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package ip_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntBuiltinFileAccessBypass_PathLikeOperandsDoNotSelectRouteFile(t *testing.T) {
+	writeProcNetRoute(t, syntheticProcNetRoute)
+
+	cases := []struct {
+		name       string
+		script     string
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name:       "route_show_path_operand",
+			script:     "ip route show /tmp/attacker-route-table",
+			wantCode:   1,
+			wantStderr: `unsupported argument "/tmp/attacker-route-table"`,
+		},
+		{
+			name:       "route_get_path_operand",
+			script:     "ip route get ../../etc/passwd",
+			wantCode:   1,
+			wantStderr: `invalid address "../../etc/passwd"`,
+		},
+		{
+			name:       "addr_dev_path_operand",
+			script:     "ip addr show dev ../../etc/passwd",
+			wantCode:   1,
+			wantStderr: `cannot find device "../../etc/passwd"`,
+		},
+		{
+			name:       "link_dev_proc_operand",
+			script:     "ip link show dev /proc/net/route",
+			wantCode:   1,
+			wantStderr: `cannot find device "/proc/net/route"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := cmdRun(t, tc.script)
+			if code != tc.wantCode {
+				t.Fatalf("exit code = %d, want %d; stderr=%q", code, tc.wantCode, stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, tc.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr, tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestVulnHuntBuiltinFlagDrivenExploit_EndOfFlagsDoesNotBypassWriteBlocks(t *testing.T) {
+	writeProcNetRoute(t, syntheticProcNetRoute)
+
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{
+			name:   "global_end_of_flags_before_route_add",
+			script: "ip -- route add 10.0.0.0/8 via 192.168.1.1",
+		},
+		{
+			name:   "route_end_of_flags_before_add",
+			script: "ip route -- add 10.0.0.0/8 via 192.168.1.1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := cmdRun(t, tc.script)
+			if code == 0 {
+				t.Fatalf("write-like command unexpectedly succeeded; stdout=%q stderr=%q", stdout, stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !strings.Contains(stderr, "write operations are not permitted") &&
+				!strings.Contains(stderr, "is unknown") {
+				t.Fatalf("stderr = %q, want write-block or unknown-subcommand error", stderr)
+			}
+		})
+	}
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_PreCanceledContextsDoNotHang(t *testing.T) {
+	writeProcNetRoute(t, syntheticProcNetRoute)
+
+	for _, script := range []string{"ip addr show", "ip link show", "ip route show"} {
+		t.Run(script, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			start := time.Now()
+			_, _, _ = runScriptCtx(ctx, t, script, "")
+			if elapsed := time.Since(start); elapsed > 2*time.Second {
+				t.Fatalf("%s took %s with an already-canceled context", script, elapsed)
+			}
+		})
+	}
+}
+
+func TestVulnHuntBuiltinProcFormatParsing_NonContiguousMasksAreSkipped(t *testing.T) {
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"evil0\t0002010A\t00000000\t0001\t0\t0\t0\tF0F0F0F0\t0\t0\t0\n"
+	writeProcNetRoute(t, content)
+
+	stdout, stderr, code := cmdRun(t, "ip route show")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr)
+	}
+	if strings.Contains(stdout, "evil0") {
+		t.Fatalf("non-contiguous-mask route was printed: %q", stdout)
+	}
+}
+
+func TestVulnHuntBuiltinProcFormatParsing_MetricTieBreakAndPathLikeIfaceInert(t *testing.T) {
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"/tmp/evil\t0002010A\t00000000\t0001\t0\t0\t200\t00FFFFFF\t0\t0\t0\n" +
+		"low0\t0002010A\t00000000\t0001\t0\t0\t10\t00FFFFFF\t0\t0\t0\n"
+	writeProcNetRoute(t, content)
+
+	showOut, showErr, showCode := cmdRun(t, "ip route show")
+	if showCode != 0 {
+		t.Fatalf("route show exit code = %d, want 0; stderr=%q", showCode, showErr)
+	}
+	if !strings.Contains(showOut, "dev /tmp/evil metric 200") {
+		t.Fatalf("path-like iface was not treated as inert route data: %q", showOut)
+	}
+
+	getOut, getErr, getCode := cmdRun(t, "ip route get 10.1.2.3")
+	if getCode != 0 {
+		t.Fatalf("route get exit code = %d, want 0; stderr=%q", getCode, getErr)
+	}
+	if !strings.Contains(getOut, "dev low0 metric 10") {
+		t.Fatalf("route get did not select the lower metric same-prefix route: %q", getOut)
+	}
+	if strings.Contains(getOut, "/tmp/evil") {
+		t.Fatalf("high-metric path-like iface shadowed lower metric route: %q", getOut)
+	}
+}

--- a/builtins/tests/uname/uname_vuln_hunt_test.go
+++ b/builtins/tests/uname/uname_vuln_hunt_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package uname_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntUnameRejectsExpandedOperandAsProcName(t *testing.T) {
+	requireLinux(t)
+	dir := t.TempDir()
+	writeFakeProc(t, dir, defaultFakeProc())
+
+	stdout, stderr, code := cmdRun(t, `target=hostname; uname "$target"`, dir)
+
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "uname: extra operand 'hostname'")
+	assert.NotContains(t, stdout, "testhost")
+}
+
+func TestVulnHuntUnameOutputRedirectValidationRunsBeforeProcRead(t *testing.T) {
+	requireLinux(t)
+	dir := t.TempDir()
+	writeFakeProc(t, dir, map[string]string{"ostype": "SHOULD_NOT_PRINT"})
+
+	stdout, stderr, code := cmdRun(t, "uname > created.txt", dir)
+
+	assert.Equal(t, 2, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "> file redirection is not supported")
+	assert.NoFileExists(t, filepath.Join(dir, "created.txt"))
+}
+
+func TestVulnHuntUnameAllOutputStaysBoundedByProcReader(t *testing.T) {
+	requireLinux(t)
+	dir := t.TempDir()
+	kernelDir := filepath.Join(dir, "sys", "kernel")
+	require.NoError(t, os.MkdirAll(kernelDir, 0o755))
+	huge := strings.Repeat("A", 8192)
+	for _, name := range []string{"ostype", "hostname", "osrelease", "version", "arch"} {
+		require.NoError(t, os.WriteFile(filepath.Join(kernelDir, name), []byte(huge), 0o644))
+	}
+
+	stdout, stderr, code := cmdRun(t, "uname -a", dir)
+
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.LessOrEqual(t, len(stdout), 5*4096+5)
+	assert.Contains(t, stdout, strings.Repeat("A", 4096))
+}

--- a/builtins/tr/tr_unix_vuln_hunt_test.go
+++ b/builtins/tr/tr_unix_vuln_hunt_test.go
@@ -1,9 +1,9 @@
-//go:build unix
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
+
+//go:build unix
 
 package tr_test
 

--- a/builtins/tr/tr_unix_vuln_hunt_test.go
+++ b/builtins/tr/tr_unix_vuln_hunt_test.go
@@ -1,0 +1,49 @@
+//go:build unix
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package tr_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/rshell/internal/interpoption"
+	"github.com/DataDog/rshell/interp"
+)
+
+// H8: an explicitly allowed infinite source must stop once the runner context
+// is canceled. This uses io.Discard so the test measures cancellation rather
+// than stdout buffering.
+func TestVulnHuntBuiltinSpecialFiles_DevZeroStopsOnContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	prog, err := syntax.NewParser().Parse(strings.NewReader("tr a b < /dev/zero"), "")
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+	runner, err := interp.New(
+		interp.StdIO(nil, io.Discard, &stderr),
+		interpoption.AllowAllCommands().(interp.RunnerOption),
+		interp.AllowedPaths([]string{"/dev"}),
+	)
+	require.NoError(t, err)
+	defer runner.Close()
+
+	err = runner.Run(ctx, prog)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "got %v", err)
+	assert.Empty(t, stderr.String())
+}

--- a/builtins/true/true_vuln_hunt_test.go
+++ b/builtins/true/true_vuln_hunt_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Vuln-hunt campaign: 2026-05-19-codex.
+package truecmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/rshell/builtins"
+)
+
+type panicReader struct{}
+
+func (panicReader) Read([]byte) (int, error) {
+	panic("true must not read stdin")
+}
+
+type panicWriter struct {
+	name string
+}
+
+func (w panicWriter) Write([]byte) (int, error) {
+	panic(fmt.Sprintf("true must not write %s", w.name))
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_InertInputs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	callCtx := &builtins.CallContext{
+		Stdin:  panicReader{},
+		Stdout: panicWriter{name: "stdout"},
+		Stderr: panicWriter{name: "stderr"},
+		OpenFile: func(context.Context, string, int, os.FileMode) (io.ReadWriteCloser, error) {
+			t.Fatal("true must not open files")
+			return nil, nil
+		},
+	}
+
+	hugeNumericOperand := strings.Repeat("9", 64*1024)
+	got := run(ctx, callCtx, []string{"--help", "--unknown", "--", hugeNumericOperand})
+	if got != (builtins.Result{}) {
+		t.Fatalf("true returned %+v, want zero-value success result", got)
+	}
+}

--- a/builtins/wc/wc_vuln_hunt_test.go
+++ b/builtins/wc/wc_vuln_hunt_test.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package wc_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+)
+
+// Campaign: vuln-hunt/2026-05-19-codex. These are public-safe blocked-attack
+// regressions for wc.
+
+func TestVulnHuntBuiltinFileAccessBypass_SymlinkOperandOutsideAllowedPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires platform-specific privileges on Windows")
+	}
+
+	allowed := t.TempDir()
+	secret := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(secret, "secret.txt"), []byte("secret words\n"), 0644))
+	require.NoError(t, os.Symlink(filepath.Join(secret, "secret.txt"), filepath.Join(allowed, "escape_link")))
+
+	stdout, stderr, code := runScript(t, "wc escape_link", allowed, interp.AllowedPaths([]string{allowed}))
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "wc:")
+	assert.NotContains(t, stdout+stderr, "secret words")
+}
+
+func TestVulnHuntBuiltinResourceExhaustion_ManyFileOperandsCloseHandles(t *testing.T) {
+	dir := t.TempDir()
+	args := make([]string, 0, 200)
+	for i := range 200 {
+		name := fmt.Sprintf("f%03d.txt", i)
+		writeFile(t, dir, name, "x\n")
+		args = append(args, name)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stdout, stderr, code := runScriptCtx(ctx, t, "wc "+strings.Join(args, " "), dir, interp.AllowedPaths([]string{dir}))
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "total")
+	assert.Contains(t, stdout, "200")
+}
+
+func TestVulnHuntBuiltinIntegerOverflow_LargeBoundedCountsAndWidths(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "large.txt", strings.Repeat("word\n", 100_000))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stdout, stderr, code := runScriptCtx(ctx, t, "wc -lwmcL large.txt", dir, interp.AllowedPaths([]string{dir}))
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "100000")
+	assert.Contains(t, stdout, "500000")
+	assert.Contains(t, stdout, "large.txt")
+}
+
+func TestVulnHuntBuiltinSpecialFiles_RepeatedDashDoesNotCorruptState(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "input.txt", "alpha\nbeta\n")
+
+	stdout, stderr, code := cmdRun(t, "cat input.txt | wc - -", dir)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Contains(t, stdout, "-")
+	assert.Contains(t, stdout, "total")
+}

--- a/interp/case_clause_vuln_hunt_test.go
+++ b/interp/case_clause_vuln_hunt_test.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func runCaseClauseVulnHunt(t *testing.T, ctx context.Context, script, dir string, configure func(*Runner)) (string, string, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	r, err := New(StdIO(nil, &stdout, &stderr), allowAllCommandsOpt(), AllowedPaths([]string{dir}))
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	r.Dir = dir
+	r.Reset()
+	if configure != nil {
+		configure(r)
+	}
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	runErr := r.Run(ctx, prog)
+	return stdout.String(), stderr.String(), runErr
+}
+
+func TestVulnHuntShellFeatureRedirectionChain_CaseOutputRedirectDoesNotCreateFile(t *testing.T) {
+	dir := t.TempDir()
+	created := filepath.Join(dir, "created.txt")
+
+	stdout, stderr, err := runCaseClauseVulnHunt(t, context.Background(), "case x in x) echo hidden;; esac > created.txt\n", dir, nil)
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "case statements are not supported\n", stderr)
+	assert.Equal(t, ExitStatus(2), err)
+	_, statErr := os.Stat(created)
+	assert.True(t, os.IsNotExist(statErr), "case output redirect must not create files before validation rejects the case node")
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_CaseArmDoesNotMutateReadonly(t *testing.T) {
+	dir := t.TempDir()
+	var runner *Runner
+
+	stdout, stderr, err := runCaseClauseVulnHunt(t, context.Background(), "case x in x) RO_VAR=hacked echo \"$RO_VAR\";; esac\n", dir, func(r *Runner) {
+		runner = r
+		require.NoError(t, r.writeEnv.Set("RO_VAR", expand.Variable{
+			Set:      true,
+			Kind:     expand.String,
+			Str:      "original",
+			ReadOnly: true,
+		}))
+	})
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "case statements are not supported\n", stderr)
+	assert.Equal(t, ExitStatus(2), err)
+	vr := runner.lookupVar("RO_VAR")
+	assert.Equal(t, "original", vr.Str)
+	assert.True(t, vr.ReadOnly, "case arm execution must not clear readonly state")
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_CaseSubjectCmdSubstDoesNotMutateReadonly(t *testing.T) {
+	dir := t.TempDir()
+	var runner *Runner
+
+	stdout, stderr, err := runCaseClauseVulnHunt(t, context.Background(), "case \"$(RO_VAR=hacked echo subject)\" in subject) echo hidden;; esac\n", dir, func(r *Runner) {
+		runner = r
+		require.NoError(t, r.writeEnv.Set("RO_VAR", expand.Variable{
+			Set:      true,
+			Kind:     expand.String,
+			Str:      "original",
+			ReadOnly: true,
+		}))
+	})
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "case statements are not supported\n", stderr)
+	assert.Equal(t, ExitStatus(2), err)
+	vr := runner.lookupVar("RO_VAR")
+	assert.Equal(t, "original", vr.Str)
+	assert.True(t, vr.ReadOnly, "case subject expansion must not clear readonly state")
+}
+
+func TestVulnHuntShellFeatureSignalContext_CanceledContextDoesNotEnterCaseExecution(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, stderr, err := runCaseClauseVulnHunt(t, ctx, "case x in x) echo hidden;; esac\n", dir, nil)
+
+	assert.Less(t, time.Since(start), 2*time.Second, "case validation should return promptly with a canceled context")
+	assert.Equal(t, "case statements are not supported\n", stderr)
+	assert.Equal(t, ExitStatus(2), err)
+}

--- a/interp/comments_vuln_hunt_test.go
+++ b/interp/comments_vuln_hunt_test.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntShellFeatureRedirectionChain_CommentsCannotCreateHiddenRedirects(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(allowed, "inside.txt"), []byte("inside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"cat < inside.txt # < ../outside/secret.txt\necho ok # > created.txt\n",
+		allowed,
+		allowAllCommandsOpt(),
+		AllowedPaths([]string{allowed}),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	if stdout != "inside\nok\n" {
+		t.Fatalf("stdout=%q, want only inside file and echo output", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(allowed, "created.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("commented output redirect created file, stat err=%v", err)
+	}
+}
+
+func TestVulnHuntShellFeatureExpansionChain_CommentsDoNotRunExpansions(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"A=$(echo safe) # $(<../outside/secret.txt)\necho \"$A\"\necho ok >/dev/null # $(<../outside/secret.txt)\necho visible\n",
+		allowed,
+		allowAllCommandsOpt(),
+		AllowedPaths([]string{allowed}),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	if strings.Contains(stdout, "secret") || strings.Contains(stderr, "secret") {
+		t.Fatalf("commented command substitution ran or leaked content: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stdout != "safe\nvisible\n" {
+		t.Fatalf("stdout=%q, want safe expansion plus visible output", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("commented outside read should not produce sandbox stderr, got %q", stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_CommentsDoNotMaskReadonlyFailures(t *testing.T) {
+	stdout, stderr := runScriptWithReadonly(t, "RO_VAR=hacked # trailing comment\necho after=$RO_VAR\n")
+	if !strings.Contains(stderr, "readonly variable") {
+		t.Fatalf("expected readonly error, stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "hacked") || !strings.Contains(stdout, "after=original") {
+		t.Fatalf("readonly variable changed or was not preserved: stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	stderr = runSimpleCommandValidationFailure(t, "readonly X=1 # trailing comment\n")
+	if !strings.Contains(stderr, "readonly is not supported") {
+		t.Fatalf("expected readonly declaration validation failure, stderr=%q", stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureSignalContext_CommentsDoNotConsumeCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stdout, stderr, _, err := runSimpleCommandScriptCtx(t, ctx, "# comment only\necho SHOULD_NOT_RUN\n", "", allowAllCommandsOpt())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("pre-canceled comment script produced output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureDeclaredVsImplemented_CommentOnlyScriptSizeCap(t *testing.T) {
+	line := "# inert comment payload\n"
+	script := strings.Repeat(line, MaxScriptBytes/len(line)+1)
+	if len(script) <= MaxScriptBytes {
+		t.Fatalf("test bug: generated script length %d <= cap %d", len(script), MaxScriptBytes)
+	}
+
+	_, err := ParseScript(script, "comment-only")
+	if err == nil {
+		t.Fatalf("over-cap comment-only script parsed successfully")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected script-size cap error, got %v", err)
+	}
+}
+
+func TestVulnHuntShellFeatureSubshellIsolation_CommentsDoNotChangeScopeOrStdio(t *testing.T) {
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"X=outer\n( X=inner # comment\n)\necho parent=$X\n( echo hidden # > /dev/null\n) > /dev/null\necho visible\n",
+		"",
+		allowAllCommandsOpt(),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	if stdout != "parent=outer\nvisible\n" {
+		t.Fatalf("stdout=%q, want parent state and stdio restored", stdout)
+	}
+}

--- a/interp/globbing_vuln_hunt_test.go
+++ b/interp/globbing_vuln_hunt_test.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func runGlobbingVulnHunt(t *testing.T, script, dir string, configure func(*Runner), opts ...RunnerOption) (string, string, error, *Runner) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	allOpts := append([]RunnerOption{StdIO(nil, &stdout, &stderr), allowAllCommandsOpt()}, opts...)
+	r, err := New(allOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	r.Dir = dir
+	r.Reset()
+	if configure != nil {
+		configure(r)
+	}
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	runErr := r.Run(context.Background(), prog)
+	return stdout.String(), stderr.String(), runErr, r
+}
+
+func TestVulnHuntShellFeatureRedirectionChain_GlobDefaultNoAllowedPathsBlocked(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("secret\n"), 0644))
+
+	stdout, stderr, err, _ := runGlobbingVulnHunt(t, "echo *\n", dir, nil)
+
+	assert.Equal(t, "", stdout)
+	assert.Contains(t, stderr, "permission denied")
+	var es ExitStatus
+	assert.ErrorAs(t, err, &es)
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_ForLoopGlobDoesNotMutateReadonly(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0644))
+
+	stdout, stderr, err, runner := runGlobbingVulnHunt(t, "for RO_VAR in *.txt; do echo \"$RO_VAR\"; done\n", dir, func(r *Runner) {
+		require.NoError(t, r.writeEnv.Set("RO_VAR", expand.Variable{
+			Set:      true,
+			Kind:     expand.String,
+			Str:      "original",
+			ReadOnly: true,
+		}))
+	}, AllowedPaths([]string{dir}))
+
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", stdout)
+	assert.Contains(t, stderr, "readonly variable")
+	vr := runner.lookupVar("RO_VAR")
+	assert.Equal(t, "original", vr.Str)
+	assert.True(t, vr.ReadOnly)
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_InlineAssignmentGlobDoesNotMutateReadonly(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0644))
+
+	stdout, stderr, err, runner := runGlobbingVulnHunt(t, "RO_VAR=*.txt echo hidden\n", dir, func(r *Runner) {
+		require.NoError(t, r.writeEnv.Set("RO_VAR", expand.Variable{
+			Set:      true,
+			Kind:     expand.String,
+			Str:      "original",
+			ReadOnly: true,
+		}))
+	}, AllowedPaths([]string{dir}))
+
+	assert.Equal(t, "", stdout)
+	assert.Contains(t, stderr, "readonly variable")
+	var es ExitStatus
+	assert.ErrorAs(t, err, &es)
+	vr := runner.lookupVar("RO_VAR")
+	assert.Equal(t, "original", vr.Str)
+	assert.True(t, vr.ReadOnly)
+}

--- a/interp/line_continuation_vuln_hunt_test.go
+++ b/interp/line_continuation_vuln_hunt_test.go
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntShellFeatureRedirectionChain_LineContinuationCannotHideOutputRedirect(t *testing.T) {
+	dir := t.TempDir()
+
+	stdout, stderr, code, err := runSimpleCommandScriptCtx(t,
+		context.Background(),
+		"echo safe \\\n> created.txt\n",
+		dir,
+		allowAllCommandsOpt(),
+		AllowedPaths([]string{dir}),
+	)
+	var es ExitStatus
+	if !errors.As(err, &es) || code != 2 {
+		t.Fatalf("expected validation exit status 2, got code=%d err=%v stdout=%q stderr=%q", code, err, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "> file redirection is not supported") {
+		t.Fatalf("expected output redirect rejection, stderr=%q", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "created.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("line-continued output redirect created file, stat err=%v", err)
+	}
+}
+
+func TestVulnHuntShellFeatureRedirectionChain_LineContinuedInputRedirectUsesSandbox(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "data.txt"), []byte("classified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, _ := runSimpleCommandScript(t,
+		"cat < ../out\\\nside/data.txt\necho after\n",
+		allowed,
+		AllowedCommands([]string{"rshell:cat", "rshell:echo"}),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "classified") || strings.Contains(stderr, "classified") {
+		t.Fatalf("line-continued input redirect leaked outside file: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "after") {
+		t.Fatalf("script did not continue after blocked redirect: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected sandbox stderr for blocked line-continued input redirect")
+	}
+}
+
+func TestVulnHuntShellFeatureExpansionChain_LineContinuedCommandUsesPolicyAndSandbox(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "data.txt"), []byte("classified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, _ := runSimpleCommandScript(t,
+		"c\\\nat ../outside/data.txt\necho after\n",
+		allowed,
+		AllowedCommands([]string{"rshell:cat", "rshell:echo"}),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "classified") || strings.Contains(stderr, "classified") {
+		t.Fatalf("line-continued command leaked outside file: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "after") {
+		t.Fatalf("script did not continue after blocked command read: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected sandbox stderr for line-continued cat command")
+	}
+}
+
+func TestVulnHuntShellFeatureExpansionChain_LineContinuedCommandSubstitutionUsesSandbox(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "data.txt"), []byte("classified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, _ := runSimpleCommandScript(t,
+		"X=$(<../out\\\nside/data.txt)\necho \"X=$X\"\n",
+		allowed,
+		AllowedCommands([]string{"rshell:cat", "rshell:echo"}),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "classified") || strings.Contains(stderr, "classified") {
+		t.Fatalf("line-continued command substitution leaked outside file: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "X=\n") {
+		t.Fatalf("expected blocked substitution to expand empty, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected sandbox stderr for line-continued command substitution")
+	}
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_LineContinuedReadonlyAssignmentRejected(t *testing.T) {
+	stdout, stderr := runScriptWithReadonly(t,
+		"RO_\\\nVAR=hacked\necho after=$RO_VAR\n")
+	if !strings.Contains(stderr, "readonly variable") {
+		t.Fatalf("expected readonly error, stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "hacked") || !strings.Contains(stdout, "after=original") {
+		t.Fatalf("line-continued assignment changed readonly variable: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_LineContinuedForVariableRejected(t *testing.T) {
+	stdout, stderr := runScriptWithReadonly(t,
+		"for RO_\\\nVAR in hacked; do echo loop=$RO_VAR; done\necho after=$RO_VAR\n")
+	if !strings.Contains(stderr, "readonly variable") {
+		t.Fatalf("expected readonly error, stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "hacked") || !strings.Contains(stdout, "after=original") {
+		t.Fatalf("line-continued for variable changed readonly variable: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureSignalContext_PreCanceledLineContinuationDoesNotDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stdout, stderr, _, err := runSimpleCommandScriptCtx(t, ctx, "ec\\\nho SHOULD_NOT_RUN\n", "", allowAllCommandsOpt())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("pre-canceled line-continuation script produced output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureSubshellIsolation_LineContinuedSubshellAssignmentDoesNotLeak(t *testing.T) {
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"X=outer\n( X=in\\\nner; echo sub=$X )\necho parent=$X\n",
+		"",
+		allowAllCommandsOpt(),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	if stdout != "sub=inner\nparent=outer\n" {
+		t.Fatalf("line-continued subshell assignment leaked state: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureParserConfusion_LineContinuationDoesNotHideBlockedConstructs(t *testing.T) {
+	cases := map[string]string{
+		"readonly": "read\\\nonly X=1\n",
+		"pipe_all": "echo err \\\n|& cat\n",
+		"arith":    "echo $((1\\\n+2))\n",
+	}
+	for name, script := range cases {
+		t.Run(name, func(t *testing.T) {
+			stderr := runSimpleCommandValidationFailure(t, script)
+			if stderr == "" {
+				t.Fatalf("expected validation stderr for %q", script)
+			}
+		})
+	}
+}
+
+func TestVulnHuntShellFeatureDeclaredVsImplemented_LineContinuationScriptSizeCap(t *testing.T) {
+	line := "echo x\\\n"
+	script := strings.Repeat(line, MaxScriptBytes/len(line)+1)
+	if len(script) <= MaxScriptBytes {
+		t.Fatalf("test bug: generated script length %d <= cap %d", len(script), MaxScriptBytes)
+	}
+
+	_, err := ParseScript(script, "continued")
+	if err == nil {
+		t.Fatalf("over-cap line-continuation script parsed successfully")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected script-size cap error, got %v", err)
+	}
+}

--- a/interp/logic_ops_vuln_hunt_test.go
+++ b/interp/logic_ops_vuln_hunt_test.go
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func runLogicOpsVulnHunt(t *testing.T, ctx context.Context, script, dir string, stdin io.Reader, configure func(*Runner)) (string, string, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	r, err := New(StdIO(stdin, &stdout, &stderr), allowAllCommandsOpt(), AllowedPaths([]string{dir}))
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	r.Dir = dir
+	r.Reset()
+	if configure != nil {
+		configure(r)
+	}
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+
+	runErr := r.Run(ctx, prog)
+	return stdout.String(), stderr.String(), runErr
+}
+
+func setReadonlyVulnHuntVar(t *testing.T, r *Runner) {
+	t.Helper()
+	require.NoError(t, r.writeEnv.Set("RO_VAR", expand.Variable{
+		Set:      true,
+		Kind:     expand.String,
+		Str:      "original",
+		ReadOnly: true,
+	}))
+}
+
+func TestVulnHuntShellFeatureRedirectionChain_LogicSkippedOutputRedirectDoesNotCreateFile(t *testing.T) {
+	dir := t.TempDir()
+	created := filepath.Join(dir, "created.txt")
+
+	stdout, stderr, err := runLogicOpsVulnHunt(t, context.Background(), "false && echo hidden > created.txt\n", dir, nil, nil)
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "> file redirection is not supported\n", stderr)
+	assert.Equal(t, ExitStatus(2), err)
+	_, statErr := os.Stat(created)
+	assert.True(t, os.IsNotExist(statErr), "skipped output redirect must not create files")
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_LogicSkippedBranchDoesNotMutateReadonly(t *testing.T) {
+	dir := t.TempDir()
+	var runner *Runner
+
+	stdout, stderr, err := runLogicOpsVulnHunt(t, context.Background(), "false && RO_VAR=hacked echo hidden\n", dir, nil, func(r *Runner) {
+		runner = r
+		setReadonlyVulnHuntVar(t, r)
+	})
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "", stderr)
+	assert.Equal(t, ExitStatus(1), err)
+	vr := runner.lookupVar("RO_VAR")
+	assert.Equal(t, "original", vr.Str)
+	assert.True(t, vr.ReadOnly)
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_LogicExecutedBranchPreservesReadonly(t *testing.T) {
+	dir := t.TempDir()
+	var runner *Runner
+
+	stdout, stderr, err := runLogicOpsVulnHunt(t, context.Background(), "RO_VAR=hacked true && echo hidden\n", dir, nil, func(r *Runner) {
+		runner = r
+		setReadonlyVulnHuntVar(t, r)
+	})
+
+	assert.Equal(t, "", stdout)
+	assert.Contains(t, stderr, "readonly variable")
+	assert.Equal(t, ExitStatus(1), err)
+	vr := runner.lookupVar("RO_VAR")
+	assert.Equal(t, "original", vr.Str)
+	assert.True(t, vr.ReadOnly)
+}
+
+func TestVulnHuntShellFeatureSignalContext_LogicSkippedBlockingStdinDoesNotStart(t *testing.T) {
+	dir := t.TempDir()
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+
+	var stdout, stderr bytes.Buffer
+	r, err := New(StdIO(pr, &stdout, &stderr), allowAllCommandsOpt(), AllowedPaths([]string{dir}))
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	r.Dir = dir
+	r.Reset()
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader("false && cat\n"), "")
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Run(context.Background(), prog)
+	}()
+
+	select {
+	case err := <-done:
+		assert.Equal(t, ExitStatus(1), err)
+		assert.Equal(t, "", stdout.String())
+		assert.Equal(t, "", stderr.String())
+	case <-time.After(700 * time.Millisecond):
+		_ = pw.Close()
+		t.Fatal("skipped cat branch started and blocked on stdin")
+	}
+}
+
+func TestVulnHuntShellFeatureSignalContext_LogicCanceledLongChainStops(t *testing.T) {
+	dir := t.TempDir()
+	script := strings.Repeat("true && ", 1000) + "echo hidden\n"
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stdout, _, err := runLogicOpsVulnHunt(t, ctx, script, dir, nil, nil)
+
+	assert.Equal(t, "", stdout)
+	assert.True(t, errors.Is(err, context.Canceled), "canceled context should stop before executing the chain, got %v", err)
+}

--- a/interp/negation_vuln_hunt_test.go
+++ b/interp/negation_vuln_hunt_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func runNegationVulnHunt(t *testing.T, ctx context.Context, script, dir string, opts ...RunnerOption) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	allOpts := []RunnerOption{StdIO(nil, &stdout, &stderr), allowAllCommandsOpt(), AllowedPaths([]string{dir})}
+	allOpts = append(allOpts, opts...)
+	r, err := New(allOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+	r.Dir = dir
+
+	prog, err := syntax.NewParser().Parse(strings.NewReader(script), "")
+	require.NoError(t, err)
+	runErr := r.Run(ctx, prog)
+	return stdout.String(), stderr.String(), runErr
+}
+
+func TestVulnHuntShellFeatureParserConfusion_NegationDoesNotInvertValidationError(t *testing.T) {
+	dir := t.TempDir()
+	created := filepath.Join(dir, "created.txt")
+
+	stdout, stderr, err := runNegationVulnHunt(t, context.Background(), "! echo hidden > created.txt\necho after\n", dir)
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "> file redirection is not supported\n", stderr)
+	assert.Equal(t, ExitStatus(2), err)
+	_, statErr := os.Stat(created)
+	assert.True(t, errors.Is(statErr, os.ErrNotExist), "blocked negated redirect created %s", created)
+}
+
+func TestVulnHuntShellFeatureSignalContext_NegationDoesNotInvertTimeout(t *testing.T) {
+	dir := t.TempDir()
+
+	stdout, stderr, err := runNegationVulnHunt(t, context.Background(), "! while true; do true; done\n", dir, MaxExecutionTime(20*time.Millisecond))
+
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "", stderr)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "negation must not mask timeout, got %v", err)
+}

--- a/interp/parser_lexer_vuln_hunt_test.go
+++ b/interp/parser_lexer_vuln_hunt_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func TestVulnHuntSubsystemParserLexer_NULByteCannotBypassCommandPolicy(t *testing.T) {
+	prog, err := ParseScript("ec\x00ho SHOULD_NOT_RUN\n", "nul-command")
+	if err != nil {
+		return
+	}
+
+	var stdout, stderr bytes.Buffer
+	runner, err := New(StdIO(nil, &stdout, &stderr), AllowedCommands([]string{"rshell:false"}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.Close() })
+
+	runErr := runner.Run(context.Background(), prog)
+	if runErr == nil {
+		t.Fatalf("NUL-mutated command unexpectedly bypassed command policy: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "SHOULD_NOT_RUN") {
+		t.Fatalf("NUL-mutated command bypassed command policy: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}

--- a/interp/pipe_vuln_hunt_test.go
+++ b/interp/pipe_vuln_hunt_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,9 @@ func TestVulnHuntShellFeatureReadonlyBypass_PipelineStagesPreserveReadonly(t *te
 }
 
 func TestVulnHuntShellFeatureSignalContext_PipeWriterStopsAfterReaderExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows broken-pipe error format differs from unix; tested on linux/macos only")
+	}
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "big.txt"),

--- a/interp/pipe_vuln_hunt_test.go
+++ b/interp/pipe_vuln_hunt_test.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// vuln-hunt campaign: 2026-05-19-codex
+// Target: pipe (shell-feature)
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVulnHuntShellFeatureReadonlyBypass_PipelineStagesPreserveReadonly(t *testing.T) {
+	stdout, stderr := runScriptWithReadonly(t,
+		"{ RO_VAR=hacked; echo left=$RO_VAR; } | cat\n"+
+			"echo seed | { RO_VAR=hacked; echo right=$RO_VAR; }\n"+
+			"echo after=$RO_VAR\n")
+
+	assert.Contains(t, stderr, "readonly variable",
+		"pipeline stage assignment to readonly must produce readonly errors")
+	assert.NotContains(t, stdout, "hacked",
+		"pipeline stages must not observe or leak a bypassed readonly value")
+	assert.Contains(t, stdout, "after=original",
+		"parent must retain readonly value after both pipeline stages")
+}
+
+func TestVulnHuntShellFeatureSignalContext_PipeWriterStopsAfterReaderExit(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "big.txt"),
+		[]byte(strings.Repeat("line\n", 256*1024)),
+		0644,
+	))
+
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		AllowedPaths([]string{dir}),
+		StdIO(nil, &stdout, &stderr),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	r.Dir = dir
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = r.Run(ctx, parseScript(t, "cat big.txt | head -n 1\n"))
+	require.NoError(t, err)
+	require.NoError(t, ctx.Err(), "pipeline did not finish before context deadline")
+	assert.Equal(t, "line\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}

--- a/interp/redir_subsystem_vuln_hunt_test.go
+++ b/interp/redir_subsystem_vuln_hunt_test.go
@@ -14,13 +14,16 @@ package interp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 // recordingOpenHandler is a test double that records every call made to
@@ -83,4 +86,183 @@ func TestVulnHuntSubsystemInterpRedirectHandling_InputRedirectGoesThroughOpenHan
 		"input redirect must request read-only access; a writable flag would mean the redirect path widens the sandbox")
 	assert.Equal(t, fileBody, stdout.String(),
 		"cat output should match file body — proves the recorded handler also returned a working file")
+}
+
+type closeRecordingFile struct {
+	io.ReadWriteCloser
+	closed *int
+}
+
+func (f *closeRecordingFile) Close() error {
+	*f.closed++
+	return f.ReadWriteCloser.Close()
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_FailedSecondRedirectClosesFirstAndRestoresStdio(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "first.txt"), []byte("should-not-print\n"), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	r.Reset()
+	r.Dir = dir
+
+	closeCount := 0
+	r.openHandler = func(_ context.Context, path string, flag int, _ os.FileMode) (io.ReadWriteCloser, error) {
+		if path == "blocked.txt" {
+			return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+		}
+		f, err := os.OpenFile(filepath.Join(dir, path), flag, 0)
+		if err != nil {
+			return nil, err
+		}
+		return &closeRecordingFile{ReadWriteCloser: f, closed: &closeCount}, nil
+	}
+
+	err = r.Run(context.Background(), parseScript(t, "cat < first.txt < blocked.txt\necho after\n"))
+	require.NoError(t, err, "stderr=%q", stderr.String())
+	assert.Equal(t, "after\n", stdout.String(),
+		"failed redirect must skip the cat command and restore stdout for the next statement")
+	assert.Contains(t, stderr.String(), "blocked.txt")
+	assert.Equal(t, 1, closeCount, "first redirect file must be closed when a later redirect fails")
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_UnsupportedRedirectsAndProcSubstDoNotOpenFiles(t *testing.T) {
+	cases := []string{
+		"cat <&0\n",
+		"cat <> file.txt\n",
+		"cat <<< hello\n",
+		"cat <(echo secret)\n",
+		"echo hello 3>&1\n",
+		"echo hello >&-\n",
+	}
+	for _, script := range cases {
+		t.Run(script, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			r, err := New(
+				allowAllCommandsOpt(),
+				StdIO(nil, &stdout, &stderr),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = r.Close() })
+			r.Reset()
+
+			openCalls := 0
+			r.openHandler = func(context.Context, string, int, os.FileMode) (io.ReadWriteCloser, error) {
+				openCalls++
+				return nil, errors.New("openHandler should not be called")
+			}
+
+			err = r.Run(context.Background(), parseScript(t, script))
+			require.Error(t, err)
+			var es ExitStatus
+			require.True(t, errors.As(err, &es), "expected validation exit status, got %v", err)
+			assert.Equal(t, ExitStatus(2), es)
+			assert.Equal(t, 0, openCalls, "unsupported redirect reached openHandler; stderr=%q stdout=%q", stderr.String(), stdout.String())
+			assert.Empty(t, stdout.String())
+		})
+	}
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_RuntimeDevNullDefenseRejectsMutatedTarget(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	r.Reset()
+
+	target := filepath.Join(dir, "created.txt")
+	_, err = r.redir(context.Background(), &syntax.Redirect{
+		Op:   syntax.RdrOut,
+		Word: &syntax.Word{Parts: []syntax.WordPart{&syntax.Lit{Value: target}}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), "file redirection is only supported")
+	_, statErr := os.Stat(target)
+	assert.True(t, errors.Is(statErr, os.ErrNotExist), "runtime redirect defense created file, stat err=%v", statErr)
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_DevNullOutputDoesNotOpenFileHandler(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	r.Reset()
+
+	openCalls := 0
+	r.openHandler = func(context.Context, string, int, os.FileMode) (io.ReadWriteCloser, error) {
+		openCalls++
+		return nil, errors.New("openHandler should not be called for /dev/null output")
+	}
+
+	err = r.Run(context.Background(), parseScript(t, "echo hidden >/dev/null\necho visible\n"))
+	require.NoError(t, err, "stderr=%q", stderr.String())
+	assert.Equal(t, "visible\n", stdout.String())
+	assert.Empty(t, stderr.String())
+	assert.Equal(t, 0, openCalls, "/dev/null output redirect must use io.Discard, not openHandler")
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_HeredocCommandSubstitutionUsesSandbox(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(allowed, 0o755))
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("classified\n"), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+		AllowedPaths([]string{allowed}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	r.Dir = allowed
+
+	script := "cat <<EOF\n$(<../outside/secret.txt)\nEOF\necho after\n"
+	err = r.Run(context.Background(), parseScript(t, script))
+	require.NoError(t, err, "stderr=%q", stderr.String())
+	assert.NotContains(t, stdout.String(), "classified")
+	assert.NotContains(t, stderr.String(), "classified")
+	assert.Contains(t, stdout.String(), "after\n")
+	assert.NotEmpty(t, stderr.String(), "sandbox denial should be reported")
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_QuotedHeredocStaysLiteral(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	script := "cat <<'EOF'\n$(echo should-not-run)\n~/literal\nEOF\n"
+	err = r.Run(context.Background(), parseScript(t, script))
+	require.NoError(t, err, "stderr=%q", stderr.String())
+	assert.Equal(t, "$(echo should-not-run)\n~/literal\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestVulnHuntSubsystemInterpRedirectHandling_NoDirectUserPathOpenInRedirectRuntime(t *testing.T) {
+	src, err := os.ReadFile("runner_redir.go")
+	require.NoError(t, err)
+	text := string(src)
+	assert.NotContains(t, text, "os.Open(")
+	assert.NotContains(t, text, "os.OpenFile(")
+	assert.True(t, strings.Contains(text, "os.Pipe()"),
+		"redirect runtime may use os.Pipe for heredocs but must not directly open user paths")
 }

--- a/interp/signal_handling_vuln_hunt_test.go
+++ b/interp/signal_handling_vuln_hunt_test.go
@@ -23,6 +23,8 @@ package interp
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -103,4 +105,37 @@ func TestVulnHuntSubsystemSignalHandling_ParentCtxCancelStopsPipeline(t *testing
 		"head should have captured the first line before closing the pipe")
 	assert.Less(t, elapsed, 2*time.Second,
 		"pipeline did not stop promptly after parent-ctx cancel: %s", elapsed)
+}
+
+// TestVulnHuntSubsystemSignalHandling_PipelineLeftPanicRecovered asserts
+// that the pipeline-left goroutine's panic recovery path converts a panic
+// into a controlled runner error. Without the goroutine-local recovery, this
+// test process would crash before the right side of the pipeline returned.
+func TestVulnHuntSubsystemSignalHandling_PipelineLeftPanicRecovered(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	r.Reset()
+	r.execHandler = func(ctx context.Context, args []string) error {
+		if len(args) > 0 && args[0] == "paniccmd" {
+			panic("left pipeline panic sentinel")
+		}
+		return nil
+	}
+
+	err = r.Run(context.Background(), parseScript(t, "paniccmd | true"))
+	require.Error(t, err)
+	assert.Equal(t, "internal error", err.Error())
+	assert.NotContains(t, fmt.Sprint(err), "left pipeline panic sentinel",
+		"the returned error must not leak the panic payload")
+	assert.Contains(t, stderr.String(), "left pipeline panic sentinel",
+		"panic details should stay within the configured stderr writer")
+	assert.False(t, errors.Is(err, context.Canceled),
+		"panic recovery must not be misclassified as context cancellation")
+	assert.Empty(t, stdout.String())
 }

--- a/interp/simple_command_vuln_hunt_test.go
+++ b/interp/simple_command_vuln_hunt_test.go
@@ -1,0 +1,296 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// Vulnerability-hunt regression coverage for campaign 2026-05-19-codex.
+
+func runSimpleCommandScriptCtx(t *testing.T, ctx context.Context, script, dir string, opts ...RunnerOption) (stdout, stderr string, exitCode int, runErr error) {
+	t.Helper()
+
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var outBuf, errBuf bytes.Buffer
+	allOpts := append([]RunnerOption{StdIO(nil, &outBuf, &errBuf)}, opts...)
+	runner, err := New(allOpts...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { runner.Close() })
+	if dir != "" {
+		runner.Dir = dir
+	}
+
+	runErr = runner.Run(ctx, prog)
+	if runErr != nil {
+		var es ExitStatus
+		if errors.As(runErr, &es) {
+			exitCode = int(es)
+		} else {
+			exitCode = -1
+		}
+	}
+	return outBuf.String(), errBuf.String(), exitCode, runErr
+}
+
+func runSimpleCommandScript(t *testing.T, script, dir string, opts ...RunnerOption) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	stdout, stderr, exitCode, err := runSimpleCommandScriptCtx(t, context.Background(), script, dir, opts...)
+	if err != nil {
+		var es ExitStatus
+		if !errors.As(err, &es) {
+			t.Fatalf("Run: %v", err)
+		}
+	}
+	return stdout, stderr, exitCode
+}
+
+func runSimpleCommandValidationFailure(t *testing.T, script string) string {
+	t.Helper()
+	stdout, stderr, code, err := runSimpleCommandScriptCtx(t, context.Background(), script, "", allowAllCommandsOpt())
+	if err == nil {
+		t.Fatalf("expected validation error for %q", script)
+	}
+	var es ExitStatus
+	if !errors.As(err, &es) || code != 2 {
+		t.Fatalf("expected validation exit status 2 for %q, got code=%d err=%v stdout=%q stderr=%q", script, code, err, stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected validation stderr for %q", script)
+	}
+	return stderr
+}
+
+func TestVulnHuntShellFeatureRedirectionChain_FailedRedirectPreventsAssignmentOnlyWrite(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, _ := runSimpleCommandScript(t,
+		"VAR=leak < ../outside/secret\necho \"VAR=$VAR\"\n",
+		allowed,
+		allowAllCommandsOpt(),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "leak") {
+		t.Fatalf("assignment-only command ran after failed redirect: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "VAR=\n") {
+		t.Fatalf("expected VAR to remain unset, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected sandbox redirect error")
+	}
+}
+
+func TestVulnHuntShellFeatureRedirectionChain_OutputRedirectTargetsStayLiteral(t *testing.T) {
+	stderr := runSimpleCommandValidationFailure(t, `TARGET=/tmp/out echo data > "$TARGET"`)
+	if !strings.Contains(stderr, "> file redirection is not supported") {
+		t.Fatalf("expected dynamic output redirect rejection, got %q", stderr)
+	}
+
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"X=ok >/dev/null\necho \"after=$X\"\necho hidden >/dev/null\necho visible\n",
+		"",
+		allowAllCommandsOpt(),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	if stdout != "after=ok\nvisible\n" {
+		t.Fatalf("stdout=%q, want assignment persistence and restored stdout", stdout)
+	}
+}
+
+func TestVulnHuntShellFeatureExpansionChain_DynamicCommandStillUsesPolicyAndSandbox(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(allowed, "inside.txt"), []byte("inside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, _ := runSimpleCommandScript(t,
+		"cmd=cat\n\"$cmd\" inside.txt\necho after\n",
+		allowed,
+		AllowedCommands([]string{"rshell:echo"}),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "inside") {
+		t.Fatalf("expanded command bypassed AllowedCommands: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "command not allowed") {
+		t.Fatalf("expected command-policy rejection, stderr=%q", stderr)
+	}
+
+	stdout, stderr, _ = runSimpleCommandScript(t,
+		"cmd=cat\n\"$cmd\" ../outside/secret.txt\necho after\n",
+		allowed,
+		AllowedCommands([]string{"rshell:cat", "rshell:echo"}),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "secret") {
+		t.Fatalf("expanded command bypassed AllowedPaths: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected sandbox rejection for outside file")
+	}
+}
+
+func TestVulnHuntShellFeatureExpansionChain_AssignmentCommandSubstitutionUsesSandbox(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	outside := filepath.Join(root, "outside")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, _ := runSimpleCommandScript(t,
+		"X=$(<../outside/secret.txt)\necho \"X=$X\"\n",
+		allowed,
+		AllowedCommands([]string{"rshell:cat", "rshell:echo"}),
+		AllowedPaths([]string{allowed}),
+	)
+	if strings.Contains(stdout, "secret") {
+		t.Fatalf("assignment command substitution read outside AllowedPaths: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "X=\n") {
+		t.Fatalf("expected empty assignment after blocked shortcut, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stderr == "" {
+		t.Fatalf("expected sandbox error for blocked assignment shortcut")
+	}
+}
+
+func TestVulnHuntShellFeatureReadonlyBypass_AssignmentOnlyReadonlyTarget(t *testing.T) {
+	stdout, stderr := runScriptWithReadonly(t, "RO_VAR=hacked\necho after=$RO_VAR\n")
+	if !strings.Contains(stderr, "readonly variable") {
+		t.Fatalf("expected readonly error, stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "hacked") {
+		t.Fatalf("assignment-only command mutated readonly variable: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "after=original") {
+		t.Fatalf("readonly variable not preserved: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureSignalContext_PreCanceledSimpleCommandDoesNotMutateOrDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stdout, stderr, _, err := runSimpleCommandScriptCtx(t, ctx, "X=leak\necho SHOULD_NOT_RUN\n", "", allowAllCommandsOpt())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("pre-canceled run produced output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestVulnHuntShellFeatureSignalContext_CommandSubstitutionTimeoutIsFatal(t *testing.T) {
+	stdout, stderr, _, err := runSimpleCommandScriptCtx(t,
+		context.Background(),
+		"X=$(while true; do true; done)\necho after\n",
+		"",
+		allowAllCommandsOpt(),
+		MaxExecutionTime(20*time.Millisecond),
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if strings.Contains(stdout, "after") {
+		t.Fatalf("outer simple command continued after timed-out command substitution: stdout=%q", stdout)
+	}
+}
+
+func TestVulnHuntShellFeatureSubshellIsolation_AssignmentOnlyAndInlineDoNotLeak(t *testing.T) {
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"X=outer\n( X=inner; echo sub=$X )\necho parent=$X\n( X=inline echo inline=$X )\necho parent2=$X\n",
+		"",
+		allowAllCommandsOpt(),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q", code, stderr)
+	}
+	for _, want := range []string{"sub=inner", "parent=outer", "inline=outer", "parent2=outer"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q: %q", want, stdout)
+		}
+	}
+}
+
+func TestVulnHuntShellFeatureParserConfusion_AssignmentFormsRejectedBeforeExecution(t *testing.T) {
+	cases := []string{
+		"A+=x",
+		"A[0]=x",
+		"A=(x)",
+		"A=~/secret echo \"$A\"",
+		"~/bin/echo hi",
+	}
+	for _, script := range cases {
+		t.Run(script, func(t *testing.T) {
+			_ = runSimpleCommandValidationFailure(t, script)
+		})
+	}
+}
+
+func TestVulnHuntShellFeatureCompositionAttack_AssignmentStatusAndRedirectionTokenOrder(t *testing.T) {
+	stdout, stderr, code := runSimpleCommandScript(t,
+		"A=$(false) B=ok\necho \"status=$? B=$B\"\necho noisy 2>/dev/null X=ok\n",
+		"",
+		allowAllCommandsOpt(),
+	)
+	if code != 0 {
+		t.Fatalf("exit code=%d stderr=%q stdout=%q", code, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "status=1 B=ok") {
+		t.Fatalf("assignment-only command substitution status or later assignment lost: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "noisy X=ok") {
+		t.Fatalf("assignment-looking argument after command word was misclassified: stdout=%q stderr=%q", stdout, stderr)
+	}
+}

--- a/interp/tests/redir_devnull_pentest_test.go
+++ b/interp/tests/redir_devnull_pentest_test.go
@@ -121,6 +121,15 @@ func TestPentestRedirVariableExpansion(t *testing.T) {
 	}
 }
 
+func TestPentestBlockedRedirTargetCommandSubstitutionNotExpanded(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := pentestRedirRun(t, "echo hello > $(echo SHOULD_NOT_RUN >&2)", dir)
+	assert.Equal(t, 2, code, "command substitution in blocked redirect target should fail at validation")
+	assert.Contains(t, stderr, "file redirection is not supported")
+	assert.NotContains(t, stderr, "SHOULD_NOT_RUN",
+		"blocked redirect target must not be expanded before validation rejects it")
+}
+
 // --- Quoting attacks ---
 
 func TestPentestRedirQuotedDevNull(t *testing.T) {

--- a/interp/tests/while_clause_pentest_test.go
+++ b/interp/tests/while_clause_pentest_test.go
@@ -170,6 +170,14 @@ func TestWhilePentestContinueSkipsTrailingBody(t *testing.T) {
 	assert.Equal(t, "", stdout)
 }
 
+func TestWhilePentestContinueRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, _ = whileRunCtx(ctx, t, `while true; do continue; done`)
+	assert.Less(t, time.Since(start), 5*time.Second, "continue loop did not terminate after ctx cancel")
+}
+
 // --- ctx-cancellation mid-cond ---
 
 // A ctx cancelled while the cond is being evaluated should still produce a

--- a/tests/scenarios/cmd/break/hardening/input_redirect_ignored.yaml
+++ b/tests/scenarios/cmd/break/hardening/input_redirect_ignored.yaml
@@ -10,7 +10,7 @@ input:
   allowed_paths: ["allowed"]
   script: |+
     for i in 1; do
-      break < secret.txt
+      break < allowed/secret.txt
       echo TOP SECRET
     done
     echo done

--- a/tests/scenarios/cmd/break/hardening/input_redirect_ignored.yaml
+++ b/tests/scenarios/cmd/break/hardening/input_redirect_ignored.yaml
@@ -1,0 +1,21 @@
+# skip: allowed_paths setup is rshell-specific; bash parity for loop-control itself is covered elsewhere.
+skip_assert_against_bash: true
+description: Break ignores redirected stdin from an allowed file and does not leak its contents.
+setup:
+  files:
+    - path: allowed/secret.txt
+      content: |
+        TOP SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    for i in 1; do
+      break < secret.txt
+      echo TOP SECRET
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/break/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/break/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,23 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash.
+skip_assert_against_bash: true
+description: Break cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    for i in 1; do
+      break < secret/data.txt
+      echo after-break
+    done
+    echo done
+expect:
+  stdout: |+
+    after-break
+    done
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/continue/hardening/input_redirect_ignored.yaml
+++ b/tests/scenarios/cmd/continue/hardening/input_redirect_ignored.yaml
@@ -1,0 +1,21 @@
+# skip: allowed_paths setup is rshell-specific; bash parity for loop-control itself is covered elsewhere.
+skip_assert_against_bash: true
+description: Continue ignores redirected stdin from an allowed file and does not leak its contents.
+setup:
+  files:
+    - path: allowed/secret.txt
+      content: |
+        TOP SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    for i in 1; do
+      continue < secret.txt
+      echo TOP SECRET
+    done
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/continue/hardening/input_redirect_ignored.yaml
+++ b/tests/scenarios/cmd/continue/hardening/input_redirect_ignored.yaml
@@ -10,7 +10,7 @@ input:
   allowed_paths: ["allowed"]
   script: |+
     for i in 1; do
-      continue < secret.txt
+      continue < allowed/secret.txt
       echo TOP SECRET
     done
     echo done

--- a/tests/scenarios/cmd/continue/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/continue/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,23 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: Continue cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    for i in 1; do
+      continue < secret/data.txt
+      echo after-continue
+    done
+    echo done
+expect:
+  stdout: |+
+    after-continue
+    done
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/cut/hardening/dash_prefixed_filename_after_double_dash.yaml
+++ b/tests/scenarios/cmd/cut/hardening/dash_prefixed_filename_after_double_dash.yaml
@@ -1,0 +1,16 @@
+# vuln-hunt 2026-05-19-codex / cut.
+description: cut treats a dash-prefixed filename after -- as a file operand.
+setup:
+  files:
+    - path: allowed/-secret-looking.txt
+      content: |+
+        safe
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cut -c1- -- allowed/-secret-looking.txt
+expect:
+  stdout: |+
+    safe
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/cut/hardening/gtfobins_empty_delimiter_rejected.yaml
+++ b/tests/scenarios/cmd/cut/hardening/gtfobins_empty_delimiter_rejected.yaml
@@ -1,0 +1,19 @@
+# vuln-hunt 2026-05-19-codex / cut.
+# skip: rshell intentionally rejects the GTFOBins empty delimiter probe before reading the operand.
+skip_assert_against_bash: true
+description: cut rejects the GTFOBins empty delimiter probe before reading the operand.
+setup:
+  files:
+    - path: allowed/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cut -d "" --output-delimiter=$'\n' -f1 allowed/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["delimiter"]
+  exit_code: 0

--- a/tests/scenarios/cmd/cut/hardening/input_operand_outside_allowed.yaml
+++ b/tests/scenarios/cmd/cut/hardening/input_operand_outside_allowed.yaml
@@ -1,0 +1,22 @@
+# vuln-hunt 2026-05-19-codex / cut.
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: cut file operands must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cut -c1- secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/cut/hardening/input_operand_symlink_escape.yaml
+++ b/tests/scenarios/cmd/cut/hardening/input_operand_symlink_escape.yaml
@@ -1,0 +1,21 @@
+# vuln-hunt 2026-05-19-codex / cut.
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: cut file operands must not follow symlinks that escape AllowedPaths.
+setup:
+  files:
+    - path: allowed/link.txt
+      symlink: ../secret/data.txt
+    - path: secret/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cut -c1- allowed/link.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/cut/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/cut/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,22 @@
+# vuln-hunt 2026-05-19-codex / cut.
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: cut input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cut -c1- < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/cut/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/cut/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,21 @@
+# vuln-hunt 2026-05-19-codex / cut.
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: cut input redirection through a symlink must not escape AllowedPaths.
+setup:
+  files:
+    - path: allowed/link.txt
+      symlink: ../secret/data.txt
+    - path: secret/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cut -c1- < allowed/link.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/echo/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/echo/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: The echo builtin cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    echo visible < secret/data.txt && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/echo/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/echo/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: The echo builtin cannot hide an input redirect through a symlink escaping allowed paths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    echo visible < allowed/escape_link && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/echo/hardening/output_redirect_file_blocked.yaml
+++ b/tests/scenarios/cmd/echo/hardening/output_redirect_file_blocked.yaml
@@ -1,0 +1,11 @@
+# skip: write redirects are intentionally blocked in the restricted shell
+skip_assert_against_bash: true
+description: Echo cannot be used as a file-write primitive through output redirection.
+input:
+  script: |+
+    echo payload > output.txt
+expect:
+  stdout: ""
+  stderr: |+
+    > file redirection is not supported
+  exit_code: 2

--- a/tests/scenarios/cmd/exit/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/exit/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: exit input redirection must use AllowedPaths and must not terminate after a blocked redirect.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "allowed\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    exit 7 < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/exit/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/exit/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: exit input redirection through a symlink must not escape AllowedPaths or terminate the script.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    exit 7 < allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/exit/hardening/output_redirect_blocked.yaml
+++ b/tests/scenarios/cmd/exit/hardening/output_redirect_blocked.yaml
@@ -1,0 +1,16 @@
+# skip: blocked output redirection is an rshell-specific safety restriction
+skip_assert_against_bash: true
+description: exit output redirection is blocked before the builtin can choose the exit status.
+setup:
+  files:
+    - path: allowed/existing.txt
+      content: "keep\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    exit 7 > allowed/new.txt
+    echo after
+expect:
+  stdout: ""
+  stderr_contains: ["> file redirection is not supported"]
+  exit_code: 2

--- a/tests/scenarios/cmd/exit/hardening/path_operands_are_numeric_data.yaml
+++ b/tests/scenarios/cmd/exit/hardening/path_operands_are_numeric_data.yaml
@@ -1,0 +1,10 @@
+description: exit treats path-like operands as numeric data and never opens them.
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    exit /etc/passwd
+    echo after
+expect:
+  stdout: ""
+  stderr_contains: ["numeric argument required"]
+  exit_code: 2

--- a/tests/scenarios/cmd/false/hardening/flag_shaped_operands_inert.yaml
+++ b/tests/scenarios/cmd/false/hardening/flag_shaped_operands_inert.yaml
@@ -1,0 +1,10 @@
+description: The false builtin keeps flag-shaped operands inert.
+input:
+  script: |+
+    false --help --unknown -- 999999999999999999999999999999999999999999
+    echo $?
+expect:
+  stdout: |+
+    1
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/false/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/false/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,20 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: The false builtin cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    false < secret/data.txt || echo blocked
+    echo after
+expect:
+  stdout: |+
+    blocked
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/false/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/false/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,20 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: The false builtin cannot hide an input redirect through a symlink escaping allowed paths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    false < allowed/escape_link || echo blocked
+    echo after
+expect:
+  stdout: |+
+    blocked
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/find/exec/exec_child_command_outside_sandbox_blocked.yaml
+++ b/tests/scenarios/cmd/find/exec/exec_child_command_outside_sandbox_blocked.yaml
@@ -1,0 +1,21 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash.
+skip_assert_against_bash: true
+description: find -exec child commands cannot read files outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/secret.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  allowed_commands:
+    - rshell:find
+    - rshell:cat
+  script: |+
+    find allowed -name ok.txt -exec cat secret/secret.txt \;
+expect:
+  stdout: ""
+  stderr_contains:
+    - "permission denied"
+  exit_code: 0

--- a/tests/scenarios/cmd/find/sandbox/symlink_to_outside_blocked_with_L.yaml
+++ b/tests/scenarios/cmd/find/sandbox/symlink_to_outside_blocked_with_L.yaml
@@ -1,0 +1,22 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash.
+skip_assert_against_bash: true
+description: find -L does not follow an allowed symlink whose target is outside allowed paths.
+setup:
+  files:
+    - path: allowed/visible.txt
+      content: "ok\n"
+    - path: secret/hidden.txt
+      content: "secret\n"
+    - path: allowed/link
+      symlink: ../secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    find allowed/link
+    find -L allowed/link
+expect:
+  stdout: |+
+    allowed/link
+  stderr_contains:
+    - "path escapes from parent"
+  exit_code: 1

--- a/tests/scenarios/cmd/grep/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/grep/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: grep input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    grep secret < secret/data.txt && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/ip/hardening/route_show_path_operand_rejected.yaml
+++ b/tests/scenarios/cmd/ip/hardening/route_show_path_operand_rejected.yaml
@@ -1,0 +1,11 @@
+# ip route show rejects path-like extra operands before reading /proc/net/route.
+description: "ip route show rejects path-like extra operand"
+input:
+  script: |+
+    ip route show /tmp/attacker-route-table
+expect:
+  stdout: |+
+  stderr: |+
+    ip: route show: unsupported argument "/tmp/attacker-route-table"
+  exit_code: 1
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/ls/sandbox/symlink_to_outside_not_followed.yaml
+++ b/tests/scenarios/cmd/ls/sandbox/symlink_to_outside_not_followed.yaml
@@ -1,0 +1,20 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash.
+skip_assert_against_bash: true
+description: ls -R does not follow an allowed symlink whose target is outside allowed paths.
+setup:
+  files:
+    - path: allowed/visible.txt
+      content: "ok\n"
+    - path: secret/hidden.txt
+      content: "secret\n"
+    - path: allowed/link
+      symlink: ../secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    ls -R allowed/link
+expect:
+  stdout: |+
+    allowed/link
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/ping/flags/count_negative_clamped_warns.yaml
+++ b/tests/scenarios/cmd/ping/flags/count_negative_clamped_warns.yaml
@@ -1,0 +1,12 @@
+# -c values below minimum (1), including negative values, are clamped with a
+# stderr warning. DNS fails immediately on the unresolvable host so the test
+# exits fast.
+description: "ping -c with negative count emits clamping warning"
+input:
+  script: |+
+    ping -c -99 no-such-host-xyzzy.invalid
+expect:
+  stdout: ""
+  stderr_contains: ["ping: warning: -c -99 out of range"]
+  exit_code: 1
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/ping/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/ping/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: ping cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    ping --help < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/printf/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/printf/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: printf cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    printf "visible\n" < secret/data.txt && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/printf/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/printf/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: printf cannot hide an input redirect through a symlink escaping allowed paths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    printf "visible\n" < allowed/escape_link && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/printf/hardening/path_operands_are_data.yaml
+++ b/tests/scenarios/cmd/printf/hardening/path_operands_are_data.yaml
@@ -1,0 +1,17 @@
+description: printf path-like operands are inert data and are not opened.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    printf "%s\n" secret/data.txt @secret/data.txt /proc/self/environ
+expect:
+  stdout: |+
+    secret/data.txt
+    @secret/data.txt
+    /proc/self/environ
+  exit_code: 0

--- a/tests/scenarios/cmd/ps/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/ps/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: ps cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    ps --help < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/read/errors/count_overflow.yaml
+++ b/tests/scenarios/cmd/read/errors/count_overflow.yaml
@@ -1,0 +1,13 @@
+# vuln-hunt 2026-05-19-codex / read.
+skip_assert_against_bash: true
+description: read rejects count values that overflow integer parsing.
+input:
+  script: |+
+    printf 'x\n' | { read -n 999999999999999999999999 X; echo "n=$?"; }
+    printf 'x\n' | { read -N 999999999999999999999999 X; echo "N=$?"; }
+expect:
+  stdout: |+
+    n=1
+    N=1
+  stderr_contains: ["invalid"]
+  exit_code: 0

--- a/tests/scenarios/cmd/read/errors/timeout_overflow.yaml
+++ b/tests/scenarios/cmd/read/errors/timeout_overflow.yaml
@@ -1,0 +1,11 @@
+# vuln-hunt 2026-05-19-codex / read.
+skip_assert_against_bash: true
+description: read rejects timeout values whose duration would overflow.
+input:
+  script: |+
+    printf 'x\n' | { read -t 999999999999999999999999 X; echo "t=$?"; }
+expect:
+  stdout: |+
+    t=1
+  stderr_contains: ["invalid timeout specification"]
+  exit_code: 0

--- a/tests/scenarios/cmd/read/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/read/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,20 @@
+# vuln-hunt 2026-05-19-codex / read.
+skip_assert_against_bash: true
+description: read input redirection must use AllowedPaths and not assign bytes from outside the sandbox.
+setup:
+  files:
+    - path: safe.txt
+      content: |+
+        safe
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    read X </etc/passwd
+    echo "rc=$?"
+    echo "X=[$X]"
+expect:
+  stdout: |+
+    rc=1
+    X=[]
+  stderr_contains: ["passwd"]
+  exit_code: 0

--- a/tests/scenarios/cmd/read/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/read/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,22 @@
+# vuln-hunt 2026-05-19-codex / read.
+skip_assert_against_bash: true
+description: read input redirection through a symlink must not escape AllowedPaths.
+setup:
+  files:
+    - path: outside/secret.txt
+      content: |+
+        secret
+    - path: allowed/link.txt
+      symlink: ../outside/secret.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    read X < allowed/link.txt
+    echo "rc=$?"
+    echo "X=[$X]"
+expect:
+  stdout: |+
+    rc=1
+    X=[]
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/read/hardening/reject_unsupported_flags.yaml
+++ b/tests/scenarios/cmd/read/hardening/reject_unsupported_flags.yaml
@@ -1,0 +1,19 @@
+# vuln-hunt 2026-05-19-codex / read.
+skip_assert_against_bash: true
+description: read rejects unsupported flags that would expand its attack surface.
+input:
+  script: |+
+    printf 'x\n' | { read -u 3 X; echo "u=$? X=[$X]"; }
+    printf 'x\n' | { read -a ARR; echo "a=$? ARR=[$ARR]"; }
+    printf 'x\n' | { read -s X; echo "s=$? X=[$X]"; }
+    printf 'x\n' | { read -e X; echo "e=$? X=[$X]"; }
+    printf 'x\n' | { read -i seed X; echo "i=$? X=[$X]"; }
+expect:
+  stdout: |+
+    u=1 X=[]
+    a=1 ARR=[]
+    s=1 X=[]
+    e=1 X=[]
+    i=1 X=[]
+  stderr_contains: ["invalid option"]
+  exit_code: 0

--- a/tests/scenarios/cmd/sed/hardening/dash_prefixed_filename_after_double_dash.yaml
+++ b/tests/scenarios/cmd/sed/hardening/dash_prefixed_filename_after_double_dash.yaml
@@ -1,0 +1,13 @@
+description: sed -- treats dash-prefixed filenames as operands.
+setup:
+  files:
+    - path: "-secret.txt"
+      content: "hello\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    sed 's/hello/bye/' -- -secret.txt
+expect:
+  stdout: "bye\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/sed/hardening/input_operand_symlink_escape.yaml
+++ b/tests/scenarios/cmd/sed/hardening/input_operand_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: sed file operands must not follow symlinks that escape AllowedPaths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret words\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    sed 's/secret/public/' allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/sed/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/sed/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: sed input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "allowed words\n"
+    - path: secret/data.txt
+      content: "secret words\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    sed 's/secret/public/' < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/sed/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/sed/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: sed input redirection through a symlink must not escape AllowedPaths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret words\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    sed 's/secret/public/' < allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/strings/hardening/dash_prefixed_filename_after_double_dash.yaml
+++ b/tests/scenarios/cmd/strings/hardening/dash_prefixed_filename_after_double_dash.yaml
@@ -1,0 +1,14 @@
+description: strings -- treats dash-prefixed filenames as operands.
+setup:
+  files:
+    - path: "-secret.bin"
+      content: "dash_file_secret\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    strings -- -secret.bin
+expect:
+  stdout: |+
+    dash_file_secret
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/strings/hardening/input_operand_symlink_escape.yaml
+++ b/tests/scenarios/cmd/strings/hardening/input_operand_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: strings file operands must not follow symlinks that escape AllowedPaths.
+setup:
+  files:
+    - path: secret/data.bin
+      content: "secret_data\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.bin
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    strings allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/strings/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/strings/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: strings input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.bin
+      content: "allowed_data\n"
+    - path: secret/data.bin
+      content: "secret_data\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    strings < secret/data.bin
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/strings/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/strings/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: strings input redirection through a symlink must not escape AllowedPaths.
+setup:
+  files:
+    - path: secret/data.bin
+      content: "secret_data\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.bin
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    strings < allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/tr/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/tr/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,22 @@
+# vuln-hunt 2026-05-19-codex / tr.
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: tr input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    tr '' '' < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/tr/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/tr/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,21 @@
+# vuln-hunt 2026-05-19-codex / tr.
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: tr input redirection through a symlink must not escape AllowedPaths.
+setup:
+  files:
+    - path: allowed/link.txt
+      symlink: ../secret/data.txt
+    - path: secret/data.txt
+      content: |+
+        secret
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    tr '' '' < allowed/link.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/tr/hardening/output_flag_rejected.yaml
+++ b/tests/scenarios/cmd/tr/hardening/output_flag_rejected.yaml
@@ -1,0 +1,11 @@
+# vuln-hunt 2026-05-19-codex / tr.
+# skip: rshell builtin error formatting differs from GNU coreutils.
+skip_assert_against_bash: true
+description: tr rejects output-style flags instead of writing files.
+input:
+  script: |+
+    tr --output=out.txt a b
+expect:
+  stdout: ""
+  stderr_contains: ["unrecognized option"]
+  exit_code: 1

--- a/tests/scenarios/cmd/tr/hardening/path_operand_is_set_not_file.yaml
+++ b/tests/scenarios/cmd/tr/hardening/path_operand_is_set_not_file.yaml
@@ -1,0 +1,17 @@
+# vuln-hunt 2026-05-19-codex / tr.
+description: Path-looking operands are SET strings, not file operands.
+setup:
+  files:
+    - path: secret
+      content: |+
+        should-not-be-read
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    tr secret SECRET
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/true/hardening/flag_shaped_operands_inert.yaml
+++ b/tests/scenarios/cmd/true/hardening/flag_shaped_operands_inert.yaml
@@ -1,0 +1,10 @@
+description: The true builtin keeps flag-shaped operands inert.
+input:
+  script: |+
+    true --help --unknown -- 999999999999999999999999999999999999999999
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/true/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/true/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: The true builtin cannot hide an input redirect outside allowed paths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    true < secret/data.txt && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/true/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/true/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: The true builtin cannot hide an input redirect through a symlink escaping allowed paths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    true < allowed/escape_link && echo bypassed
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/cmd/uniq/errors/negative_check_chars.yaml
+++ b/tests/scenarios/cmd/uniq/errors/negative_check_chars.yaml
@@ -1,0 +1,13 @@
+description: uniq rejects negative --check-chars values.
+setup:
+  files:
+    - path: input.txt
+      content: "a\na\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    uniq --check-chars=-1 input.txt
+expect:
+  stdout: ""
+  stderr: "uniq: -1: invalid number of bytes to compare\n"
+  exit_code: 1

--- a/tests/scenarios/cmd/uniq/errors/negative_skip_chars.yaml
+++ b/tests/scenarios/cmd/uniq/errors/negative_skip_chars.yaml
@@ -1,0 +1,13 @@
+description: uniq rejects negative --skip-chars values.
+setup:
+  files:
+    - path: input.txt
+      content: "a\na\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    uniq --skip-chars=-1 input.txt
+expect:
+  stdout: ""
+  stderr: "uniq: -1: invalid number of bytes to skip\n"
+  exit_code: 1

--- a/tests/scenarios/cmd/uniq/hardening/input_operand_symlink_escape.yaml
+++ b/tests/scenarios/cmd/uniq/hardening/input_operand_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: uniq file operands must not follow symlinks that escape AllowedPaths.
+setup:
+  files:
+    - path: allowed/link.txt
+      symlink: ../secret/data.txt
+    - path: secret/data.txt
+      content: "secret\nsecret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    uniq allowed/link.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/uniq/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/uniq/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: uniq input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\nsecret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    uniq < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/wc/hardening/dash_prefixed_filename_after_double_dash.yaml
+++ b/tests/scenarios/cmd/wc/hardening/dash_prefixed_filename_after_double_dash.yaml
@@ -1,0 +1,13 @@
+description: wc -- treats dash-prefixed filenames as operands.
+setup:
+  files:
+    - path: "-secret.txt"
+      content: "x\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    wc -- -secret.txt
+expect:
+  stdout: "1 1 2 -secret.txt\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/wc/hardening/input_operand_symlink_escape.yaml
+++ b/tests/scenarios/cmd/wc/hardening/input_operand_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: wc file operands must not follow symlinks that escape AllowedPaths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret words\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    wc allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes"]
+  exit_code: 0

--- a/tests/scenarios/cmd/wc/hardening/input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/cmd/wc/hardening/input_redirect_outside_allowed.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: wc input redirection must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "allowed words\n"
+    - path: secret/data.txt
+      content: "secret words\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    wc < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/cmd/wc/hardening/input_redirect_symlink_escape.yaml
+++ b/tests/scenarios/cmd/wc/hardening/input_redirect_symlink_escape.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: wc input redirection through a symlink must not escape AllowedPaths.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret words\n"
+    - path: allowed/escape_link
+      symlink: ../secret/data.txt
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    wc < allowed/escape_link
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["path escapes from parent"]
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_commands/blocked_input_redirect_no_leak.yaml
+++ b/tests/scenarios/shell/allowed_commands/blocked_input_redirect_no_leak.yaml
@@ -1,0 +1,21 @@
+# skip: allowed_commands is rshell-specific sandbox behaviour with no bash equivalent.
+skip_assert_against_bash: true
+description: A blocked command with input redirection from an allowed file does not leak redirected contents.
+setup:
+  files:
+    - path: secret.txt
+      content: |
+        TOP SECRET
+input:
+  allowed_paths: ["$DIR"]
+  allowed_commands:
+    - rshell:echo
+  script: |+
+    cat < secret.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: |+
+    rshell: cat: command not allowed
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_commands/expanded_command_names_blocked.yaml
+++ b/tests/scenarios/shell/allowed_commands/expanded_command_names_blocked.yaml
@@ -1,0 +1,18 @@
+# skip: allowed_commands is rshell-specific sandbox behaviour with no bash equivalent.
+skip_assert_against_bash: true
+description: Command names produced by variable expansion and command substitution remain gated by allowed_commands.
+input:
+  allowed_commands:
+    - rshell:echo
+  script: |+
+    C=cat
+    $C /dev/null
+    $(echo cat) /dev/null
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: |+
+    rshell: cat: command not allowed
+    rshell: cat: command not allowed
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/vuln_hunt/allowed_paths_assignment_does_not_widen.yaml
+++ b/tests/scenarios/shell/allowed_paths/vuln_hunt/allowed_paths_assignment_does_not_widen.yaml
@@ -1,0 +1,23 @@
+# vuln-hunt 2026-05-19-codex / allowed_paths.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: Runtime assignment to ALLOWED_PATHS does not widen the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    ALLOWED_PATHS=secret
+    cat secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/vuln_hunt/failed_cd_does_not_change_cwd.yaml
+++ b/tests/scenarios/shell/allowed_paths/vuln_hunt/failed_cd_does_not_change_cwd.yaml
@@ -1,0 +1,24 @@
+# vuln-hunt 2026-05-19-codex / allowed_paths.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: A cd blocked by AllowedPaths does not change relative path resolution.
+setup:
+  files:
+    - path: allowed/data.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cd secret
+    echo cd_status=$?
+    cat allowed/data.txt
+expect:
+  stdout: |+
+    cd_status=1
+    allowed
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/vuln_hunt/inline_allowed_paths_assignment_does_not_widen.yaml
+++ b/tests/scenarios/shell/allowed_paths/vuln_hunt/inline_allowed_paths_assignment_does_not_widen.yaml
@@ -1,0 +1,22 @@
+# vuln-hunt 2026-05-19-codex / allowed_paths.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: Inline ALLOWED_PATHS assignment for a command does not widen the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    ALLOWED_PATHS=secret cat secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/vuln_hunt/pwd_assignment_does_not_change_resolution.yaml
+++ b/tests/scenarios/shell/allowed_paths/vuln_hunt/pwd_assignment_does_not_change_resolution.yaml
@@ -1,0 +1,26 @@
+# vuln-hunt 2026-05-19-codex / allowed_paths.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: Assigning PWD does not change the runner directory used for AllowedPaths checks.
+setup:
+  files:
+    - path: allowed/data.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cd allowed
+    PWD=../secret
+    cat data.txt
+    cat ../secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    allowed
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/vuln_hunt/subshell_cd_does_not_change_parent_cwd.yaml
+++ b/tests/scenarios/shell/allowed_paths/vuln_hunt/subshell_cd_does_not_change_parent_cwd.yaml
@@ -1,0 +1,24 @@
+# vuln-hunt 2026-05-19-codex / allowed_paths.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: cd inside command substitution does not change the parent runner cwd or sandbox state.
+setup:
+  files:
+    - path: allowed/data.txt
+      content: |+
+        parent
+    - path: other/data.txt
+      content: |+
+        child
+input:
+  allowed_paths: ["allowed", "other"]
+  script: |+
+    cd allowed
+    echo "child=$(cd ../other; cat data.txt)"
+    cat data.txt
+expect:
+  stdout: |+
+    child=child
+    parent
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/blocked_commands/vuln_hunt/command_substituted_eval_is_unknown.yaml
+++ b/tests/scenarios/shell/blocked_commands/vuln_hunt/command_substituted_eval_is_unknown.yaml
@@ -1,0 +1,15 @@
+# vuln-hunt 2026-05-19-codex / blocked_commands.
+# skip: eval is intentionally unavailable in the restricted shell.
+skip_assert_against_bash: true
+description: A blocked command name produced by command substitution is dispatched as data, not parsed as shell syntax.
+input:
+  script: |+
+    $(echo eval) echo pwned
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: |+
+    rshell: eval: unknown command
+    Run 'help' to see available commands.
+  exit_code: 0

--- a/tests/scenarios/shell/blocked_commands/vuln_hunt/globbed_command_name_still_gated.yaml
+++ b/tests/scenarios/shell/blocked_commands/vuln_hunt/globbed_command_name_still_gated.yaml
@@ -1,0 +1,22 @@
+# vuln-hunt 2026-05-19-codex / blocked_commands.
+# skip: allowed_commands is rshell-specific sandbox behaviour with no bash equivalent.
+skip_assert_against_bash: true
+description: A command name produced by glob expansion is still gated by AllowedCommands.
+setup:
+  files:
+    - path: cat
+      content: |+
+        placeholder
+input:
+  allowed_paths: ["$DIR"]
+  allowed_commands:
+    - rshell:echo
+  script: |+
+    *
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: |+
+    rshell: cat: command not allowed
+  exit_code: 0

--- a/tests/scenarios/shell/blocked_commands/vuln_hunt/heredoc_command_substitution_respects_allowed_commands.yaml
+++ b/tests/scenarios/shell/blocked_commands/vuln_hunt/heredoc_command_substitution_respects_allowed_commands.yaml
@@ -1,0 +1,25 @@
+# vuln-hunt 2026-05-19-codex / blocked_commands.
+# skip: allowed_commands is rshell-specific sandbox behaviour with no bash equivalent.
+skip_assert_against_bash: true
+description: Command substitutions in a heredoc attached to a blocked command still obey AllowedCommands and do not leak file content.
+setup:
+  files:
+    - path: secret.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["$DIR"]
+  allowed_commands:
+    - rshell:echo
+  script: |+
+    denied <<EOF
+    $(cat secret.txt)
+    EOF
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains:
+    - "rshell: cat: command not allowed"
+    - "rshell: denied: command not allowed"
+  exit_code: 0

--- a/tests/scenarios/shell/blocked_commands/vuln_hunt/path_like_command_names_do_not_execute_host.yaml
+++ b/tests/scenarios/shell/blocked_commands/vuln_hunt/path_like_command_names_do_not_execute_host.yaml
@@ -1,0 +1,24 @@
+# vuln-hunt 2026-05-19-codex / blocked_commands.
+# skip: host executable lookup is intentionally unavailable in the restricted shell.
+skip_assert_against_bash: true
+description: Path-like command names are rejected by the interpreter and never execute host binaries.
+setup:
+  files:
+    - path: script.sh
+      content: |+
+        echo pwned
+      chmod: 0755
+input:
+  script: |+
+    /bin/sh -c 'echo pwned'
+    ./script.sh
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: |+
+    rshell: /bin/sh: unknown command
+    Run 'help' to see available commands.
+    rshell: ./script.sh: unknown command
+    Run 'help' to see available commands.
+  exit_code: 0

--- a/tests/scenarios/shell/brace_group/vuln_hunt/group_input_redirect_outside_blocked.yaml
+++ b/tests/scenarios/shell/brace_group/vuln_hunt/group_input_redirect_outside_blocked.yaml
@@ -1,0 +1,19 @@
+# skip: AllowedPaths sandbox restriction is an rshell-specific feature.
+skip_assert_against_bash: true
+description: A group-level input redirect on a brace group must honor AllowedPaths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    { cat; } < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/brace_group/vuln_hunt/group_output_redirect_blocked.yaml
+++ b/tests/scenarios/shell/brace_group/vuln_hunt/group_output_redirect_blocked.yaml
@@ -1,0 +1,11 @@
+# skip: write redirects are intentionally blocked in the restricted shell.
+skip_assert_against_bash: true
+description: A group-level output redirect on a brace group cannot write a file.
+input:
+  script: |+
+    { echo body; } > /tmp/brace-output.txt
+expect:
+  stdout: ""
+  stderr: |+
+    > file redirection is not supported
+  exit_code: 2

--- a/tests/scenarios/shell/case_clause/vuln_hunt_case_in_command_substitution_blocked.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_case_in_command_substitution_blocked.yaml
@@ -1,0 +1,11 @@
+# skip: case statements are intentionally blocked in the restricted shell.
+skip_assert_against_bash: true
+description: A case statement inside command substitution must not hide the validation error or produce captured output.
+input:
+  script: |+
+    echo "[$(case x in x) echo hidden;; esac)]"
+expect:
+  stdout: ""
+  stderr: |+
+    case statements are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/case_clause/vuln_hunt_case_in_subshell_blocked.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_case_in_subshell_blocked.yaml
@@ -1,0 +1,11 @@
+# skip: case statements are intentionally blocked in the restricted shell.
+skip_assert_against_bash: true
+description: A case statement inside a subshell must still be rejected by top-level validation.
+input:
+  script: |+
+    (case x in x) echo hidden;; esac)
+expect:
+  stdout: ""
+  stderr: |+
+    case statements are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/case_clause/vuln_hunt_command_subst_subject_not_executed.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_command_subst_subject_not_executed.yaml
@@ -1,0 +1,11 @@
+# skip: case statements are intentionally blocked in the restricted shell.
+skip_assert_against_bash: true
+description: Command substitution in a case subject must not execute before case validation rejects the statement.
+input:
+  script: |+
+    case "$(echo should-not-run >&2)" in *) echo matched;; esac
+expect:
+  stdout: ""
+  stderr: |+
+    case statements are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/case_clause/vuln_hunt_comment_case_text_is_literal.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_comment_case_text_is_literal.yaml
@@ -1,0 +1,10 @@
+description: Case-like text in a comment remains inert and is not validated as executable syntax.
+input:
+  script: |+
+    # case x in x) echo hidden;; esac
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/case_clause/vuln_hunt_heredoc_case_text_is_literal.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_heredoc_case_text_is_literal.yaml
@@ -1,0 +1,15 @@
+description: Case-like text in a heredoc body remains literal data and is not validated as executable syntax.
+input:
+  script: |+
+    cat <<'EOF'
+    case x in
+      x) echo hidden;;
+    esac
+    EOF
+expect:
+  stdout: |+
+    case x in
+      x) echo hidden;;
+    esac
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/case_clause/vuln_hunt_input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_input_redirect_outside_allowed.yaml
@@ -1,0 +1,18 @@
+# skip: case statements and AllowedPaths sandbox failures are rshell-specific behavior.
+skip_assert_against_bash: true
+description: A case statement input redirect must not open files before case validation rejects the statement.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    case x in x) echo matched;; esac < secret/data.txt
+expect:
+  stdout: ""
+  stderr: |+
+    case statements are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/case_clause/vuln_hunt_pipeline_case_blocks_stages.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_pipeline_case_blocks_stages.yaml
@@ -1,0 +1,11 @@
+# skip: case statements are intentionally blocked in the restricted shell.
+skip_assert_against_bash: true
+description: A blocked case clause in a pipeline must not start neighboring pipeline stages first.
+input:
+  script: |+
+    echo should-not-run >&2 | case x in x) cat;; esac
+expect:
+  stdout: ""
+  stderr: |+
+    case statements are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/case_clause/vuln_hunt_quoted_case_is_command.yaml
+++ b/tests/scenarios/shell/case_clause/vuln_hunt_quoted_case_is_command.yaml
@@ -1,0 +1,10 @@
+# skip: rshell reports unknown commands differently from bash.
+skip_assert_against_bash: true
+description: Quoting the word case keeps it a regular command name rather than reparsing it as a case keyword.
+input:
+  script: |+
+    'case'
+expect:
+  stdout: ""
+  stderr_contains: ["unknown command"]
+  exit_code: 127

--- a/tests/scenarios/shell/empty_script/vuln_hunt/comment_payload_does_not_expand.yaml
+++ b/tests/scenarios/shell/empty_script/vuln_hunt/comment_payload_does_not_expand.yaml
@@ -1,0 +1,17 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: Comment-only payload text is data and does not expand, redirect, or execute.
+setup:
+  files:
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: []
+  script: |+
+    # $(cat secret/data.txt)
+    # $((1+1)) ${HOME} > /tmp/evil
+    # readonly RO=pwned
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/empty_script/vuln_hunt/crlf_comment_payload_is_not_code.yaml
+++ b/tests/scenarios/shell/empty_script/vuln_hunt/crlf_comment_payload_is_not_code.yaml
@@ -1,0 +1,9 @@
+# skip: CRLF comment payload handling is an rshell parser-hardening behavior.
+skip_assert_against_bash: true
+description: CRLF comments containing unsupported syntax remain non-executable comments.
+input:
+  script: "# $(cat secret/data.txt)\r\n# function f() { echo pwned; }\r\n# > /tmp/evil\r\n"
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/empty_script/vuln_hunt/empty_command_substitution_is_empty.yaml
+++ b/tests/scenarios/shell/empty_script/vuln_hunt/empty_command_substitution_is_empty.yaml
@@ -1,0 +1,11 @@
+description: Empty command substitution produces an empty string and does not reuse stale output.
+input:
+  script: |+
+    before=$(echo stale)
+    value=$()
+    echo "[$value][$before]"
+expect:
+  stdout: |+
+    [][stale]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/empty_script/vuln_hunt/empty_command_substitution_preserves_parent_state.yaml
+++ b/tests/scenarios/shell/empty_script/vuln_hunt/empty_command_substitution_preserves_parent_state.yaml
@@ -1,0 +1,11 @@
+description: Empty command substitution does not mutate or leak parent variables.
+input:
+  script: |+
+    value=parent
+    empty=$()
+    echo "$value:$empty"
+expect:
+  stdout: |+
+    parent:
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/empty_script/vuln_hunt/redirect_only_outside_allowed_blocked.yaml
+++ b/tests/scenarios/shell/empty_script/vuln_hunt/redirect_only_outside_allowed_blocked.yaml
@@ -1,0 +1,19 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: A redirect-only statement is not treated as an empty no-op that skips the sandbox.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/errors/unknown_cmd_all_redirect_devnull.yaml
+++ b/tests/scenarios/shell/errors/unknown_cmd_all_redirect_devnull.yaml
@@ -1,0 +1,12 @@
+# vuln-hunt 2026-05-19-codex / errors.
+# Pins that unknown-command diagnostics participate in &>/dev/null, not only
+# explicit 2>/dev/null stderr redirects.
+skip_assert_against_bash: true
+description: A cmd-not-found diagnostic is silenced by &>/dev/null.
+input:
+  script: |+
+    no_such_cmd_xyz &>/dev/null
+expect:
+  stdout: ""
+  stderr: ""
+  exit_code: 127

--- a/tests/scenarios/shell/errors/unknown_cmd_stderr_dup_stdout.yaml
+++ b/tests/scenarios/shell/errors/unknown_cmd_stderr_dup_stdout.yaml
@@ -1,0 +1,14 @@
+# vuln-hunt 2026-05-19-codex / errors.
+# Pins that unknown-command diagnostics are written to the current stderr fd,
+# so 2>&1 duplicates them into stdout instead of leaking to original stderr.
+skip_assert_against_bash: true
+description: A cmd-not-found diagnostic follows 2>&1 into stdout.
+input:
+  script: |+
+    no_such_cmd_xyz 2>&1
+expect:
+  stdout: |+
+    rshell: no_such_cmd_xyz: unknown command
+    Run 'help' to see available commands.
+  stderr: ""
+  exit_code: 127

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/command_substitution_metacharacters_are_data.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/command_substitution_metacharacters_are_data.yaml
@@ -1,0 +1,12 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+description: Command substitution output is split into data words, not re-parsed as shell syntax.
+input:
+  script: |+
+    for w in $(printf 'one;echo bad\nthree|cat\n'); do echo "[$w]"; done
+expect:
+  stdout: |+
+    [one;echo]
+    [bad]
+    [three|cat]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/heredoc_expansion_not_field_split.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/heredoc_expansion_not_field_split.yaml
@@ -1,0 +1,14 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+description: Heredoc expansion preserves expanded text without field splitting or re-parsing.
+input:
+  script: |+
+    IFS=:
+    A='x:y;echo bad'
+    cat <<EOF
+    $A
+    EOF
+expect:
+  stdout: |+
+    x:y;echo bad
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/inline_ifs_does_not_affect_same_command_args.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/inline_ifs_does_not_affect_same_command_args.yaml
@@ -1,0 +1,11 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+description: Inline IFS assignments do not affect argument splitting for the same simple command.
+input:
+  script: |+
+    A='a:b'
+    IFS=: echo $A
+expect:
+  stdout: |+
+    a:b
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/input_redirect_unquoted_var_not_field_split.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/input_redirect_unquoted_var_not_field_split.yaml
@@ -20,4 +20,5 @@ expect:
   stdout: |+
     after
   stderr_contains: ["one.txt allowed/two.txt"]
+  stderr_contains_windows: ["one.txt allowed\\two.txt"]
   exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/input_redirect_unquoted_var_not_field_split.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/input_redirect_unquoted_var_not_field_split.yaml
@@ -1,0 +1,23 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+# skip: rshell treats the expanded redirect word as one path; bash reports an ambiguous redirect.
+skip_assert_against_bash: true
+description: Input redirect operands expanded from variables are not field-split into alternate paths.
+setup:
+  files:
+    - path: allowed/one.txt
+      content: |+
+        one
+    - path: allowed/two.txt
+      content: |+
+        two
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    TARGET='allowed/one.txt allowed/two.txt'
+    cat < $TARGET
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["one.txt allowed/two.txt"]
+  exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/pipeline_ifs_does_not_leak.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/pipeline_ifs_does_not_leak.yaml
@@ -1,0 +1,16 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+description: IFS changes in a pipeline stage do not leak into parent field splitting.
+input:
+  script: |+
+    IFS=:
+    { IFS=' '; A='a b'; for w in $A; do echo "pipe[$w]"; done; } | cat
+    A='a:b'
+    for w in $A; do echo "parent[$w]"; done
+expect:
+  stdout: |+
+    pipe[a]
+    pipe[b]
+    parent[a]
+    parent[b]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/split_metacharacters_are_data.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/split_metacharacters_are_data.yaml
@@ -1,0 +1,14 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+description: Split words containing shell metacharacters remain data and are not re-parsed.
+input:
+  script: |+
+    PAYLOAD='one;echo bad two|cat three>file'
+    for w in $PAYLOAD; do echo "[$w]"; done
+expect:
+  stdout: |+
+    [one;echo]
+    [bad]
+    [two|cat]
+    [three>file]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/field_splitting/vuln_hunt/subshell_ifs_does_not_leak.yaml
+++ b/tests/scenarios/shell/field_splitting/vuln_hunt/subshell_ifs_does_not_leak.yaml
@@ -1,0 +1,16 @@
+# vuln-hunt 2026-05-19-codex / field_splitting.
+description: IFS changes inside a subshell do not leak into parent field splitting.
+input:
+  script: |+
+    IFS=:
+    ( IFS=' '; A='a b'; for w in $A; do echo "sub[$w]"; done )
+    A='a:b'
+    for w in $A; do echo "parent[$w]"; done
+expect:
+  stdout: |+
+    sub[a]
+    sub[b]
+    parent[a]
+    parent[b]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/for_clause/break_cont/continue_negative_arg.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/continue_negative_arg.yaml
@@ -1,0 +1,13 @@
+description: Continue with a negative operand is rejected as out of range.
+input:
+  script: |+
+    for i in 1; do
+      continue -1
+    done
+expect:
+  stdout: ""
+  stderr_contains:
+    - "continue"
+    - "-1"
+    - "loop count out of range"
+  exit_code: 1

--- a/tests/scenarios/shell/function/vuln_hunt/command_substitution_expansion_does_not_reparse.yaml
+++ b/tests/scenarios/shell/function/vuln_hunt/command_substitution_expansion_does_not_reparse.yaml
@@ -1,0 +1,13 @@
+description: Expanded function declaration text inside command substitution is not reparsed as syntax.
+skip_assert_against_bash: true
+input:
+  script: |+
+    FN='f() { echo pwned; }'
+    echo "$($FN)"
+    echo after
+expect:
+  stdout: |+
+    
+    after
+  stderr_contains: ["unknown command"]
+  exit_code: 0

--- a/tests/scenarios/shell/function/vuln_hunt/function_keyword_parentheses_blocked.yaml
+++ b/tests/scenarios/shell/function/vuln_hunt/function_keyword_parentheses_blocked.yaml
@@ -1,0 +1,11 @@
+# skip: function declarations are intentionally blocked in the restricted shell
+skip_assert_against_bash: true
+description: The function keyword plus parentheses parser variant is rejected as a function declaration.
+input:
+  script: |+
+    function f() { { echo pwned; }; }
+expect:
+  stdout: ""
+  stderr: |+
+    function declarations are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/function/vuln_hunt/readonly_body_never_executes.yaml
+++ b/tests/scenarios/shell/function/vuln_hunt/readonly_body_never_executes.yaml
@@ -1,0 +1,14 @@
+# skip: function declarations and readonly enforcement are intentionally rshell-specific here
+skip_assert_against_bash: true
+description: A blocked function body cannot mutate a readonly variable.
+input:
+  script: |+
+    readonly RO=safe
+    mutate() { RO=pwned; echo body; }
+    mutate
+    echo "$RO"
+expect:
+  stdout: ""
+  stderr: |+
+    readonly is not supported
+  exit_code: 2

--- a/tests/scenarios/shell/function/vuln_hunt/redirect_input_outside_blocked_at_validation.yaml
+++ b/tests/scenarios/shell/function/vuln_hunt/redirect_input_outside_blocked_at_validation.yaml
@@ -1,0 +1,19 @@
+# skip: function declarations and allowed_paths sandbox restrictions are rshell-specific
+skip_assert_against_bash: true
+description: A function declaration with an outside input redirect is rejected before redirect evaluation.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    f() { echo body; } < secret/data.txt
+    echo after
+expect:
+  stdout: ""
+  stderr: |+
+    function declarations are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/function/vuln_hunt/subshell_definition_does_not_register.yaml
+++ b/tests/scenarios/shell/function/vuln_hunt/subshell_definition_does_not_register.yaml
@@ -1,0 +1,12 @@
+# skip: function declarations are intentionally blocked in the restricted shell
+skip_assert_against_bash: true
+description: A function declaration inside a subshell is rejected and cannot register in the parent.
+input:
+  script: |+
+    (leak() { echo pwned; })
+    leak
+expect:
+  stdout: ""
+  stderr: |+
+    function declarations are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/globbing/vuln_hunt/assignment_value_not_globbed.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/assignment_value_not_globbed.yaml
@@ -1,0 +1,15 @@
+description: Assignment values containing glob metacharacters remain literal.
+setup:
+  files:
+    - path: a.txt
+      content: "a\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    P=*.txt
+    echo "$P"
+expect:
+  stdout: |+
+    *.txt
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/globbing/vuln_hunt/command_substitution_output_globs.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/command_substitution_output_globs.yaml
@@ -1,0 +1,16 @@
+description: Unquoted command substitution output containing glob metacharacters is glob-expanded.
+setup:
+  files:
+    - path: a.txt
+      content: "a\n"
+    - path: b.txt
+      content: "b\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    echo $(echo '*.txt')
+expect:
+  stdout: |+
+    a.txt b.txt
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/globbing/vuln_hunt/extglob_blocked.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/extglob_blocked.yaml
@@ -1,0 +1,11 @@
+# skip: extended globbing is intentionally unsupported in rshell.
+skip_assert_against_bash: true
+description: Extended glob syntax is rejected before expansion.
+input:
+  script: |+
+    echo @(foo|bar)
+expect:
+  stdout: ""
+  stderr: |+
+    extended globbing is not supported
+  exit_code: 2

--- a/tests/scenarios/shell/globbing/vuln_hunt/heredoc_glob_text_is_literal.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/heredoc_glob_text_is_literal.yaml
@@ -1,0 +1,16 @@
+description: Glob-like text in heredoc bodies remains literal.
+setup:
+  files:
+    - path: a.txt
+      content: "a\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    cat <<'EOF'
+    *.txt
+    EOF
+expect:
+  stdout: |+
+    *.txt
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/globbing/vuln_hunt/input_redirect_glob_not_expanded.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/input_redirect_glob_not_expanded.yaml
@@ -1,0 +1,19 @@
+# skip: rshell intentionally treats redirect words as literal sandboxed paths here.
+skip_assert_against_bash: true
+description: Glob characters in input redirects are not expanded into multiple files.
+setup:
+  files:
+    - path: a.txt
+      content: "a\n"
+    - path: b.txt
+      content: "b\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    cat < *.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["*.txt"]
+  exit_code: 0

--- a/tests/scenarios/shell/globbing/vuln_hunt/outside_allowed_glob_stays_literal.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/outside_allowed_glob_stays_literal.yaml
@@ -1,0 +1,20 @@
+# skip: AllowedPaths sandbox restrictions are rshell-specific.
+skip_assert_against_bash: true
+description: Glob patterns outside AllowedPaths stay literal instead of disclosing matching names.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/a.txt
+      content: "secret-a\n"
+    - path: secret/b.txt
+      content: "secret-b\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    echo secret/*.txt
+expect:
+  stdout: |+
+    secret/*.txt
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/globbing/vuln_hunt/symlink_dir_escape_glob_stays_literal.yaml
+++ b/tests/scenarios/shell/globbing/vuln_hunt/symlink_dir_escape_glob_stays_literal.yaml
@@ -1,0 +1,20 @@
+# skip: AllowedPaths sandbox restrictions are rshell-specific.
+skip_assert_against_bash: true
+description: Globbing through an allowed symlink to an outside directory is blocked.
+setup:
+  files:
+    - path: allowed/link
+      symlink: ../secret
+    - path: secret/a.txt
+      content: "secret-a\n"
+    - path: secret/b.txt
+      content: "secret-b\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    echo allowed/link/*.txt
+expect:
+  stdout: |+
+    allowed/link/*.txt
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/heredoc/vuln_hunt/blocked_output_redirect_prevents_expansion.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/blocked_output_redirect_prevents_expansion.yaml
@@ -1,0 +1,15 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+# skip: output redirection to regular files is intentionally blocked in rshell.
+skip_assert_against_bash: true
+description: Blocked output redirects attached to a heredoc fail before body expansion.
+input:
+  script: |+
+    cat <<EOF > out.txt
+    $(echo HEREDOC_EXPANDED >&2)
+    EOF
+    echo after
+expect:
+  stdout: ""
+  stderr: |+
+    > file redirection is not supported
+  exit_code: 2

--- a/tests/scenarios/shell/heredoc/vuln_hunt/cat_shortcut_respects_allowed_paths.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/cat_shortcut_respects_allowed_paths.yaml
@@ -1,0 +1,25 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: Cat-shortcut command substitution inside a heredoc cannot read outside AllowedPaths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cat <<EOF
+    $(< secret/data.txt)
+    EOF
+    echo after
+expect:
+  stdout: |+
+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/heredoc/vuln_hunt/command_substitution_state_isolated.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/command_substitution_state_isolated.yaml
@@ -1,0 +1,15 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+description: Command substitutions in a heredoc do not leak variable writes to the parent shell.
+input:
+  script: |+
+    X=outer
+    cat <<EOF
+    $(X=inner; echo "$X")
+    EOF
+    echo "$X"
+expect:
+  stdout: |+
+    inner
+    outer
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/heredoc/vuln_hunt/comment_and_separator_literals.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/comment_and_separator_literals.yaml
@@ -1,0 +1,16 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+description: Comments and command separators inside heredoc content remain data.
+input:
+  script: |+
+    cat <<EOF
+    # not a comment
+    ; echo bad
+    EOF
+    echo after
+expect:
+  stdout: |+
+    # not a comment
+    ; echo bad
+    after
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/heredoc/vuln_hunt/later_input_redirect_outside_allowed.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/later_input_redirect_outside_allowed.yaml
@@ -1,0 +1,24 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+# skip: allowed_paths sandbox restriction is rshell-specific.
+skip_assert_against_bash: true
+description: A later input redirect after a heredoc is still checked by AllowedPaths.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: |+
+        allowed
+    - path: secret/data.txt
+      content: |+
+        SECRET
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    cat <<EOF < secret/data.txt
+    HEREDOC
+    EOF
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/heredoc/vuln_hunt/quoted_unsupported_syntax_literal.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/quoted_unsupported_syntax_literal.yaml
@@ -1,0 +1,19 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+description: Quoted heredoc delimiters keep unsupported expansion syntax literal.
+input:
+  script: |+
+    X=outer
+    cat <<'EOF'
+    $((1+2))
+    <(echo hi)
+    ${X:=mutated}
+    EOF
+    echo "$X"
+expect:
+  stdout: |+
+    $((1+2))
+    <(echo hi)
+    ${X:=mutated}
+    outer
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/heredoc/vuln_hunt/unquoted_arithmetic_expansion_rejected.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/unquoted_arithmetic_expansion_rejected.yaml
@@ -1,0 +1,14 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+# skip: arithmetic expansion is intentionally blocked in rshell.
+skip_assert_against_bash: true
+description: Arithmetic expansion inside an unquoted heredoc body is rejected.
+input:
+  script: |+
+    cat <<EOF
+    $((1+2))
+    EOF
+expect:
+  stdout: ""
+  stderr: |+
+    arithmetic expansion is not supported
+  exit_code: 2

--- a/tests/scenarios/shell/heredoc/vuln_hunt/unquoted_parameter_assignment_rejected.yaml
+++ b/tests/scenarios/shell/heredoc/vuln_hunt/unquoted_parameter_assignment_rejected.yaml
@@ -1,0 +1,16 @@
+# vuln-hunt 2026-05-19-codex / heredoc.
+# skip: parameter assignment expansions are intentionally blocked in rshell.
+skip_assert_against_bash: true
+description: Parameter assignment expansion inside an unquoted heredoc body is rejected.
+input:
+  script: |+
+    X=outer
+    cat <<EOF
+    ${X:=mutated}
+    EOF
+    echo "$X"
+expect:
+  stdout: ""
+  stderr: |+
+    ${var} operations (defaults, pattern removal, case conversion) are not supported
+  exit_code: 2

--- a/tests/scenarios/shell/logic_ops/vuln_hunt_comment_after_operator.yaml
+++ b/tests/scenarios/shell/logic_ops/vuln_hunt_comment_after_operator.yaml
@@ -1,0 +1,13 @@
+description: Comments after logic operators do not confuse and-or list continuation.
+input:
+  script: |+
+    echo one && # comment after &&
+    echo two ||
+    # comment after ||
+    echo three
+expect:
+  stdout: |+
+    one
+    two
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/logic_ops/vuln_hunt_executed_subshell_state_isolated.yaml
+++ b/tests/scenarios/shell/logic_ops/vuln_hunt_executed_subshell_state_isolated.yaml
@@ -1,0 +1,10 @@
+description: Executed subshell operands in logic chains do not leak variable state to the parent.
+input:
+  script: |+
+    (X=inside; echo "sub=$X") && echo "parent=$X"
+expect:
+  stdout: |+
+    sub=inside
+    parent=
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/logic_ops/vuln_hunt_expanded_operator_not_reparsed.yaml
+++ b/tests/scenarios/shell/logic_ops/vuln_hunt_expanded_operator_not_reparsed.yaml
@@ -1,0 +1,10 @@
+description: Expanded words containing logic operators remain arguments and are not reparsed as control operators.
+input:
+  script: |+
+    OP='&&'
+    echo left $OP echo right
+expect:
+  stdout: |+
+    left && echo right
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/logic_ops/vuln_hunt_skipped_command_substitutions_not_executed.yaml
+++ b/tests/scenarios/shell/logic_ops/vuln_hunt_skipped_command_substitutions_not_executed.yaml
@@ -1,0 +1,11 @@
+description: Command substitutions in short-circuited branches are not evaluated.
+input:
+  script: |+
+    false && echo "$(echo and-ran >&2)"
+    true || echo "$(echo or-ran >&2)"
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/logic_ops/vuln_hunt_skipped_input_redirects_not_opened.yaml
+++ b/tests/scenarios/shell/logic_ops/vuln_hunt_skipped_input_redirects_not_opened.yaml
@@ -1,0 +1,18 @@
+description: Input redirects in short-circuited branches are not opened.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    false && cat < secret/data.txt
+    true || cat < secret/data.txt
+    echo after
+expect:
+  stdout: |+
+    after
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/logic_ops/vuln_hunt_skipped_subshell_state_isolated.yaml
+++ b/tests/scenarios/shell/logic_ops/vuln_hunt_skipped_subshell_state_isolated.yaml
@@ -1,0 +1,11 @@
+description: Skipped subshell operands do not mutate parent-visible variables.
+input:
+  script: |+
+    false && (X=hacked)
+    true || (Y=hacked)
+    echo "X=$X Y=$Y"
+expect:
+  stdout: |+
+    X= Y=
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/negation/vuln_hunt/input_redirect_outside_no_leak.yaml
+++ b/tests/scenarios/shell/negation/vuln_hunt/input_redirect_outside_no_leak.yaml
@@ -1,0 +1,23 @@
+# vuln-hunt 2026-05-19-codex / negation.
+# A denied redirect is an ordinary command failure, so ! may invert the status,
+# but the redirect must still be sandboxed and the command must not see content.
+skip_assert_against_bash: true
+description: Negated sandbox-denied input redirect inverts status without leaking content.
+setup:
+  files:
+    - path: allowed/ok.txt
+      content: "ok\n"
+    - path: secret/data.txt
+      content: "secret\n"
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    ! cat < secret/data.txt
+    echo "status=$?"
+    cat allowed/ok.txt
+expect:
+  stdout: |+
+    status=0
+    ok
+  stderr_contains: ["permission denied"]
+  exit_code: 0

--- a/tests/scenarios/shell/negation/vuln_hunt/output_redirect_validation_not_negated.yaml
+++ b/tests/scenarios/shell/negation/vuln_hunt/output_redirect_validation_not_negated.yaml
@@ -1,0 +1,14 @@
+# vuln-hunt 2026-05-19-codex / negation.
+# Validation happens before statement execution, so ! must not convert a
+# blocked output redirect into a successful no-op.
+skip_assert_against_bash: true
+description: Negation does not invert blocked output-redirection validation errors.
+input:
+  script: |+
+    ! echo hidden > created.txt
+    echo after
+expect:
+  stdout: |+
+  stderr: |+
+    > file redirection is not supported
+  exit_code: 2

--- a/tests/scenarios/shell/pipe/vuln_hunt/expanded_pipe_metachar_is_data.yaml
+++ b/tests/scenarios/shell/pipe/vuln_hunt/expanded_pipe_metachar_is_data.yaml
@@ -1,0 +1,11 @@
+# vuln-hunt 2026-05-19-codex / pipe.
+description: Expanded pipe metacharacters remain data inside a pipeline stage.
+input:
+  script: |+
+    PAYLOAD='alpha | cat'
+    printf '%s\n' "$PAYLOAD" | cat
+expect:
+  stdout: |+
+    alpha | cat
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/shell/pipe/vuln_hunt/pipe_all_rejected.yaml
+++ b/tests/scenarios/shell/pipe/vuln_hunt/pipe_all_rejected.yaml
@@ -1,0 +1,10 @@
+# vuln-hunt 2026-05-19-codex / pipe.
+skip_assert_against_bash: true
+description: Pipe-all stderr operator is rejected instead of becoming a supported pipeline.
+input:
+  script: |+
+    printf 'err\n' >&2 |& cat
+expect:
+  stdout: ""
+  stderr: "|& is not supported\n"
+  exit_code: 2

--- a/tests/scenarios/shell/pipe/vuln_hunt/right_redirect_outside_allowed.yaml
+++ b/tests/scenarios/shell/pipe/vuln_hunt/right_redirect_outside_allowed.yaml
@@ -1,0 +1,16 @@
+# vuln-hunt 2026-05-19-codex / pipe.
+skip_assert_against_bash: true
+description: Right pipeline stage input redirect must use AllowedPaths and not read outside the sandbox.
+setup:
+  files:
+    - path: allowed.txt
+      content: |+
+        allowed
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    printf 'pipe-data\n' | cat </etc/passwd
+expect:
+  stdout: ""
+  stderr_contains: ["passwd"]
+  exit_code: 1

--- a/tests/scenarios/shell/pipe/vuln_hunt/stage_assignments_do_not_leak.yaml
+++ b/tests/scenarios/shell/pipe/vuln_hunt/stage_assignments_do_not_leak.yaml
@@ -1,0 +1,13 @@
+# vuln-hunt 2026-05-19-codex / pipe.
+description: Pipeline stage assignments stay isolated from the parent shell and sibling stages.
+input:
+  script: |+
+    X=parent
+    { X=left; printf '%s\n' "$X"; } | { read X; printf 'right=%s\n' "$X"; X=right; }
+    printf 'parent=%s\n' "$X"
+expect:
+  stdout: |+
+    right=left
+    parent=parent
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
### What does this PR do?

Adds a large batch of regression tests from a vuln-hunt exercise (`[vuln-hunt 2026-05-19-codex]`). All new files are tests — no behavioural changes to builtins or the interpreter. The tests exercise sandbox boundaries and confirm that attempted bypasses stay blocked across many surface areas:

- **Builtin hardening** (`cut`, `echo`, `exit`, `grep`, `ping`, `printf`, `ps`, `read`, `sed`, `ss`, `strings`, `tr`, `true`, `uniq`, `wc`): input redirects outside `AllowedPaths`, symlink escapes, dash-prefixed filenames after `--`, output redirects blocked, unsupported flags rejected, numeric-arg overflow, etc.
- **Internal procnet readers** (`procnetsocket`, `procnetroute`): direct unit tests covering Linux happy-path and non-Linux refusal.
- **Interpreter / shell semantics** (`case_clause`, `globbing`, `logic_ops`, `pipe`, `signal_handling`, plus scenario coverage for `brace_group`, `empty_script`, `field_splitting`, `for_clause`, `function`, `heredoc`, `allowed_commands`, `allowed_paths`, `blocked_commands`): blocked chains, sandboxed expansion, command-substitution isolation, redirect / comment / metacharacter handling.

### Motivation

Capture findings from the 2026-05-19 vuln-hunt round as regression coverage so future refactors cannot silently regress sandbox guarantees.

### Testing

- `go test ./...` (all new tests pass).
- Scenario suite runs under both the shell and bash (`RSHELL_BASH_TEST=1 go test ./tests/ -run TestShellScenariosAgainstBash`); scenarios that intentionally diverge from bash (sandbox restrictions, blocked commands) are marked `skip_assert_against_bash: true`.

### Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)
