### PR TITLE
feat(analysis): split interpAllowedSymbols into per-mode lists [PR C]

### DIFF
--- a/analysis/symbols_interp.go
+++ b/analysis/symbols_interp.go
@@ -150,3 +150,156 @@ var interpAllowedSymbols = []string{
 	"mvdan.cc/sh/v3/syntax.WordIter",     // 🟢 AST node for word iteration (for-in); pure type.
 	"mvdan.cc/sh/v3/syntax.WordPart",     // 🟢 AST interface for word components; pure interface.
 }
+
+// interpPerModeSymbols maps each interpreter mode to its symbol allowlist.
+// Every symbol here must also appear in interpAllowedSymbols (ceiling check).
+//
+//	"read-only"   — symbols allowed in ALL interp/ files.
+//	"remediation" — ADDITIONAL symbols allowed ONLY in interp/*_remediation.go files.
+//	                Starts empty; grows as write features are wired in.
+//
+// Remediation files are checked against "read-only" ∪ "remediation".
+// Non-remediation files are checked against "read-only" only.
+var interpPerModeSymbols = map[string][]string{
+	"read-only": {
+		// Every symbol currently in interpAllowedSymbols belongs here for now.
+		// (Move entries to "remediation" only when they are write-capable and
+		//  only used by _remediation.go files.)
+		"bytes.Buffer",                // 🟢 in-memory byte buffer; pure data structure, no I/O.
+		"context.Background",          // 🟢 returns the empty background context; used in StdIO option where no run-scoped context is available.
+		"context.CancelFunc",          // 🟢 function type returned by WithTimeout/WithCancel; pure function type, no side effects.
+		"context.Canceled",            // 🟢 sentinel error returned by ctx.Err() when Done was closed by CancelFunc; used to classify the run-span outcome.
+		"context.Context",             // 🟢 deadline/cancellation plumbing; pure interface, no side effects.
+		"context.DeadlineExceeded",    // 🟢 sentinel error returned by ctx.Err() on deadline; used to classify the run-span outcome.
+		"context.WithTimeout",         // 🟢 derives a context with a deadline; needed for execution timeout support.
+		"context.WithValue",           // 🟢 derives a context carrying a key-value pair; pure function.
+		"errors.As",                   // 🟢 error type assertion; pure function, no I/O.
+		"errors.Is",                   // 🟢 sentinel-error equivalence check; pure function, no I/O.
+		"errors.New",                  // 🟢 creates a sentinel error value; pure function, no I/O.
+		"fmt.Errorf",                  // 🟢 formatted error creation; pure function, no I/O.
+		"fmt.Fprintf",                 // 🟠 formatted write to an io.Writer; delegates to Write, no filesystem access.
+		"fmt.Fprintln",                // 🟠 writes to an io.Writer with newline; delegates to Write, no filesystem access.
+		"fmt.Sprintf",                 // 🟢 string formatting; pure function, no I/O.
+		"io.Closer",                   // 🟢 interface type for closing; no side effects.
+		"io.Copy",                     // 🟠 copies from Reader to Writer; no filesystem access, delegates to Read/Write.
+		"io.Discard",                  // 🟢 write sink that discards all data; no side effects.
+		"io.LimitReader",              // 🟢 wraps a Reader with a byte cap; pure function, no I/O.
+		"io.Reader",                   // 🟢 interface type for reading; no side effects.
+		"io.ReadWriteCloser",          // 🟢 combined interface type; no side effects.
+		"io.Writer",                   // 🟢 interface type for writing; no side effects.
+		"io/fs.DirEntry",              // 🟢 interface type for directory entries; no side effects.
+		"io/fs.FileInfo",              // 🟢 interface type for file metadata; no side effects.
+		"io/fs.ReadDirFile",           // 🟢 read-only directory handle interface; no write capability.
+		"maps.Insert",                 // 🟢 inserts all key-value pairs from one map into another; pure function.
+		"os.DirEntry",                 // 🟢 type alias for fs.DirEntry; no side effects.
+		"os.File",                     // 🟠 file handle type; interpreter needs file I/O for redirects and pipes.
+		"os.FileMode",                 // 🟢 file permission bits type; pure type.
+		"os.Getwd",                    // 🟠 returns current working directory; read-only.
+		"os.O_RDONLY",                 // 🟢 read-only file flag constant; pure constant.
+		"os.PathError",                // 🟢 error type wrapping path and operation; pure type.
+		"os.Pipe",                     // 🟠 creates an OS pipe pair; needed for shell pipelines.
+		"path/filepath.Clean",         // 🟢 normalizes a path lexically; pure function, no I/O.
+		"path/filepath.IsAbs",         // 🟢 checks if path is absolute; pure function, no I/O.
+		"path/filepath.Join",          // 🟢 joins path elements; pure function, no I/O.
+		"path/filepath.ListSeparator", // 🟢 OS-specific path list separator; pure constant.
+		"runtime.GOOS",                // 🟢 current OS name constant; pure constant, no I/O.
+		"strconv.Itoa",                // 🟢 int-to-string conversion; pure function, no I/O.
+		"strings.Builder",             // 🟢 efficient string concatenation; pure in-memory buffer, no I/O.
+		"strings.ContainsRune",        // 🟢 checks if a rune is in a string; pure function, no I/O.
+		"strings.NewReader",           // 🟢 wraps a string as an io.Reader; pure function, no I/O; used by ParseScript.
+		"strings.Index",               // 🟢 finds substring index; pure function, no I/O.
+		"strings.HasPrefix",           // 🟢 pure function for prefix matching; no I/O.
+		"strings.HasSuffix",           // 🟢 pure function for suffix matching; no I/O.
+		"strings.Join",                // 🟢 joins string slices; pure function, no I/O.
+		"strings.Split",               // 🟢 splits a string by separator; pure function, no I/O.
+		"strings.ToUpper",             // 🟢 converts string to uppercase; pure function, no I/O.
+		"strings.TrimLeft",            // 🟢 trims leading characters; pure function, no I/O.
+		"sync.Mutex",                  // 🟢 mutual exclusion lock; concurrency primitive, no I/O.
+		"sync.Once",                   // 🟢 ensures a function runs exactly once; concurrency primitive, no I/O.
+		"sync.WaitGroup",              // 🟢 waits for goroutines to finish; concurrency primitive, no I/O.
+		"sync/atomic.Int64",           // 🟢 atomic int64 counter; concurrency primitive, no I/O.
+		"time.Duration",               // 🟢 numeric duration type; pure type, no side effects.
+		"time.Now",                    // 🟠 returns current time; read-only, no mutation.
+		"time.Time",                   // 🟢 time value type; pure data, no side effects.
+
+		// --- github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry ---
+
+		"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry.Span",                 // 🟢 pointer type used to hold a span across the if-block that starts it; no side effects from the type reference itself.
+		"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry.StartSpanFromContext", // 🟠 starts a span from a parent carried on ctx; registers with the package-global tracer. No I/O here — flushing happens only if the embedding process has also called NewTelemetry.
+
+		// --- mvdan.cc/sh/v3/expand ---
+
+		"mvdan.cc/sh/v3/expand.Config",                 // 🟢 configuration for word expansion; pure type.
+		"mvdan.cc/sh/v3/expand.Document",               // 🟢 expands a here-document; pure function.
+		"mvdan.cc/sh/v3/expand.Environ",                // 🟢 interface for environment variable access; pure interface.
+		"mvdan.cc/sh/v3/expand.Fields",                 // 🟢 expands words into fields (splitting, globbing); core expansion.
+		"mvdan.cc/sh/v3/expand.KeepValue",              // 🟢 sentinel for variable expansion; pure constant.
+		"mvdan.cc/sh/v3/expand.ListEnviron",            // 🟢 converts string slice to Environ; pure function.
+		"mvdan.cc/sh/v3/expand.Literal",                // 🟢 expands a word to a single literal string; pure function.
+		"mvdan.cc/sh/v3/expand.String",                 // 🟢 expands a word to a string; pure function.
+		"mvdan.cc/sh/v3/expand.UnexpectedCommandError", // 🟢 error for unexpected command substitution in restricted mode; pure type.
+		"mvdan.cc/sh/v3/expand.UnsetParameterError",    // 🟢 error for unset parameter expansion; pure type.
+		"mvdan.cc/sh/v3/expand.Variable",               // 🟢 represents a shell variable; pure type.
+		"mvdan.cc/sh/v3/expand.WriteEnviron",           // 🟢 interface for setting environment variables; pure interface.
+
+		// --- mvdan.cc/sh/v3/syntax ---
+
+		"mvdan.cc/sh/v3/syntax.AndStmt",      // 🟢 AST node for && operator; pure type.
+		"mvdan.cc/sh/v3/syntax.AppAll",       // 🟢 redirect operator constant (&>>); pure constant.
+		"mvdan.cc/sh/v3/syntax.AppOut",       // 🟢 redirect operator constant (>>); pure constant.
+		"mvdan.cc/sh/v3/syntax.ArithmCmd",    // 🟢 AST node for (( )) arithmetic command; pure type.
+		"mvdan.cc/sh/v3/syntax.ArithmExp",    // 🟢 AST node for $(( )) arithmetic expansion; pure type.
+		"mvdan.cc/sh/v3/syntax.ArithmExpr",   // 🟢 AST interface for arithmetic expressions; pure interface.
+		"mvdan.cc/sh/v3/syntax.Assign",       // 🟢 AST node for variable assignment; pure type.
+		"mvdan.cc/sh/v3/syntax.BinaryCmd",    // 🟢 AST node for binary command (&&, ||, |); pure type.
+		"mvdan.cc/sh/v3/syntax.Block",        // 🟢 AST node for { } command group; pure type.
+		"mvdan.cc/sh/v3/syntax.CallExpr",     // 🟢 AST node for simple command call; pure type.
+		"mvdan.cc/sh/v3/syntax.CaseClause",   // 🟢 AST node for case statement; pure type.
+		"mvdan.cc/sh/v3/syntax.ClbOut",       // 🟢 redirect operator constant (>|); pure constant.
+		"mvdan.cc/sh/v3/syntax.CmdSubst",     // 🟢 AST node for $() command substitution; pure type.
+		"mvdan.cc/sh/v3/syntax.Command",      // 🟢 AST interface for all command types; pure interface.
+		"mvdan.cc/sh/v3/syntax.CoprocClause", // 🟢 AST node for coproc command; pure type.
+		"mvdan.cc/sh/v3/syntax.DashHdoc",     // 🟢 here-doc operator constant (<<-); pure constant.
+		"mvdan.cc/sh/v3/syntax.DblQuoted",    // 🟢 AST node for double-quoted string; pure type.
+		"mvdan.cc/sh/v3/syntax.DeclClause",   // 🟢 AST node for declare/local/export; pure type.
+		"mvdan.cc/sh/v3/syntax.DplIn",        // 🟢 redirect operator constant (<&); pure constant.
+		"mvdan.cc/sh/v3/syntax.DplOut",       // 🟢 redirect operator constant (>&); pure constant.
+		"mvdan.cc/sh/v3/syntax.ExtGlob",      // 🟢 AST node for extended glob pattern; pure type.
+		"mvdan.cc/sh/v3/syntax.File",         // 🟢 AST root node for a parsed shell script; pure type.
+		"mvdan.cc/sh/v3/syntax.ForClause",    // 🟢 AST node for for loop; pure type.
+		"mvdan.cc/sh/v3/syntax.FuncDecl",     // 🟢 AST node for function declaration; pure type.
+		"mvdan.cc/sh/v3/syntax.Hdoc",         // 🟢 here-doc operator constant (<<); pure constant.
+		"mvdan.cc/sh/v3/syntax.IfClause",     // 🟢 AST node for if statement; pure type.
+		"mvdan.cc/sh/v3/syntax.LetClause",    // 🟢 AST node for let command; pure type.
+		"mvdan.cc/sh/v3/syntax.Lit",          // 🟢 AST node for literal string; pure type.
+		"mvdan.cc/sh/v3/syntax.Node",         // 🟢 AST interface for all nodes; pure interface.
+		"mvdan.cc/sh/v3/syntax.OrStmt",       // 🟢 AST node for || operator; pure type.
+		"mvdan.cc/sh/v3/syntax.ParamExp",     // 🟢 AST node for ${} parameter expansion; pure type.
+		"mvdan.cc/sh/v3/syntax.Pipe",         // 🟢 AST node for pipeline; pure type.
+		"mvdan.cc/sh/v3/syntax.PipeAll",      // 🟢 redirect operator constant (|&); pure constant.
+		"mvdan.cc/sh/v3/syntax.Pos",          // 🟢 source position type; pure type.
+		"mvdan.cc/sh/v3/syntax.ProcSubst",    // 🟢 AST node for process substitution; pure type.
+		"mvdan.cc/sh/v3/syntax.RdrAll",       // 🟢 redirect operator constant (&>); pure constant.
+		"mvdan.cc/sh/v3/syntax.RdrIn",        // 🟢 redirect operator constant (<); pure constant.
+		"mvdan.cc/sh/v3/syntax.RdrInOut",     // 🟢 redirect operator constant (<>); pure constant.
+		"mvdan.cc/sh/v3/syntax.RdrOut",       // 🟢 redirect operator constant (>); pure constant.
+		"mvdan.cc/sh/v3/syntax.Redirect",     // 🟢 AST node for I/O redirection; pure type.
+		"mvdan.cc/sh/v3/syntax.SglQuoted",    // 🟢 AST node for single-quoted string; pure type.
+		"mvdan.cc/sh/v3/syntax.Stmt",         // 🟢 AST node for a complete statement; pure type.
+		"mvdan.cc/sh/v3/syntax.Subshell",     // 🟢 AST node for ( ) subshell; pure type.
+		"mvdan.cc/sh/v3/syntax.TestClause",   // 🟢 AST node for [[ ]] test command; pure type.
+		"mvdan.cc/sh/v3/syntax.TestDecl",     // 🟢 AST node for test declaration; pure type.
+		"mvdan.cc/sh/v3/syntax.TimeClause",   // 🟢 AST node for time command; pure type.
+		"mvdan.cc/sh/v3/syntax.NewParser",    // 🟢 creates a new shell parser; used by ParseScript to parse scripts into AST nodes.
+		"mvdan.cc/sh/v3/syntax.Walk",         // 🟢 traverses the AST; pure function, no I/O.
+		"mvdan.cc/sh/v3/syntax.WhileClause",  // 🟢 AST node for while/until loop; pure type.
+		"mvdan.cc/sh/v3/syntax.Word",         // 🟢 AST node for a shell word; pure type.
+		"mvdan.cc/sh/v3/syntax.WordHdoc",     // 🟢 redirect operator constant (<<<); pure constant.
+		"mvdan.cc/sh/v3/syntax.WordIter",     // 🟢 AST node for word iteration (for-in); pure type.
+		"mvdan.cc/sh/v3/syntax.WordPart",     // 🟢 AST interface for word components; pure interface.
+	},
+	"remediation": {
+		// Empty to start. Write-capable symbols (os.O_WRONLY, os.O_CREATE, …)
+		// land here when remediation write features are wired in.
+	},
+}

