### PR TITLE
Address AllowedPaths follow-up nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every access path is default-deny:
 |----------------------|-------------------------------------|----------------------------------------------|
 | Command execution    | All commands blocked (exit code 127)| `AllowedCommands` with namespaced command list (e.g. `rshell:cat`) |
 | External commands    | Blocked (exit code 127)             | Provide an `ExecHandler`                     |
-| Filesystem access    | Blocked                             | Configure `AllowedPaths` with directory list |
+| Filesystem access    | Blocked                             | Configure `AllowedPaths` with `PATH[:ro|:rw]` root specs |
 | Environment variables| Empty (no host env inherited)       | Pass variables via the `Env` option          |
 | Output redirections  | Only `/dev/null` allowed in read-only mode (exit code 2 for other targets); file-target redirects enabled in remediation mode, gated by `AllowedPaths` | `>/dev/null`, `2>/dev/null`, `&>/dev/null`, `2>&1`; in remediation mode: `>FILE`, `>>FILE`, `2>FILE`, `&>FILE`, `&>>FILE` |
 

--- a/allowedpaths/path_mode_windows.go
+++ b/allowedpaths/path_mode_windows.go
@@ -12,5 +12,11 @@ func resolveAllowedPathMode(path string) (string, pathMode) {
 	if !ok {
 		return path, pathModeReadOnly
 	}
+	// Windows treats terminal ":ro" and ":rw" as rshell access-mode
+	// metadata unconditionally. Unlike POSIX, where ":" is ordinary filename
+	// text and an existing literal path must be preserved, Windows path
+	// components cannot normally end this way without entering NTFS alternate
+	// data stream syntax (for example, "file:rw"). We intentionally choose the
+	// rshell mode suffix interpretation for this unsupported ambiguity.
 	return stripped, mode
 }

--- a/analysis/symbols_allowedpaths.go
+++ b/analysis/symbols_allowedpaths.go
@@ -42,9 +42,9 @@ var allowedpathsAllowedSymbols = []string{
 	"os.Getgid",                          // 🟠 returns the numeric group id of the caller; read-only syscall.
 	"os.Getgroups",                       // 🟠 returns supplementary group ids; read-only syscall.
 	"os.Getuid",                          // 🟠 returns the numeric user id of the caller; read-only syscall.
+	"os.Lstat",                           // 🟠 checks whether a literal AllowedPaths entry exists without following symlinks, preserving legacy paths that end in :ro/:rw.
 	"os.O_APPEND",                        // 🟢 append-on-write file flag constant; pure constant. Part of the sandbox open-flag allowlist.
 	"os.O_CREATE",                        // 🟢 create-if-missing file flag constant; pure constant. Part of the sandbox open-flag allowlist.
-	"os.Lstat",                           // 🟠 checks whether a literal AllowedPaths entry exists without following symlinks, preserving legacy paths that end in :ro/:rw.
 	"os.O_RDONLY",                        // 🟢 read-only file flag constant; pure constant.
 	"os.O_TRUNC",                         // 🟢 truncate-on-open file flag constant; pure constant. Part of the sandbox open-flag allowlist.
 	"os.O_WRONLY",                        // 🟢 write-only file flag constant; pure constant. Part of the sandbox open-flag allowlist.

--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -139,12 +139,12 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 
 	cmd.Flags().StringVarP(&command, "command", "c", "", "shell command string to execute")
 	cmd.Flags().MarkHidden("command") //nolint:errcheck // flag is guaranteed to exist
-	cmd.Flags().StringVarP(&allowedPaths, "allowed-paths", "p", "", "comma-separated list of directories the shell is allowed to access")
+	cmd.Flags().StringVarP(&allowedPaths, "allowed-paths", "p", "", "comma-separated list of PATH[:ro|:rw] directories the shell is allowed to access; entries without a suffix are read-only")
 	cmd.Flags().StringVar(&allowedCommands, "allowed-commands", "", "comma-separated list of namespaced commands (e.g. rshell:cat,rshell:find)")
 	cmd.Flags().BoolVar(&allowAllCmds, "allow-all-commands", false, "allow execution of all commands (builtins and external)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "maximum execution time for the entire shell run (e.g. 100ms, 5s, 1m)")
 	cmd.Flags().StringVar(&procPath, "proc-path", "", "path to the proc filesystem used by ps (default \"/proc\")")
-	cmd.Flags().StringVar(&mode, "mode", "read-only", "shell execution mode: read-only (default) or remediation (enables file-target output redirections within AllowedPaths)")
+	cmd.Flags().StringVar(&mode, "mode", "read-only", "shell execution mode: read-only (default) or remediation (enables file-target output redirections within :rw AllowedPaths roots)")
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		var status interp.ExitStatus

--- a/cmd/rshell/main_test.go
+++ b/cmd/rshell/main_test.go
@@ -176,8 +176,11 @@ func TestHelp(t *testing.T) {
 	code, stdout, _ := runCLI(t, "--help")
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout, "--allowed-paths")
+	assert.Contains(t, stdout, "PATH[:ro|:rw]")
+	assert.Contains(t, stdout, "entries without a suffix are read-only")
 	assert.Contains(t, stdout, "--allowed-commands")
 	assert.Contains(t, stdout, "--allow-all-commands")
+	assert.Contains(t, stdout, "file-target output redirections within :rw AllowedPaths roots")
 	assert.Contains(t, stdout, "--timeout")
 	assert.NotContains(t, stdout, "--command", "-c/--command should be hidden from help")
 }


### PR DESCRIPTION
## Summary

This is a small follow-up to address review nits that came up on #271 before it was merged.

- Update the CLI `--allowed-paths` help text to mention `PATH[:ro|:rw]`, including the default read-only behavior.
- Clarify the `--mode remediation` help text so it names `:rw` AllowedPaths roots.
- Document the Windows `:ro` / `:rw` suffix interpretation, including the intentional ADS-style ambiguity tradeoff versus Unix literal-path preservation.
- Preserve alphabetical ordering in the `allowedpaths` analysis symbol allowlist.

## Impact

No runtime sandbox behavior changes are intended. This keeps user-facing help, docs, comments, and review-maintained allowlist ordering aligned with the merged AllowedPaths mode work.

## Validation

- `make fmt`
- `go test ./cmd/rshell`
- `go run ./cmd/rshell --help`
- `go test ./allowedpaths`
- `GOOS=windows go test -c ./allowedpaths -o /tmp/rshell-allowedpaths-windows.test.exe`
- `go test ./analysis`
- `git diff --check`
