### PR TITLE
Document CLI development scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ rshell --allow-all-commands --timeout 5s -c 'echo "hello from rshell"'
 
 ## Security Model
 
+**CLI scope:** The `rshell` CLI is a development, debugging, and local validation harness for the interpreter. It is not intended to be exposed as a production execution boundary or as an interface for untrusted users. Production integrations should embed the Go API and set `AllowedCommands`, `AllowedPaths`, environment, timeout, and mode explicitly. Security review should treat the interpreter and embedding configuration as the security boundary, not the developer CLI.
+
 Every access path is default-deny:
 
 | Resource             | Default                             | Opt-in                                       |

--- a/cmd/rshell/main.go
+++ b/cmd/rshell/main.go
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-// Package main provides the rshell CLI — a restricted shell interpreter.
+// Package main provides the rshell development CLI. It is a local harness for
+// exercising the interpreter, not the production security boundary; production
+// integrations should embed the interp package and configure policy explicitly.
 package main
 
 import (
@@ -46,6 +48,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	cmd := &cobra.Command{
 		Use:           "rshell [file ...]",
 		Short:         "A restricted shell interpreter for AI agents",
+		Long:          "rshell is a development, debugging, and local validation harness for the interpreter. Production integrations should embed the Go API and configure commands, paths, environment, timeout, and mode explicitly.",
 		Version:       version.Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,


### PR DESCRIPTION
## Summary

Document that the `rshell` CLI is intended for development, debugging, and local validation of the interpreter, not as a production execution boundary for untrusted users.

## Impact

This clarifies that production integrations should embed the Go API and configure commands, paths, environment, timeout, and mode explicitly. Security reviews should focus on the interpreter and embedding configuration rather than treating developer-only CLI flags as the production threat boundary.

## Validation

- `make fmt`
