### PR TITLE
fix(truncate): block --help in read-only mode, consistent with disallowed commands

### DIFF
--- a/builtins/truncate/truncate.go
+++ b/builtins/truncate/truncate.go
@@ -109,6 +109,9 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 			callCtx.Out("--no-create is given.\n\n")
 			fs.SetOutput(callCtx.Stdout)
 			fs.PrintDefaults()
+			if callCtx.Truncate == nil {
+				callCtx.Out("\nNote: this command is not available in the current session (requires remediation mode).\n")
+			}
 			return builtins.Result{}
 		}
 

--- a/builtins/truncate/truncate.go
+++ b/builtins/truncate/truncate.go
@@ -101,6 +101,14 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	noCreate := fs.BoolP("no-create", "c", false, "do not create files that do not exist")
 
 	return func(ctx context.Context, callCtx *builtins.CallContext, files []string) builtins.Result {
+		// Capability check before everything else — including --help — so that
+		// truncate --help behaves the same as invoking a disallowed command:
+		// it fails immediately without showing help text.
+		if callCtx.Truncate == nil {
+			callCtx.Errf("truncate: filesystem capability not available (remediation mode required)\n")
+			return builtins.Result{Code: 1}
+		}
+
 		if *help {
 			callCtx.Out("Usage: truncate [OPTION]... FILE...\n")
 			callCtx.Out("Shrink or extend the size of each FILE to the specified size.\n")
@@ -109,18 +117,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 			callCtx.Out("--no-create is given.\n\n")
 			fs.SetOutput(callCtx.Stdout)
 			fs.PrintDefaults()
-			if callCtx.Truncate == nil {
-				callCtx.Out("\nNote: this command is not available in the current session (requires remediation mode).\n")
-			}
 			return builtins.Result{}
-		}
-
-		// Capability check first — it is a setup invariant rather than a
-		// per-input validation. Failing fast here keeps the error message
-		// stable even when the user supplies a malformed --size.
-		if callCtx.Truncate == nil {
-			callCtx.Errf("truncate: filesystem capability not available (remediation mode required)\n")
-			return builtins.Result{Code: 1}
 		}
 
 		if !fs.Changed("size") {

--- a/tests/scenarios/cmd/truncate/errors/readonly_mode_help.yaml
+++ b/tests/scenarios/cmd/truncate/errors/readonly_mode_help.yaml
@@ -1,0 +1,11 @@
+description: truncate --help in read-only mode shows help with a note about remediation.
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    truncate --help
+expect:
+  stdout_contains:
+    - "Note: this command is not available in the current session (requires remediation mode)."
+  stderr: |+
+  exit_code: 0
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/truncate/errors/readonly_mode_help.yaml
+++ b/tests/scenarios/cmd/truncate/errors/readonly_mode_help.yaml
@@ -1,11 +1,11 @@
-description: truncate --help in read-only mode shows help with a note about remediation.
+description: truncate --help in read-only mode fails with the same error as truncate itself.
 input:
   allowed_paths: ["$DIR"]
   script: |+
     truncate --help
 expect:
-  stdout_contains:
-    - "Note: this command is not available in the current session (requires remediation mode)."
+  stdout: |+
   stderr: |+
-  exit_code: 0
+    truncate: filesystem capability not available (remediation mode required)
+  exit_code: 1
 skip_assert_against_bash: true


### PR DESCRIPTION
## Issue

Inconsistency in the READ-ONLY mode: `truncate --help` works but not `truncate` as the builtin is blocked

<img width="792" height="464" alt="Screenshot 2026-06-22 at 14 29 14" src="https://github.com/user-attachments/assets/8725f54a-9e2a-403e-8fc1-f575a39c8e74" />

## Summary

- `truncate --help` in read-only mode previously printed full help text and exited 0,
  even though the command is completely blocked
- When a command is absent from the allow-list, `--help` is rejected at the interpreter
  level before the handler runs — this fix makes the mode-based block behave the same way
- The capability check now fires before flag parsing, so `truncate --help` returns the
  same error as `truncate` itself:
  `truncate: filesystem capability not available (remediation mode required)` with exit 1

## Test plan
- [ ] New scenario `tests/scenarios/cmd/truncate/errors/readonly_mode_help.yaml` verifies
  that `truncate --help` in read-only mode exits 1 with the capability error on stderr and
  nothing on stdout
- [ ] Existing `readonly_mode.yaml` scenario continues to verify that `truncate -s 0 f.txt`
  fails the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)