### PR TITLE
Document process argv privacy rules

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -147,6 +147,10 @@ only the filesystem-accessing *functions* are forbidden.
 - Process-listing commands such as `ps` MUST report only process name / executable metadata unless an explicit security-reviewed exception is documented
 - Any exception that exposes argv-like data MUST define a redaction strategy and include tests proving sensitive arguments are not emitted
 
+### Environment Privacy
+- Builtins and interpreter runtime code MUST NOT read the host process environment directly via `os.Getenv`, `os.LookupEnv`, `os.Environ`, or platform-specific environment APIs.
+- Commands that inspect host processes MUST NOT read or expose raw process environment blocks, such as `/proc/<pid>/environ`, macOS process environment APIs, Windows PEB environment blocks, or equivalent sources.
+
 ### Testing Requirements
 - Every dangerous flag MUST have a test verifying it is rejected
 - Every supported flag MUST have correctness tests

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -142,6 +142,11 @@ only the filesystem-accessing *functions* are forbidden.
 - Commands MUST handle line endings consistently (\n, \r\n, \r)
 - Commands MUST preserve or correctly handle binary data (non-UTF8)
 
+### Process Introspection Privacy
+- Commands that inspect host processes MUST NOT read or expose raw process argv / full command lines (for example `/proc/<pid>/cmdline`, macOS `KERN_PROCARGS*`, Windows command-line APIs, or equivalent sources)
+- Process-listing commands such as `ps` MUST report only process name / executable metadata unless an explicit security-reviewed exception is documented
+- Any exception that exposes argv-like data MUST define a redaction strategy and include tests proving sensitive arguments are not emitted
+
 ### Testing Requirements
 - Every dangerous flag MUST have a test verifying it is rejected
 - Every supported flag MUST have correctness tests


### PR DESCRIPTION
### What does this PR do?

Documents a security rule for process-introspection builtins: they must not read or expose raw host process argv / full command lines. The rule calls out `/proc/<pid>/cmdline`, macOS `KERN_PROCARGS*`, Windows command-line APIs, and equivalent sources. Process-listing commands such as `ps` remain scoped to process name / executable metadata unless an explicit security-reviewed exception is documented.

### Motivation

Process argv can contain tokens, passwords, API keys, or other secrets from unrelated host processes. The rule makes that privacy boundary explicit for future builtins and preserves the existing `ps` design.

### Implementation audit

Reviewed the current process-introspection and process-adjacent code paths. Production code does not reference `/proc/<pid>/cmdline`, `KERN_PROCARGS*`, Windows command-line APIs, or equivalent raw argv sources. `ps` populates `CMD` from process comm/executable metadata only, and `ss` rejects `-p`/`--processes`.

### Testing

- Ran `make fmt`.
- Ran `go test ./builtins/ps ./builtins/tests/ps ./builtins/ss ./builtins/tests/ss ./builtins/tests/help ./builtins/tests/uname`.

### Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)
