### PR TITLE
fix(ci): skip Static Analysis Verification in MQ

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -8,6 +8,10 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  # The merge_group event is required so this check reports a result inside the
+  # merge queue.  Required status checks are evaluated identically in the queue
+  # and on the PR, and there is no way to make a check required only on PRs.
+  merge_group:
 
 permissions:
   contents: read
@@ -18,6 +22,8 @@ jobs:
     name: Static Analysis Label Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Only run if on the PR itself, skip in MQ (nothing to do since the check already passed before enqueueing)
+    if: github.event_name == 'pull_request_target'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION


### What does this PR do?

Trigger the `Static Analysis Verification` workflow in the MQ as well as on the PR. We make it a no-op in that case so it always reports as success (it would be unfeasible to run the check again anyway since the merge group event trigger does not provide the required information)

### Motivation

Without this change, the workflow never runs in the MQ and does not publish the required "Static Analysis Verification" check. There is no way to mark a check as required on the PR but not in the MQ. 

### Testing

<!-- How was this tested? -->

### Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