--- a/analysis/symbols_interp_test.go
+++ b/analysis/symbols_interp_test.go
@@ -36,6 +36,27 @@ func TestInterpAllowedSymbols(t *testing.T) {
 	checkAllowedSymbols(t, interpCheckConfig())
 }
 
+// interpPerModeCheckConfig returns the perInterpModeConfig used to enforce
+// per-mode symbol restrictions on interp/. Verification tests reuse this
+// function to ensure they test the exact same configuration.
+func interpPerModeCheckConfig() perInterpModeConfig {
+	return perInterpModeConfig{
+		GlobalSymbols:  interpAllowedSymbols,
+		PerModeSymbols: interpPerModeSymbols,
+		TargetDir:      "interp",
+		ExemptImport: func(importPath string) bool {
+			return strings.HasPrefix(importPath, "github.com/DataDog/rshell/")
+		},
+	}
+}
+
+// TestInterpPerModeSymbols enforces per-mode symbol restrictions on interp/.
+// Read-only files may only use interpPerModeSymbols["read-only"]; remediation
+// files may additionally use interpPerModeSymbols["remediation"].
+func TestInterpPerModeSymbols(t *testing.T) {
+	checkInterpPerModeSymbols(t, interpPerModeCheckConfig())
+}
+
 // internalPerPackageCheckConfig returns the perBuiltinConfig for testing
 // per-package symbol restrictions on builtins/internal/ packages.
 func internalPerPackageCheckConfig() perBuiltinConfig {

--- a/analysis/symbols_interp_verification_test.go
+++ b/analysis/symbols_interp_verification_test.go
@@ -89,6 +89,166 @@ func TestVerificationInterpIgnoresSubdirs(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Per-interp-mode verification tests
+// ---------------------------------------------------------------------------
+
+// interpPerModeVerifyCfg returns a perInterpModeConfig with RepoRootOverride
+// and Errors set for verification testing.
+func interpPerModeVerifyCfg(tempRoot string, errs *[]string) perInterpModeConfig {
+	cfg := interpPerModeCheckConfig()
+	cfg.RepoRootOverride = tempRoot
+	cfg.Errors = errs
+	return cfg
+}
+
+func TestVerificationInterpPerModeCleanPass(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	var errs []string
+	checkInterpPerModeSymbols(t, interpPerModeVerifyCfg(tmp, &errs))
+
+	if len(errs) > 0 {
+		t.Errorf("expected no errors on clean copy, got:\n%s", strings.Join(errs, "\n"))
+	}
+}
+
+func TestVerificationInterpPerModeSymbolNotInGlobalList(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Add a symbol to "remediation" that is not in interpAllowedSymbols.
+	cfg := interpPerModeVerifyCfg(tmp, nil)
+	cfg.PerModeSymbols = copyPerCommandMap(cfg.PerModeSymbols)
+	cfg.PerModeSymbols["remediation"] = append(cfg.PerModeSymbols["remediation"], "os.Remove")
+
+	var errs []string
+	cfg.Errors = &errs
+	checkInterpPerModeSymbols(t, cfg)
+
+	if !errContains(errs, "os.Remove") || !errContains(errs, "not in interpAllowedSymbols") {
+		t.Errorf("expected error about os.Remove not in interpAllowedSymbols, got: %v", errs)
+	}
+}
+
+func TestVerificationInterpPerModeReadOnlyFileUsesUnlistedSymbol(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Inject os.Setenv (not in the read-only list) into a read-only file.
+	target := findFirstFlatGoFile(t, filepath.Join(tmp, "interp"))
+	injectUnlistedSymbol(t, target)
+
+	var errs []string
+	checkInterpPerModeSymbols(t, interpPerModeVerifyCfg(tmp, &errs))
+
+	if !errContains(errs, "os.Setenv") || !errContains(errs, "not in the allowlist") {
+		t.Errorf("expected 'not in the allowlist' error for os.Setenv in read-only file, got: %v", errs)
+	}
+}
+
+func TestVerificationInterpPerModeUnusedSymbolInReadOnly(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Add a symbol to both GlobalSymbols and "read-only" that no file uses.
+	cfg := interpPerModeVerifyCfg(tmp, nil)
+	cfg.GlobalSymbols = append(append([]string{}, cfg.GlobalSymbols...), "fmt.Println")
+	cfg.PerModeSymbols = copyPerCommandMap(cfg.PerModeSymbols)
+	cfg.PerModeSymbols["read-only"] = append(cfg.PerModeSymbols["read-only"], "fmt.Println")
+
+	var errs []string
+	cfg.Errors = &errs
+	checkInterpPerModeSymbols(t, cfg)
+
+	if !errContains(errs, "fmt.Println") || !errContains(errs, "not used") {
+		t.Errorf("expected 'not used' error for fmt.Println, got: %v", errs)
+	}
+}
+
+func TestVerificationInterpPerModeGlobalSymbolNotInAnyList(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Add a symbol to GlobalSymbols only (not to any mode list).
+	cfg := interpPerModeVerifyCfg(tmp, nil)
+	cfg.GlobalSymbols = append(append([]string{}, cfg.GlobalSymbols...), "fmt.Println")
+
+	var errs []string
+	cfg.Errors = &errs
+	checkInterpPerModeSymbols(t, cfg)
+
+	if !errContains(errs, "fmt.Println") || !errContains(errs, "not in any per-mode list") {
+		t.Errorf("expected error about fmt.Println not in any per-mode list, got: %v", errs)
+	}
+}
+
+func TestVerificationInterpPerModeMissingKey(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Remove the "remediation" key.
+	cfg := interpPerModeVerifyCfg(tmp, nil)
+	cfg.PerModeSymbols = copyPerCommandMap(cfg.PerModeSymbols)
+	delete(cfg.PerModeSymbols, "remediation")
+
+	var errs []string
+	cfg.Errors = &errs
+	checkInterpPerModeSymbols(t, cfg)
+
+	if !errContains(errs, `"remediation"`) {
+		t.Errorf("expected error about missing remediation key, got: %v", errs)
+	}
+}
+
+func TestVerificationInterpPerModeRemediationFileUsesUnlistedSymbol(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Create a _remediation.go file that uses a symbol outside the union.
+	writeGoFile(t,
+		filepath.Join(tmp, "interp", "write_remediation.go"),
+		"interp",
+		[]string{`"os"`},
+		"var _ = os.Setenv\n",
+	)
+
+	var errs []string
+	checkInterpPerModeSymbols(t, interpPerModeVerifyCfg(tmp, &errs))
+
+	if !errContains(errs, "os.Setenv") || !errContains(errs, "not in the allowlist") {
+		t.Errorf("expected 'not in the allowlist' error for os.Setenv in remediation file, got: %v", errs)
+	}
+}
+
+func TestVerificationInterpPerModeUnusedRemediationSymbol(t *testing.T) {
+	root := repoRoot(t)
+	tmp := t.TempDir()
+	copyDir(t, filepath.Join(root, "interp"), filepath.Join(tmp, "interp"))
+
+	// Add a symbol to "remediation" that is in interpAllowedSymbols but no
+	// _remediation.go file exists to use it.
+	cfg := interpPerModeVerifyCfg(tmp, nil)
+	cfg.PerModeSymbols = copyPerCommandMap(cfg.PerModeSymbols)
+	cfg.PerModeSymbols["remediation"] = append(cfg.PerModeSymbols["remediation"], "fmt.Sprintf")
+
+	var errs []string
+	cfg.Errors = &errs
+	checkInterpPerModeSymbols(t, cfg)
+
+	if !errContains(errs, "fmt.Sprintf") || !errContains(errs, "not used") {
+		t.Errorf("expected 'not used' error for fmt.Sprintf in remediation mode, got: %v", errs)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Per-internal-package verification tests
 // ---------------------------------------------------------------------------
 

--- a/analysis/symbols_test.go
+++ b/analysis/symbols_test.go
@@ -250,6 +250,167 @@ func checkPerBuiltinAllowedSymbols(t *testing.T, cfg perBuiltinConfig) {
 	}
 }
 
+// perInterpModeConfig holds the configuration for checkInterpPerModeSymbols.
+type perInterpModeConfig struct {
+	// GlobalSymbols is the ceiling list (interpAllowedSymbols).
+	GlobalSymbols []string
+	// PerModeSymbols maps each mode name to its allowlist.
+	// Must have exactly "read-only" and "remediation" keys.
+	PerModeSymbols map[string][]string
+	// TargetDir is the directory to scan, relative to the repo root (e.g. "interp").
+	TargetDir string
+	// ExemptImport returns true for import paths that are auto-allowed.
+	ExemptImport func(importPath string) bool
+	// RepoRootOverride, if set, overrides auto-detection of the repo root.
+	RepoRootOverride string
+	// Errors, if non-nil, collects error messages instead of calling t.Errorf.
+	Errors *[]string
+}
+
+// checkInterpPerModeSymbols enforces two-layer per-mode symbol restrictions on interp/:
+//  1. Every symbol in any per-mode list must be in GlobalSymbols (ceiling check).
+//  2. Read-only files (.go not ending in _remediation.go) may only use "read-only" symbols.
+//     Remediation files (_remediation.go) may use "read-only" ∪ "remediation" symbols.
+//  3. Every symbol in each per-mode list must be used by at least one file in that mode.
+//     The unused-per-mode check is skipped when no remediation files exist (MinFiles: 0).
+//  4. Every symbol in GlobalSymbols must appear in at least one per-mode list.
+//  5. Both "read-only" and "remediation" keys must exist in PerModeSymbols.
+func checkInterpPerModeSymbols(t *testing.T, cfg perInterpModeConfig) {
+	t.Helper()
+
+	reportErr := func(format string, args ...any) {
+		msg := fmt.Sprintf(format, args...)
+		if cfg.Errors != nil {
+			*cfg.Errors = append(*cfg.Errors, msg)
+		} else {
+			t.Errorf("%s", msg)
+		}
+	}
+
+	// Check 5: required keys must exist.
+	readOnlySymbols, hasReadOnly := cfg.PerModeSymbols["read-only"]
+	remediationSymbols, hasRemediation := cfg.PerModeSymbols["remediation"]
+	if !hasReadOnly {
+		reportErr(`interpPerModeSymbols must have a "read-only" key`)
+	}
+	if !hasRemediation {
+		reportErr(`interpPerModeSymbols must have a "remediation" key`)
+	}
+	if !hasReadOnly || !hasRemediation {
+		return
+	}
+
+	// Build global ceiling set.
+	globalSet := make(map[string]bool, len(cfg.GlobalSymbols))
+	for _, s := range cfg.GlobalSymbols {
+		globalSet[s] = true
+	}
+
+	// Track which global symbols appear in at least one per-mode list (for check 4).
+	globalUsed := make(map[string]bool)
+
+	// Check 1: every per-mode symbol must be in the global list.
+	for mode, symbols := range cfg.PerModeSymbols {
+		for _, s := range symbols {
+			if !globalSet[s] {
+				reportErr("interpPerModeSymbols[%q]: symbol %q is not in interpAllowedSymbols", mode, s)
+			}
+			globalUsed[s] = true
+		}
+	}
+
+	// Determine repo root.
+	var root string
+	if cfg.RepoRootOverride != "" {
+		root = cfg.RepoRootOverride
+	} else {
+		dir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		root = filepath.Dir(dir)
+	}
+	targetDir := filepath.Join(root, cfg.TargetDir)
+
+	// Collect and partition files into read-only and remediation.
+	allFiles, err := collectFlatGoFiles(targetDir)
+	if err != nil {
+		t.Fatalf("checkInterpPerModeSymbols: %v", err)
+	}
+
+	var readOnlyFiles, remediationFiles []string
+	for _, f := range allFiles {
+		if strings.HasSuffix(filepath.Base(f), "_remediation.go") {
+			remediationFiles = append(remediationFiles, f)
+		} else {
+			readOnlyFiles = append(readOnlyFiles, f)
+		}
+	}
+
+	// Check 2+3 for read-only files via checkAllowedSymbols.
+	var readOnlyErrs []string
+	checkAllowedSymbols(t, allowedSymbolsConfig{
+		Symbols:   readOnlySymbols,
+		TargetDir: cfg.TargetDir,
+		CollectFiles: func(_ string) ([]string, error) {
+			return readOnlyFiles, nil
+		},
+		ExemptImport:     cfg.ExemptImport,
+		ListName:         `interpPerModeSymbols["read-only"]`,
+		MinFiles:         1,
+		RepoRootOverride: root,
+		Errors:           &readOnlyErrs,
+	})
+	for _, e := range readOnlyErrs {
+		reportErr("%s", e)
+	}
+
+	// Check 2+3 for remediation files.
+	// Effective allowlist = "read-only" ∪ "remediation" (containment).
+	// Unused check applies only to remediation-specific symbols (not the full union).
+	// MinFiles: 0 — skipped when no _remediation.go files exist yet.
+	if len(remediationFiles) > 0 {
+		unionSymbols := make([]string, 0, len(readOnlySymbols)+len(remediationSymbols))
+		unionSymbols = append(unionSymbols, readOnlySymbols...)
+		unionSymbols = append(unionSymbols, remediationSymbols...)
+
+		unionSet, unionPkgs := buildAllowlistSets(unionSymbols)
+		usedInRemediation := make(map[string]bool, len(unionSymbols))
+
+		fset := token.NewFileSet()
+		for _, path := range remediationFiles {
+			rel, _ := filepath.Rel(targetDir, path)
+			f, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				reportErr("%s: parse error: %v", rel, parseErr)
+				continue
+			}
+			reporter := fileLineReporter(fset, rel, reportErr)
+			localToPath := checkFileImports(f, unionPkgs, cfg.ExemptImport, reporter)
+			checkFileSelectors(f, localToPath, unionSet, usedInRemediation, reporter)
+			checkFileScannerBuffer(f, reporter)
+			checkFileOpenFileClose(f, reporter)
+		}
+
+		// Check 3: each remediation-specific symbol must be used by at least one remediation file.
+		reportUnused(remediationSymbols, usedInRemediation, func(entry string) {
+			reportErr(`interpPerModeSymbols["remediation"] symbol %q is not used by any _remediation.go file — remove it from interpPerModeSymbols["remediation"] or add it to a _remediation.go file`, entry)
+		})
+	} else if len(remediationSymbols) > 0 {
+		// Remediation symbols listed but no files exist to consume them.
+		for _, s := range remediationSymbols {
+			reportErr(`interpPerModeSymbols["remediation"] symbol %q is not used by any _remediation.go file — remove it from interpPerModeSymbols["remediation"] or add it to a _remediation.go file`, s)
+		}
+	}
+
+	// Check 4: every global symbol must appear in at least one per-mode list.
+	for _, s := range cfg.GlobalSymbols {
+		if !globalUsed[s] {
+			reportErr("interpAllowedSymbols symbol %q is not in any per-mode list — remove it from interpAllowedSymbols or add it to interpPerModeSymbols", s)
+		}
+	}
+}
+
 // collectGoFilesRecursive walks a directory tree and returns all non-test .go
 // files, including those at the top level. Directories named in skipDirs are
 // pruned. Top-level files (rel has no separator) are excluded only when


### PR DESCRIPTION
⚠️ Please review carefully, this PR impacts the analysis of symbols in the interpreter

## Summary

Splits the interp symbol allowlist into a two-layer per-mode system, modelled on how `builtins/` already works.

- **`interpAllowedSymbols`** — unchanged, becomes the global ceiling
- **`interpPerModeSymbols["read-only"]`** — all current symbols; enforced on every `interp/` file
- **`interpPerModeSymbols["remediation"]`** — empty for now; grows as write features land in `*_remediation.go` files

Files are partitioned by name suffix (`_remediation.go`) rather than subdirectory. Remediation files are checked against the union of both mode lists; read-only files against `"read-only"` only. The five checks mirror `checkPerBuiltinAllowedSymbols`.

## Test plan

- `go test ./analysis/... -timeout 60s` — all existing tests pass
- 9 new tests: `TestInterpPerModeSymbols` + 8 `TestVerificationInterpPerMode*` covering each of the five checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)