### PR TITLE
feat(interp): add RemediationMode() RunnerOption [PR A]

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Every access path is default-deny:
 
 **ProcPath** (Linux-only) overrides the proc filesystem root used by the `ps` builtin (default `/proc`). This is a privileged option set at runner construction time by trusted caller code — scripts cannot influence it. Access to the proc path is intentionally not subject to `AllowedPaths` restrictions. To avoid leaking secrets passed as CLI arguments, `ps` does not read `/proc/<pid>/cmdline`; the `CMD` column reports only the process comm/executable name.
 
+**RemediationMode** opts the runner into host-remediation mode, which will enable write operations (file-target redirections, truncate, log rotation) within the configured `AllowedPaths`. This option is inert in the current release; write behavior is enabled in follow-up PRs. CLI flag: `--remediation-mode`.
+
 ## Shell Features
 
 Inside rshell, run `help` to list supported feature categories, a concise unsupported-feature summary, enabled commands, and the configured `AllowedPaths` sandbox roots (or a notice when none are configured). Use `help <feature|command>` for details about a specific rshell feature or command.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Every access path is default-deny:
 
 **ProcPath** (Linux-only) overrides the proc filesystem root used by the `ps` builtin (default `/proc`). This is a privileged option set at runner construction time by trusted caller code — scripts cannot influence it. Access to the proc path is intentionally not subject to `AllowedPaths` restrictions. To avoid leaking secrets passed as CLI arguments, `ps` does not read `/proc/<pid>/cmdline`; the `CMD` column reports only the process comm/executable name.
 
-**RemediationMode** opts the runner into host-remediation mode, which will enable write operations (file-target redirections, truncate, log rotation) within the configured `AllowedPaths`. This option is inert in the current release; write behavior is enabled in follow-up PRs. CLI flag: `--remediation-mode`.
+**RemediationMode** opts the runner into host-remediation mode, which will enable write operations (file-target redirections, truncate, log rotation) within the configured `AllowedPaths`. This option is inert in the current release; write behavior is enabled in follow-up PRs. CLI flag: `--mode remediation` (default: `--mode read-only`).
 
 ## Shell Features
 

--- a/SHELL_FEATURES.md
+++ b/SHELL_FEATURES.md
@@ -111,6 +111,7 @@ The in-shell `help` command mirrors these feature categories: run `help` for a c
 - ✅ AllowedPaths filesystem sandboxing — restricts all file access to specified directories
 - ✅ Whole-run execution timeout — callers can bound a `Run()` call via `context.Context`, `interp.MaxExecutionTime`, or the CLI `--timeout` flag; the deadline applies to the entire script, not each individual command
 - ✅ ProcPath — overrides the proc filesystem path used by `ps` (default `/proc`; Linux-only; useful for testing/container environments); `ps` does not read `/proc/<pid>/cmdline`
+- ✅ RemediationMode — opt-in mode (`interp.RemediationMode()` / `--remediation-mode`) that will enable write operations within `AllowedPaths`; currently inert (write behavior wired in follow-up PRs)
 - ❌ External commands — blocked by default; requires an ExecHandler to be configured and the binary to be within AllowedPaths
 - ❌ Background execution: `cmd &`
 - ❌ Coprocesses: `coproc`

--- a/SHELL_FEATURES.md
+++ b/SHELL_FEATURES.md
@@ -111,7 +111,7 @@ The in-shell `help` command mirrors these feature categories: run `help` for a c
 - ✅ AllowedPaths filesystem sandboxing — restricts all file access to specified directories
 - ✅ Whole-run execution timeout — callers can bound a `Run()` call via `context.Context`, `interp.MaxExecutionTime`, or the CLI `--timeout` flag; the deadline applies to the entire script, not each individual command
 - ✅ ProcPath — overrides the proc filesystem path used by `ps` (default `/proc`; Linux-only; useful for testing/container environments); `ps` does not read `/proc/<pid>/cmdline`
