### PR TITLE
set .go files to eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set go source line endings to LF on all platforms so gofmt can be used
+*.go text=auto eol=lf
+go.mod text eol=lf
+go.sum -diff -merge linguist-generated=true


### PR DESCRIPTION
### What does this PR do?

Add `.gitattributes` to the repo and set `.go` related files to `eol=lf`

### Motivation

`gofmt` always writes with LF so it always fails / creates diff churn on Windows checkouts which default to `core.autocrlf=true`

