### PR TITLE
fix(loopctl): match bash exit code 2 for invalid break/continue argument

### DIFF
--- a/builtins/internal/loopctl/loopctl.go
+++ b/builtins/internal/loopctl/loopctl.go
@@ -25,7 +25,7 @@ func LoopControl(callCtx *builtins.CallContext, name string, args []string) buil
 		parsed, err := strconv.Atoi(args[0])
 		if err != nil {
 			callCtx.Errf("%s: %s: numeric argument required\n", name, args[0])
-			return builtins.Result{Code: 128, Exiting: true}
+			return builtins.Result{Code: 2, Exiting: true}
 		}
 		if parsed < 1 {
 			callCtx.Errf("%s: %s: loop count out of range\n", name, args[0])

--- a/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/break_invalid_arg.yaml
@@ -8,4 +8,4 @@ expect:
   stdout: ""
   stderr_contains:
     - "break: abc: numeric argument required"
-  exit_code: 128
+  exit_code: 2

--- a/tests/scenarios/shell/for_clause/break_cont/break_overflow_arg.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/break_overflow_arg.yaml
@@ -1,0 +1,11 @@
+description: Break with an integer-overflowing argument exits the shell and produces an error.
+input:
+  script: |+
+    for i in a b c; do
+      break 99999999999999999999999
+    done
+expect:
+  stdout: ""
+  stderr: |+
+    break: 99999999999999999999999: numeric argument required
+  exit_code: 2

--- a/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/continue_invalid_arg.yaml
@@ -8,4 +8,4 @@ expect:
   stdout: ""
   stderr_contains:
     - "continue: abc: numeric argument required"
-  exit_code: 128
+  exit_code: 2

--- a/tests/scenarios/shell/for_clause/break_cont/continue_overflow_arg.yaml
+++ b/tests/scenarios/shell/for_clause/break_cont/continue_overflow_arg.yaml
@@ -1,0 +1,11 @@
+description: Continue with an integer-overflowing argument exits the shell and produces an error.
+input:
+  script: |+
+    for i in a b c; do
+      continue 99999999999999999999999
+    done
+expect:
+  stdout: ""
+  stderr: |+
+    continue: 99999999999999999999999: numeric argument required
+  exit_code: 2

--- a/tests/scenarios/shell/while_clause/continue_overflow.yaml
+++ b/tests/scenarios/shell/while_clause/continue_overflow.yaml
@@ -7,4 +7,4 @@ input:
 expect:
   stdout: ""
   stderr_contains: ["numeric argument required"]
-  exit_code: 128
+  exit_code: 2


### PR DESCRIPTION
## Summary
- `break`/`continue`'s "numeric argument required" fatal error returned exit code 128; real bash returns 2 for this error.
- Fixed the exit code and corrected the scenario tests that baked in the wrong (128) value, including one in a different directory (`tests/scenarios/shell/while_clause/continue_overflow.yaml`) that a prior pass missed.
- Added new overflow-argument scenarios to pin the behavior.

## Test plan
- [x] `make fmt`
- [x] `go test ./builtins/... ./tests/...`
- [x] Manually verified against real bash 5.3 (`break abc`, `break <huge number>`, `continue <huge number>`) — all exit 2