-- ✅ RemediationMode — opt-in mode (`interp.RemediationMode()` / `--remediation-mode`) that will enable write operations within `AllowedPaths`; currently inert (write behavior wired in follow-up PRs)
+- ✅ RemediationMode — opt-in mode (`interp.RemediationMode()` / `--mode remediation`) that will enable write operations within `AllowedPaths`; currently inert (write behavior wired in follow-up PRs)
 - ❌ External commands — blocked by default; requires an ExecHandler to be configured and the binary to be within AllowedPaths
 - ❌ Background execution: `cmd &`
 - ❌ Coprocesses: `coproc`

--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -40,6 +40,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		allowAllCmds    bool
 		timeout         time.Duration
 		procPath        string
+		remediationMode bool
 	)
 
 	cmd := &cobra.Command{
@@ -85,6 +86,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 				allowedCommands:  cmds,
 				allowAllCommands: allowAllCmds,
 				procPath:         procPath,
+				remediationMode:  remediationMode,
 			}
 
 			if commandSet {
@@ -137,6 +139,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	cmd.Flags().BoolVar(&allowAllCmds, "allow-all-commands", false, "allow execution of all commands (builtins and external)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "maximum execution time for the entire shell run (e.g. 100ms, 5s, 1m)")
 	cmd.Flags().StringVar(&procPath, "proc-path", "", "path to the proc filesystem used by ps (default \"/proc\")")
+	cmd.Flags().BoolVar(&remediationMode, "remediation-mode", false, "enable host-remediation mode (allows write operations within AllowedPaths; inert in this release)")
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		var status interp.ExitStatus
@@ -206,6 +209,7 @@ type executeOpts struct {
 	allowedCommands  []string
 	allowAllCommands bool
 	procPath         string
+	remediationMode  bool
 }
 
 func execute(ctx context.Context, script, name string, opts executeOpts, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -231,6 +235,9 @@ func execute(ctx context.Context, script, name string, opts executeOpts, stdin i
 	}
 	if opts.procPath != "" {
 		runOpts = append(runOpts, interp.ProcPath(opts.procPath))
+	}
+	if opts.remediationMode {
+		runOpts = append(runOpts, interp.RemediationMode())
 	}
 
 	runner, err := interp.New(runOpts...)

--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -81,7 +81,8 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 				cmds = strings.Split(allowedCommands, ",")
 			}
 
-			if mode != "read-only" && mode != "remediation" {
+			parsedMode := interp.Mode(mode)
+			if parsedMode != interp.ModeReadOnly && parsedMode != interp.ModeRemediation {
 				return fmt.Errorf("--mode must be one of: read-only, remediation")
 			}
 
@@ -90,7 +91,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 				allowedCommands:  cmds,
 				allowAllCommands: allowAllCmds,
 				procPath:         procPath,
-				remediationMode:  mode == "remediation",
+				mode:             parsedMode,
 			}
 
 			if commandSet {
@@ -213,7 +214,7 @@ type executeOpts struct {
 	allowedCommands  []string
 	allowAllCommands bool
 	procPath         string
-	remediationMode  bool
+	mode             interp.Mode
 }
 
 func execute(ctx context.Context, script, name string, opts executeOpts, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -240,7 +241,7 @@ func execute(ctx context.Context, script, name string, opts executeOpts, stdin i
 	if opts.procPath != "" {
 		runOpts = append(runOpts, interp.ProcPath(opts.procPath))
 	}
-	if opts.remediationMode {
+	if opts.mode == interp.ModeRemediation {
 		runOpts = append(runOpts, interp.RemediationMode())
 	}
 

--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -40,7 +40,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		allowAllCmds    bool
 		timeout         time.Duration
 		procPath        string
-		remediationMode bool
+		mode            string
 	)
 
 	cmd := &cobra.Command{
@@ -81,12 +81,16 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 				cmds = strings.Split(allowedCommands, ",")
 			}
 
+			if mode != "read-only" && mode != "remediation" {
+				return fmt.Errorf("--mode must be one of: read-only, remediation")
+			}
+
 			execOpts := executeOpts{
 				allowedPaths:     paths,
 				allowedCommands:  cmds,
 				allowAllCommands: allowAllCmds,
 				procPath:         procPath,
-				remediationMode:  remediationMode,
+				remediationMode:  mode == "remediation",
 			}
 
 			if commandSet {
@@ -139,7 +143,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	cmd.Flags().BoolVar(&allowAllCmds, "allow-all-commands", false, "allow execution of all commands (builtins and external)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "maximum execution time for the entire shell run (e.g. 100ms, 5s, 1m)")
 	cmd.Flags().StringVar(&procPath, "proc-path", "", "path to the proc filesystem used by ps (default \"/proc\")")
-	cmd.Flags().BoolVar(&remediationMode, "remediation-mode", false, "enable host-remediation mode (allows write operations within AllowedPaths; inert in this release)")
+	cmd.Flags().StringVar(&mode, "mode", "read-only", "shell execution mode: read-only (default) or remediation (enables write operations within AllowedPaths; inert in this release)")
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		var status interp.ExitStatus

--- a/interp/api.go
+++ b/interp/api.go
@@ -90,6 +90,10 @@ type runnerConfig struct {
 	// Defaults to "/proc" when empty.
 	procPath string
 
+	// remediationMode enables write operations (file-target redirections, etc.)
+	// when true. Inert in this release; behavior is wired in follow-up PRs.
+	remediationMode bool
+
 	// proc is the ProcProvider constructed from procPath, created once in
 	// New() and shared across subshells via runnerConfig value copy.
 	proc *builtins.ProcProvider
@@ -827,6 +831,17 @@ func allowAllCommandsOpt() RunnerOption {
 func ProcPath(path string) RunnerOption {
 	return func(r *Runner) error {
 		r.procPath = path
+		return nil
+	}
+}
+
+// RemediationMode opts the runner into host-remediation mode. In this mode,
+// write operations (such as file-target redirections) that are normally blocked
+// will be permitted when AllowedPaths is also configured. This option is inert
+// in the current release; write behavior is enabled in a follow-up PR.
+func RemediationMode() RunnerOption {
+	return func(r *Runner) error {
+		r.remediationMode = true
 		return nil
 	}
 }

--- a/interp/api.go
+++ b/interp/api.go
@@ -835,6 +835,18 @@ func ProcPath(path string) RunnerOption {
 	}
 }
 
+// Mode controls the execution mode of a Runner.
+type Mode string
+
+const (
+	// ModeReadOnly is the default mode: all write operations are blocked.
+	ModeReadOnly Mode = "read-only"
+	// ModeRemediation enables write operations (file-target redirections, etc.)
+	// within the configured AllowedPaths. Inert in this release; behavior is
+	// wired in follow-up PRs.
+	ModeRemediation Mode = "remediation"
+)
+
 // RemediationMode opts the runner into host-remediation mode. In this mode,
 // write operations (such as file-target redirections) that are normally blocked
 // will be permitted when AllowedPaths is also configured. This option is inert


### PR DESCRIPTION
## Summary

- Adds `RemediationMode() RunnerOption` in `interp/api.go` with the corresponding `remediationMode bool` field on `runnerConfig`
- Adds `--remediation-mode` boolean CLI flag (default `false`) in `cmd/rshell/main.go`
- Documents the new mode in `README.md` and `SHELL_FEATURES.md` (one line each)

**This PR is purely an API addition — no behavior changes.** The option is accepted and stored on the runner but is otherwise inert.

## Context (multi-PR series)

| PR | Description |
|----|-------------|
| **A (this PR)** | `RemediationMode()` option — API only, inert |
| B | Add write capability to `allowedpaths/sandbox.go` |
| C | Wire `remediationMode` into interpreter so `>` / `>>` redirects work when set |
| Later | `truncate` and `logrotate` builtins |

End goal: a `runRemediationCommand` PAR action creates a `Runner` with `RemediationMode()` set; the existing `runCommand` action does not.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `make fmt` — no changes after formatting