### PR TITLE
feat(help): show mode in header; hide remediation-only commands in read-only mode

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -55,6 +55,11 @@ type Command struct {
 	// parsing. This allows commands to support legacy flag syntax that pflag
 	// cannot handle natively (e.g. head/tail -5 → -n 5).
 	NormalizeArgs func(args []string) []string
+
+	// RemediationOnly marks a builtin as only available in remediation mode.
+	// The help builtin uses this to move the command to the disabled list
+	// when the shell is in read-only mode.
+	RemediationOnly bool
 }
 
 // NoFlags wraps a HandlerFunc in the MakeFlags format for commands that
@@ -86,7 +91,7 @@ func (c Command) Register() {
 	factory(probe)
 	hasFlags := probe.HasFlags()
 
-	metaRegistry[name] = CommandMeta{Name: name, Description: c.Description, Help: c.Help, HasFlags: hasFlags}
+	metaRegistry[name] = CommandMeta{Name: name, Description: c.Description, Help: c.Help, HasFlags: hasFlags, RemediationOnly: c.RemediationOnly}
 	addToRegistry(name, func(ctx context.Context, callCtx *CallContext, args []string) Result {
 		fs := pflag.NewFlagSet(name, pflag.ContinueOnError)
 		fs.SetOutput(io.Discard) // handler formats errors itself
@@ -180,6 +185,11 @@ type CallContext struct {
 	// os.ErrNotExist. Negative sizes are rejected. Only available in
 	// remediation mode; nil otherwise.
 	Truncate func(ctx context.Context, path string, size int64, create bool) error
+
+	// RemediationMode reports whether the shell is running in remediation mode.
+	// When false (read-only mode), write-capable builtins such as truncate are
+	// not available. Used by the help builtin to partition commands correctly.
+	RemediationMode bool
 
 	// PortableErr normalizes an OS error to a POSIX-style message.
 	PortableErr func(err error) string
@@ -334,10 +344,11 @@ var registry = map[string]HandlerFunc{}
 
 // CommandMeta holds metadata about a registered builtin command.
 type CommandMeta struct {
-	Name        string
-	Description string
-	Help        string
-	HasFlags    bool // true when MakeFlags registers at least one flag
+	Name            string
+	Description     string
+	Help            string
+	HasFlags        bool // true when MakeFlags registers at least one flag
+	RemediationOnly bool // true when the command requires remediation mode
 }
 
 var metaRegistry = map[string]CommandMeta{}

--- a/builtins/help/help.go
+++ b/builtins/help/help.go
@@ -110,6 +110,11 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 				notAllowed = append(notAllowed, name)
 				continue
 			}
+			meta, _ := builtins.Meta(name)
+			if meta.RemediationOnly && !callCtx.RemediationMode {
+				notAllowed = append(notAllowed, name)
+				continue
+			}
 			allowed = append(allowed, name)
 		}
 
@@ -153,12 +158,16 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	}
 }
 
-// printHeader writes the version line.
+// printHeader writes the version line with the current shell mode.
 func printHeader(callCtx *builtins.CallContext) {
+	mode := "read-only mode"
+	if callCtx.RemediationMode {
+		mode = "remediation mode"
+	}
 	if version.Version != "" {
-		callCtx.Outf("rshell (%s)\n\n", version.Version)
+		callCtx.Outf("rshell (%s) - %s\n\n", version.Version, mode)
 	} else {
-		callCtx.Out("rshell\n\n")
+		callCtx.Outf("rshell - %s\n\n", mode)
 	}
 }
 

