### PR TITLE
fix(break/continue): unwind all enclosing loops on out-of-range count

### DIFF
--- a/builtins/internal/loopctl/loopctl.go
+++ b/builtins/internal/loopctl/loopctl.go
@@ -11,9 +11,10 @@ import (
 	"github.com/DataDog/rshell/builtins"
 )
 
-// unwindAllLoops is used as a break/continue depth that is guaranteed to
-// exceed any realistic loop nesting depth, so the clamp-at-outermost logic
-// in interp/runner_exec.go fully unwinds every enclosing loop. It is a plain
+// unwindAllLoops is used as a break/continue depth that comfortably exceeds
+// any loop nesting depth the interpreter could actually reach before its own
+// recursion/stack limits kick in first, so the clamp-at-outermost logic in
+// interp/runner_exec.go fully unwinds every enclosing loop. It is a plain
 // literal (rather than math.MaxInt) to avoid depending on the "math" package,
 // and is small enough to avoid any risk of overflow when decremented once
 // per enclosing loop.

--- a/builtins/internal/loopctl/loopctl.go
+++ b/builtins/internal/loopctl/loopctl.go
@@ -11,6 +11,14 @@ import (
 	"github.com/DataDog/rshell/builtins"
 )
 
+// unwindAllLoops is used as a break/continue depth that is guaranteed to
+// exceed any realistic loop nesting depth, so the clamp-at-outermost logic
+// in interp/runner_exec.go fully unwinds every enclosing loop. It is a plain
+// literal (rather than math.MaxInt) to avoid depending on the "math" package,
+// and is small enough to avoid any risk of overflow when decremented once
+// per enclosing loop.
+const unwindAllLoops = 1 << 30
+
 // LoopControl implements the shared logic for the break and continue builtins.
 func LoopControl(callCtx *builtins.CallContext, name string, args []string) builtins.Result {
 	if !callCtx.InLoop {
@@ -29,7 +37,17 @@ func LoopControl(callCtx *builtins.CallContext, name string, args []string) buil
 		}
 		if parsed < 1 {
 			callCtx.Errf("%s: %s: loop count out of range\n", name, args[0])
-			return builtins.Result{Code: 1, BreakN: 1}
+			// Bash unwinds every enclosing loop (not just the innermost one)
+			// when the count is out of range — for BOTH break and continue.
+			// This differs from a count that merely exceeds the nesting
+			// depth (e.g. "continue 100" in two loops), which clamps to the
+			// outermost loop and keeps iterating there; an out-of-range
+			// count terminates all enclosing loops outright, exactly like
+			// "break" with an effectively infinite count. Use BreakN (not
+			// ContinueN) with a very large value so the shared
+			// clamp-at-outermost logic in interp/runner_exec.go fully
+			// unwinds the loop stack instead of resuming iteration anywhere.
+			return builtins.Result{Code: 1, BreakN: unwindAllLoops}
 		}
 		n = parsed
 	default:

--- a/tests/scenarios/shell/for_clause/break_cont/break_negative_arg_nested.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/break_negative_arg_nested.yaml
@@ -1,0 +1,23 @@
+description: Break with an out-of-range negative operand unwinds every enclosing loop, not just the innermost one.
+input:
+  script: |+
+    for i in 1 2; do
+      echo outer $i
+      for j in 1 2; do
+        echo inner $i $j
+        break -1
+        echo unreached $i $j
+      done
+      echo after-inner $i
+    done
+    echo done
+expect:
+  stdout: |+
+    outer 1
+    inner 1 1
+    done
+  stderr_contains:
+    - "break"
+    - "-1"
+    - "loop count out of range"
+  exit_code: 0

--- a/tests/scenarios/shell/for_clause/break_cont/break_negative_arg_triple_nested.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/break_negative_arg_triple_nested.yaml
@@ -1,0 +1,28 @@
+description: Break with an out-of-range negative operand in triple nested for loops unwinds all three, not just the innermost.
+input:
+  script: |+
+    for i in 1 2 3; do
+      echo in $i
+      for j in a b c; do
+        echo in $i $j
+        for k in + -; do
+          echo in $i $j $k
+          break -1
+          echo out $i $j $k
+        done
+        echo out $i $j
+      done
+      echo out $i
+    done
+    echo done $?
+expect:
+  stdout: |+
+    in 1
+    in 1 a
+    in 1 a +
+    done 1
+  stderr_contains:
+    - "break"
+    - "-1"
+    - "loop count out of range"
+  exit_code: 0

--- a/tests/scenarios/shell/for_clause/break_cont/break_zero_arg_nested.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/break_zero_arg_nested.yaml
@@ -1,0 +1,23 @@
+description: Break 0 in a nested loop unwinds every enclosing loop, not just the innermost one.
+input:
+  script: |+
+    for i in 1 2; do
+      echo outer $i
+      for j in 1 2; do
+        echo inner $i $j
+        break 0
+        echo unreached $i $j
+      done
+      echo after-inner $i
+    done
+    echo done
+expect:
+  stdout: |+
+    outer 1
+    inner 1 1
+    done
+  stderr_contains:
+    - "break"
+    - "0"
+    - "loop count out of range"
+  exit_code: 0

--- a/tests/scenarios/shell/for_clause/break_cont/continue_negative_arg_nested.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/continue_negative_arg_nested.yaml
@@ -1,0 +1,23 @@
+description: Continue with an out-of-range negative operand unwinds every enclosing loop, matching break -- not just the innermost loop, and not a continue of the outermost loop.
+input:
+  script: |+
+    for i in 1 2; do
+      echo outer $i
+      for j in 1 2; do
+        echo inner $i $j
+        continue -1
+        echo unreached $i $j
+      done
+      echo after-inner $i
+    done
+    echo done
+expect:
+  stdout: |+
+    outer 1
+    inner 1 1
+    done
+  stderr_contains:
+    - "continue"
+    - "-1"
+    - "loop count out of range"
+  exit_code: 0

--- a/tests/scenarios/shell/for_clause/break_cont/continue_zero_arg_nested.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/continue_zero_arg_nested.yaml
@@ -1,0 +1,23 @@
+description: Continue 0 in a nested loop unwinds every enclosing loop, not just the innermost one.
+input:
+  script: |+
+    for i in 1 2; do
+      echo outer $i
+      for j in 1 2; do
+        echo inner $i $j
+        continue 0
+        echo unreached $i $j
+      done
+      echo after-inner $i
+    done
+    echo done
+expect:
+  stdout: |+
+    outer 1
+    inner 1 1
+    done
+  stderr_contains:
+    - "continue"
+    - "0"
+    - "loop count out of range"
+  exit_code: 0


### PR DESCRIPTION
## Summary
- `break`/`continue` with an out-of-range count (0 or negative, e.g. `break -1`) only unwound the innermost enclosing loop instead of terminating all nested loops like real bash.
- Fixed by returning a large `BreakN` sentinel for the invalid-count path so the existing clamp-at-outermost logic in `interp/runner_exec.go` fully unwinds the loop stack.

## Test plan
- [x] `make fmt`
- [x] `go test ./builtins/... ./tests/...`
- [x] Manually verified `break -1`/`continue -1`/`break 0`/`continue 0` against real bash
- [x] Added 5 new scenario tests under `tests/scenarios/shell/for_clause/break_cont/`