### PR TITLE
reword comments

### DIFF
--- a/builtins/df/df.go
+++ b/builtins/df/df.go
@@ -666,7 +666,7 @@ func formatCount(v uint64, mode unitMode, inodeMode bool) string {
 // otherwise. Suffixes go up to E (exa); larger sizes are clamped at "E"
 // to avoid overflow.
 //
-// Suffix case follows GNU's lib/human.c convention: in SI / -H mode the
+// Suffix case follows GNU df's convention: in SI / -H mode the
 // kilo suffix is lowercase ("k") to match the SI symbol, while the
 // kibi / -h mode keeps the uppercase "K". M, G, T, P, E stay uppercase
 // in both modes — only K differs.
@@ -869,11 +869,10 @@ func printRows(callCtx *builtins.CallContext, header []string, rows []row, withT
 	}
 }
 
-// minColumnWidths returns the per-column minimum widths used by GNU
-// coreutils df (see lib/df.c field_data: SOURCE_FIELD=14, FSTYPE=4,
-// SIZE/USED/AVAIL=5, USE%=4). Headers are always at least the label
-// width, so the only minimums that exceed their header are SOURCE
-// (14 vs "Filesystem"=10) and USED (5 vs "Used"=4).
+// minColumnWidths returns the per-column minimum widths matching GNU df's
+// output (SOURCE=14, FSTYPE=4, SIZE/USED/AVAIL=5, USE%=4). Headers are
+// always at least the label width, so the only minimums that exceed their
+// header are SOURCE (14 vs "Filesystem"=10) and USED (5 vs "Used"=4).
 func minColumnWidths(withType bool) []int {
 	if withType {
 		// Filesystem, Type, blocks, Used, Available, Use%, Mounted on

--- a/builtins/df/df_internal_test.go
+++ b/builtins/df/df_internal_test.go
@@ -61,7 +61,7 @@ func TestHumanBytes_1024(t *testing.T) {
 
 func TestHumanBytes_1000(t *testing.T) {
 	// SI mode uses lowercase "k" for the kilo suffix (matches GNU
-	// df / lib/human.c). Other suffixes stay uppercase.
+	// df). Other suffixes stay uppercase.
 	cases := []struct {
 		v    uint64
 		want string

--- a/builtins/internal/diskstats/diskstats_linux.go
+++ b/builtins/internal/diskstats/diskstats_linux.go
@@ -71,8 +71,7 @@ var pseudoTypes = map[string]bool{
 }
 
 // remoteTypePrefixes lists filesystem-type prefixes that mark a filesystem
-// as remote (i.e. !Local). GNU df classifies these via me_remote in
-// lib/mountlist.c.
+// as remote (i.e. !Local), matching the classification GNU df applies.
 //
 // Linux mountinfo reports FUSE mounts as "fuse.<subtype>" (e.g.
 // "fuse.sshfs", "fuse.smbnetfs"), so the remote FUSE backends are

--- a/builtins/internal/diskstats/diskstats_linux_parse_test.go
+++ b/builtins/internal/diskstats/diskstats_linux_parse_test.go
@@ -166,9 +166,9 @@ func TestIsRemoteSource_TypeOnly(t *testing.T) {
 
 // Mounts whose type is generic (gpfs, acfs, "auto", custom NFS-flavored
 // types) but whose source carries a network signature must still be
-// classified remote, mirroring GNU me_remote (lib/mountlist.c). Without
-// this, `df -l` would keep the mount and statfs(2) could hang on a
-// stale network mount.
+// classified remote, matching GNU df's classification. Without this,
+// `df -l` would keep the mount and statfs(2) could hang on a stale
+// network mount.
 func TestIsRemoteSource_BySourceShape(t *testing.T) {
 	for _, src := range []string{
 		"server:/export",        // classic NFS


### PR DESCRIPTION
Rewords a few comments in df and diskstats to describe behavior
instead of citing specific source files. Comment-only change, no
functional diff.