### PR TITLE
Fix absolute glob expansion in sandbox

### DIFF
--- a/allowedpaths/sandbox.go
+++ b/allowedpaths/sandbox.go
@@ -142,7 +142,7 @@ func (s *Sandbox) isAncestorOfRoot(absPath string) bool {
 		if err != nil {
 			continue
 		}
-		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			continue
 		}
 		return true

--- a/allowedpaths/sandbox.go
+++ b/allowedpaths/sandbox.go
@@ -126,6 +126,30 @@ func (s *Sandbox) resolve(absPath string) (*root, string, bool) {
 	return nil, "", false
 }
 
+// isAncestorOfRoot reports whether absPath is a directory prefix of any
+// configured sandbox root, without being inside that root itself.
+func (s *Sandbox) isAncestorOfRoot(absPath string) bool {
+	if s == nil {
+		return false
+	}
+	absPath = filepath.Clean(absPath)
+	for i := range s.roots {
+		rootPath := filepath.Clean(s.roots[i].absPath)
+		if absPath == rootPath {
+			continue
+		}
+		rel, err := filepath.Rel(absPath, rootPath)
+		if err != nil {
+			continue
+		}
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // resolveRootFollowingSymlinks resolves absPath to a (root, relPath) pair,
 // following symlinks that cross between allowed roots. It walks the
 // relative path component by component; when a component is a symlink,
@@ -368,6 +392,13 @@ func (s *Sandbox) readDirN(path string, cwd string, maxEntries int) ([]fs.DirEnt
 
 	ar, relPath, ok := s.resolve(absPath)
 	if !ok {
+		if maxEntries > 0 && s.isAncestorOfRoot(absPath) {
+			// Absolute glob expansion walks non-meta path components with
+			// ReadDirForGlob before it reaches the directory containing the
+			// metacharacters. Let it traverse harmless ancestors of allowed
+			// roots, but do not expose their entries.
+			return nil, nil
+		}
 		return nil, &os.PathError{Op: "readdir", Path: path, Err: os.ErrPermission}
 	}
 

--- a/interp/allowed_paths_test.go
+++ b/interp/allowed_paths_test.go
@@ -180,6 +180,45 @@ func TestAllowedPathsGlobInside(t *testing.T) {
 	assert.Contains(t, stdout, "b.txt")
 }
 
+func TestAllowedPathsAbsoluteGlobInside(t *testing.T) {
+	dir := t.TempDir()
+	data := filepath.Join(dir, "data")
+	require.NoError(t, os.Mkdir(data, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(data, "test-s-2-o"), []byte("2\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(data, "test-s-1-o"), []byte("1\n"), 0644))
+
+	pattern := shellQuoteForTest(filepath.ToSlash(data)) + "/test-s-*-o"
+	stdout, stderr, exitCode := runScript(t, "printf '%s\\n' "+pattern, dir,
+		interp.AllowedPaths([]string{data}),
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "", stderr)
+	assert.Equal(t, []string{
+		filepath.Join(data, "test-s-1-o"),
+		filepath.Join(data, "test-s-2-o"),
+	}, cleanOutputPaths(stdout))
+}
+
+func TestAllowedPathsAbsoluteGlobOutsideStaysLiteral(t *testing.T) {
+	dir := t.TempDir()
+	allowed := filepath.Join(dir, "allowed")
+	secret := filepath.Join(dir, "secret")
+	require.NoError(t, os.Mkdir(allowed, 0755))
+	require.NoError(t, os.Mkdir(secret, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(secret, "a.txt"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(secret, "b.txt"), []byte(""), 0644))
+
+	pattern := shellQuoteForTest(filepath.ToSlash(secret)) + "/*.txt"
+	stdout, stderr, exitCode := runScript(t, "printf '%s\\n' "+pattern, dir,
+		interp.AllowedPaths([]string{allowed}),
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "", stderr)
+	assert.Equal(t, []string{filepath.Join(secret, "*.txt")}, cleanOutputPaths(stdout))
+}
+
 func TestAllowedPathsGlobOutside(t *testing.T) {
 	allowed := t.TempDir()
 	secret := t.TempDir()
@@ -192,6 +231,22 @@ func TestAllowedPathsGlobOutside(t *testing.T) {
 	)
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "*.txt") // pattern not expanded
+}
+
+func shellQuoteForTest(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func cleanOutputPaths(stdout string) []string {
+	trimmed := strings.TrimSuffix(stdout, "\n")
+	if trimmed == "" {
+		return nil
+	}
+	lines := strings.Split(trimmed, "\n")
+	for i, line := range lines {
+		lines[i] = filepath.Clean(line)
+	}
+	return lines
 }
 
 func TestAllowedPathsTraversalBlocked(t *testing.T) {

--- a/tests/scenarios/shell/allowed_paths/absolute_glob_bracket_negation.yaml
+++ b/tests/scenarios/shell/allowed_paths/absolute_glob_bracket_negation.yaml
@@ -1,0 +1,29 @@
+description: Absolute glob expansion supports bracket ranges and negated character classes inside allowed paths.
+setup:
+  files:
+    - path: data/team-a/report-1.txt
+      content: |+
+        a1
+    - path: data/team-a/report-2.txt
+      content: |+
+        a2
+    - path: data/team-b/report-1.txt
+      content: |+
+        b1
+    - path: data/team-c/report-1.txt
+      content: |+
+        c1
+    - path: data/team-a/report-3.txt
+      content: |+
+        a3
+input:
+  allowed_paths: ["data"]
+  script: |+
+    cat "$PWD"/data/team-[!c]/report-[1-2].txt
+expect:
+  stdout: |+
+    a1
+    a2
+    b1
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/absolute_glob_inside_allowed.yaml
+++ b/tests/scenarios/shell/allowed_paths/absolute_glob_inside_allowed.yaml
@@ -1,0 +1,19 @@
+description: Absolute glob expansion works inside allowed paths.
+setup:
+  files:
+    - path: data/test-s-2-o
+      content: |+
+        2
+    - path: data/test-s-1-o
+      content: |+
+        1
+input:
+  allowed_paths: ["data"]
+  script: |+
+    cat "$PWD"/data/test-s-*-o
+expect:
+  stdout: |+
+    1
+    2
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/absolute_glob_multiple_complex_patterns.yaml
+++ b/tests/scenarios/shell/allowed_paths/absolute_glob_multiple_complex_patterns.yaml
@@ -1,0 +1,30 @@
+description: Multiple absolute glob patterns expand independently inside allowed paths.
+setup:
+  files:
+    - path: data/src/apple/one.txt
+      content: |+
+        apple-one
+    - path: data/src/apricot/one.txt
+      content: |+
+        apricot-one
+    - path: data/src/banana/two-a.txt
+      content: |+
+        banana-two-a
+    - path: data/src/banana/two-b.txt
+      content: |+
+        banana-two-b
+    - path: data/src/cherry/two-a.txt
+      content: |+
+        cherry-two-a
+input:
+  allowed_paths: ["data"]
+  script: |+
+    cat "$PWD"/data/src/a*/one.txt "$PWD"/data/src/b*/two-[ab].txt
+expect:
+  stdout: |+
+    apple-one
+    apricot-one
+    banana-two-a
+    banana-two-b
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/absolute_glob_nested_mixed_patterns.yaml
+++ b/tests/scenarios/shell/allowed_paths/absolute_glob_nested_mixed_patterns.yaml
@@ -1,0 +1,29 @@
+description: Absolute glob expansion supports mixed metacharacters across nested allowed paths.
+setup:
+  files:
+    - path: data/pkg-alpha/release-1/artifact-aa.txt
+      content: |+
+        alpha-1
+    - path: data/pkg-alpha/release-2/artifact-ab.txt
+      content: |+
+        alpha-2
+    - path: data/pkg-beta/release-1/artifact-ba.txt
+      content: |+
+        beta-1
+    - path: data/pkg-beta/release-3/artifact-bc.txt
+      content: |+
+        beta-3
+    - path: data/pkg-gamma/release-1/artifact-long.txt
+      content: |+
+        gamma-long
+input:
+  allowed_paths: ["data"]
+  script: |+
+    cat "$PWD"/data/pkg-*/release-[12]/artifact-??.txt
+expect:
+  stdout: |+
+    alpha-1
+    alpha-2
+    beta-1
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/shell/allowed_paths/absolute_glob_outside_allowed.yaml
+++ b/tests/scenarios/shell/allowed_paths/absolute_glob_outside_allowed.yaml
@@ -1,0 +1,20 @@
+# skip: allowed_paths sandbox restriction is an rshell-specific feature not present in bash
+skip_assert_against_bash: true
+description: Absolute glob expansion outside allowed paths stays literal.
+setup:
+  files:
+    - path: allowed/keep.txt
+      content: |+
+    - path: secret/a.txt
+      content: |+
+    - path: secret/b.txt
+      content: |+
+input:
+  allowed_paths: ["allowed"]
+  script: |+
+    printf '%s\n' "$PWD"/secret/*.txt
+expect:
+  stdout_contains:
+    - "secret/*.txt"
+  stderr: |+
+  exit_code: 0


### PR DESCRIPTION
## What changed

- Allow absolute glob expansion to traverse non-enumerated ancestors of configured AllowedPaths roots.
- Keep out-of-sandbox absolute glob patterns literal so they do not disclose filenames.
- Add regression coverage for absolute globs inside and outside the sandbox.

## Why

The shell expander validates non-meta absolute path components with ReadDirForGlob before it reaches the directory containing the glob metacharacters. When AllowedPaths was set to a nested root, those ancestor reads were denied, so patterns such as /var/tmp/test-s-*-o stayed literal even though the target directory was allowed.

## Validation

- make fmt
- go test ./interp -run 'TestAllowedPaths(AbsoluteGlobInside|AbsoluteGlobOutsideStaysLiteral|GlobInside|GlobOutside)$'
- go test ./allowedpaths ./interp ./tests
- go test ./...
