### PR TITLE
feat(help): move command count to Commands section header

### DIFF
--- a/builtins/help/help.go
+++ b/builtins/help/help.go
@@ -113,14 +113,19 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 			allowed = append(allowed, name)
 		}
 
-		// Header: version + command counts.
-		printHeader(callCtx, len(allowed), len(allNames))
+		// Header: version line only.
+		printHeader(callCtx)
 
 		callCtx.Out("Features:\n")
 		printFeatureTable(callCtx, builtins.Features())
 		printUnsupportedSummary(callCtx, builtins.UnsupportedSummary())
 
-		callCtx.Out("\nCommands:\n")
+		// Commands section label, with count when not all commands are enabled.
+		if len(notAllowed) > 0 {
+			callCtx.Outf("\nCommands (%d of %d enabled):\n", len(allowed), len(allNames))
+		} else {
+			callCtx.Out("\nCommands:\n")
+		}
 		printCommandTable(callCtx, allowed)
 
 		// Show disabled commands when restrictions are active.
@@ -148,20 +153,12 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	}
 }
 
-// printHeader writes the version line and command count summary.
-func printHeader(callCtx *builtins.CallContext, allowed, total int) {
-	var header strings.Builder
-	header.WriteString("rshell")
+// printHeader writes the version line.
+func printHeader(callCtx *builtins.CallContext) {
 	if version.Version != "" {
-		header.WriteString(" (")
-		header.WriteString(version.Version)
-		header.WriteByte(')')
-	}
-	header.WriteString(" — ")
-	if allowed < total {
-		callCtx.Outf("%s%d of %d commands enabled\n\n", header.String(), allowed, total)
+		callCtx.Outf("rshell (%s)\n\n", version.Version)
 	} else {
-		callCtx.Outf("%sAll %d commands available\n\n", header.String(), total)
+		callCtx.Out("rshell\n\n")
 	}
 }
 

--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -58,7 +58,7 @@ func tableLines(output, header string) []string {
 	var out []string
 	inSection := false
 	for _, line := range lines {
-		if line == header {
+		if strings.HasPrefix(line, header) {
 			inSection = true
 			continue
 		}
@@ -110,15 +110,14 @@ func TestHelpHeaderShowsRshell(t *testing.T) {
 	stdout, _, code := runScript(t, "help", "", interpoption.AllowAllCommands().(interp.RunnerOption))
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout, "rshell")
-	assert.Contains(t, stdout, "All ")
 }
 
 func TestHelpHeaderRestrictedShowsCount(t *testing.T) {
 	stdout, _, code := runScript(t, "help", "",
 		interp.AllowedCommands([]string{"rshell:echo", "rshell:help"}))
 	assert.Equal(t, 0, code)
-	assert.Contains(t, stdout, "2 of")
-	assert.Contains(t, stdout, "commands enabled")
+	assert.Contains(t, stdout, "Commands (2 of")
+	assert.Contains(t, stdout, "enabled):")
 }
 
 // --- Output content ---


### PR DESCRIPTION
Before, the command count appeared in the top-level header line:

```
rshell (v0.0.20) — 32 of 34 commands enabled
```

That's easy to miss and not where you'd look for it. It now sits next to the section it actually describes:

```
rshell (v0.0.20)

...

Commands (32 of 34 enabled):
  cat   concatenate and print files
  ...
```

When all commands are enabled, the label stays as plain `Commands:` — no count needed.