--- a/builtins/tests/help/help_test.go
+++ b/builtins/tests/help/help_test.go
@@ -128,7 +128,9 @@ func TestHelpListsAllCommands(t *testing.T) {
 	require.NoError(t, err)
 	r.Close()
 
-	stdout, _, code := runScript(t, "help", "", interpoption.AllowAllCommands().(interp.RunnerOption))
+	// Run in remediation mode so all builtins (including remediation-only ones
+	// like truncate) appear in the enabled Commands table with their descriptions.
+	stdout, _, code := runScript(t, "help", "", interpoption.AllowAllCommands().(interp.RunnerOption), interp.WithMode(interp.ModeRemediation))
 	assert.Equal(t, 0, code)
 
 	// Drive the inventory check off the registry itself so adding a builtin
@@ -159,7 +161,7 @@ func TestHelpListsSorted(t *testing.T) {
 
 	// Extract command names from the first column of the Commands table.
 	var names []string
-	for _, line := range tableLines(stdout, "Commands:") {
+	for _, line := range tableLines(stdout, "Commands") {
 		fields := strings.Fields(line)
 		if len(fields) > 0 {
 			names = append(names, fields[0])
@@ -197,7 +199,7 @@ func TestHelpColumnsAligned(t *testing.T) {
 
 	// The format is "%-*s  %s\n" — name padded to maxLen, two spaces, description.
 	assertTableAligned(t, tableLines(stdout, "Features:"))
-	assertTableAligned(t, tableLines(stdout, "Commands:"))
+	assertTableAligned(t, tableLines(stdout, "Commands"))
 }
 
 func TestHelpListsFeaturesAndUnsupportedSummary(t *testing.T) {
@@ -247,7 +249,7 @@ func TestHelpRestrictedShowsOnlyAllowedInTable(t *testing.T) {
 	assert.Empty(t, stderr)
 	assert.Contains(t, stdout, "echo")
 	assert.Contains(t, stdout, "help")
-	for _, line := range tableLines(stdout, "Commands:") {
+	for _, line := range tableLines(stdout, "Commands") {
 		fields := strings.Fields(line)
 		if len(fields) > 0 {
 			assert.True(t, fields[0] == "echo" || fields[0] == "help",
@@ -281,7 +283,7 @@ func TestHelpRestrictedAlignmentAdjusts(t *testing.T) {
 		interp.AllowedCommands([]string{"rshell:wc", "rshell:strings", "rshell:help"}))
 	assert.Equal(t, 0, code)
 
-	for _, line := range tableLines(stdout, "Commands:") {
+	for _, line := range tableLines(stdout, "Commands") {
 		// "strings" is the longest name (7 chars), so the description should
 		// start at the same column for all lines.
 		fields := strings.Fields(line)
@@ -322,9 +324,9 @@ func TestHelpAllFlagShowsNotAllowedWithDescriptions(t *testing.T) {
 }
 
 func TestHelpAllFlagNoRestrictions(t *testing.T) {
-	// When all commands are allowed, --all should not show "Disabled command"
-	// but should confirm that all commands are allowed.
-	stdout, _, code := runScript(t, "help --all", "", interpoption.AllowAllCommands().(interp.RunnerOption))
+	// When all commands are allowed in remediation mode, --all should not show
+	// "Disabled command" but should confirm that all commands are allowed.
+	stdout, _, code := runScript(t, "help --all", "", interpoption.AllowAllCommands().(interp.RunnerOption), interp.WithMode(interp.ModeRemediation))
 	assert.Equal(t, 0, code)
 	assert.NotContains(t, stdout, "Disabled command")
 	assert.Contains(t, stdout, "All commands are allowed in this session.")

--- a/builtins/truncate/truncate.go
+++ b/builtins/truncate/truncate.go
@@ -81,9 +81,10 @@ import (
 
 // Cmd is the truncate builtin command descriptor.
 var Cmd = builtins.Command{
-	Name:        "truncate",
-	Description: "shrink or extend file size",
-	MakeFlags:   registerFlags,
+	Name:            "truncate",
+	Description:     "shrink or extend file size",
+	MakeFlags:       registerFlags,
+	RemediationOnly: true,
 }
 
 // errInvalidSize is returned by parseSize for any non-numeric, malformed,

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -803,7 +803,8 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 				vr := r.writeEnv.Get(name)
 				return vr.Str, vr.IsSet()
 			},
-			Proc: r.proc,
+			Proc:            r.proc,
+			RemediationMode: r.remediationMode,
 		}
 		if r.remediationMode && r.sandbox != nil {
 			call.Truncate = func(ctx context.Context, path string, size int64, create bool) error {

--- a/tests/scenarios/cmd/help/help_readonly_mode.yaml
+++ b/tests/scenarios/cmd/help/help_readonly_mode.yaml
@@ -1,0 +1,11 @@
+description: help in read-only mode shows the mode in the header and truncate in disabled commands.
+skip_assert_against_bash: true
+input:
+  script: |+
+    help
+expect:
+  stdout_contains:
+    - "read-only mode"
+    - "truncate"
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/help/help_remediation_mode.yaml
+++ b/tests/scenarios/cmd/help/help_remediation_mode.yaml
@@ -1,0 +1,11 @@
+description: help in remediation mode shows the mode in the header.
+skip_assert_against_bash: true
+input:
+  mode: "remediation"
+  script: |+
+    help
+expect:
+  stdout_contains:
+    - "remediation mode"
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/help/unrestricted.yaml
+++ b/tests/scenarios/cmd/help/unrestricted.yaml
@@ -12,7 +12,7 @@ expect:
     - "Not supported:"
     - "arithmetic $((...))"
     - "case, select"
-    - "Commands:"
+    - "Commands"
     - "echo"
     - "write arguments to stdout"
     - "help"

--- a/tests/scenarios/cmd/help/unrestricted_all_flag.yaml
+++ b/tests/scenarios/cmd/help/unrestricted_all_flag.yaml
@@ -1,6 +1,7 @@
 description: Help --all with no restrictions shows features, the commands table, and a confirmation that all commands are allowed. Uses stdout_contains so the test does not need editing each time a new builtin is added — exact registry coverage lives in builtins/tests/help/help_test.go.
 skip_assert_against_bash: true
 input:
+  mode: "remediation"
   script: |+
     help --all
 expect:


### PR DESCRIPTION
## Summary

- The \`help\` header now shows the current execution mode: \`rshell (v0.0.21) - read-only mode\` or \`- remediation mode\`
- Introduces \`RemediationOnly bool\` on the \`Command\` and \`CommandMeta\` structs so builtins can declare they require remediation mode
- \`truncate\` is marked \`RemediationOnly: true\` — in read-only mode it moves from the enabled Commands table to the Disabled commands list, matching what actually happens when you try to run it
- \`RemediationMode bool\` is added to \`CallContext\` and wired from \`runner_exec.go\`

## Test plan
- [ ] New scenarios \`help_readonly_mode.yaml\` and \`help_remediation_mode.yaml\` verify the mode string in the header
- [ ] Updated \`unrestricted_all_flag.yaml\` runs in remediation mode so \`truncate\` stays in the enabled list and "All commands are allowed" still appears
- [ ] Unit tests updated: \`TestHelpListsAllCommands\` and \`TestHelpAllFlagNoRestrictions\` use remediation mode; four \`tableLines\` calls broadened from \`"Commands:"\` to \`"Commands"\` prefix to handle both \`Commands:\` and \`Commands (N of M enabled):\` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)