### PR TITLE
fix(uptime): correct duration/pretty formatting divergences from real uptime

### DIFF
--- a/analysis/symbols_builtins.go
+++ b/analysis/symbols_builtins.go
@@ -516,6 +516,7 @@ var builtinPerCommandSymbols = map[string][]string{
 		"fmt.Sprintf",     // 🟢 string formatting for duration and load average; pure function, no I/O.
 		"runtime.GOOS",    // 🟢 current OS name constant; used in "not supported" error message; pure constant, no I/O.
 		"strings.Builder", // 🟢 efficient string concatenation for default output line; pure in-memory buffer, no I/O.
+		"strings.Join",    // 🟢 concatenates pretty-format duration units with ", "; pure function, no I/O.
 		"time.Time",       // 🟢 time value type; used for callCtx.Now display and boot-time formatting; pure data, no side effects.
 		"time.Unix",       // 🟢 constructs absolute Time from Unix-epoch seconds for -s output; pure constructor, no I/O.
 		// Note: builtins/internal/sysinfo symbols are exempt from this allowlist

--- a/builtins/tests/uptime/uptime_test.go
+++ b/builtins/tests/uptime/uptime_test.go
@@ -63,14 +63,14 @@ func give(info sysinfo.Info) func() (sysinfo.Info, error) {
 
 func TestUptimeDefault(t *testing.T) {
 	stdout, stderr, code := runHandler(t, give(fakeInfo))
-	assert.Equal(t, " 15:36:09 up 1 day, 2:03,  load average: 1.23, 4.56, 7.89\n", stdout)
+	assert.Equal(t, " 15:36:09 up 1 day,  2:03,  load average: 1.23, 4.56, 7.89\n", stdout)
 	assert.Empty(t, stderr)
 	assert.Equal(t, uint8(0), code)
 }
 
 func TestUptimePretty(t *testing.T) {
 	stdout, stderr, code := runHandler(t, give(fakeInfo), "-p")
-	assert.Equal(t, "up 1 day, 2 hours\n", stdout)
+	assert.Equal(t, "up 1 day, 2 hours, 3 minutes\n", stdout)
 	assert.Empty(t, stderr)
 	assert.Equal(t, uint8(0), code)
 }

--- a/builtins/uptime/uptime.go
+++ b/builtins/uptime/uptime.go
@@ -120,10 +120,17 @@ func formatDefault(now time.Time, info sysinfo.Info) string {
 // formatDuration converts a duration in seconds to the standard uptime
 // duration format:
 //
-//	< 1 hour:  "N min"
-//	< 1 day:   "H:MM"
-//	= 1 day:   "1 day, H:MM"
-//	> 1 day:   "N days, H:MM"
+//	< 1 hour:            "N min"
+//	< 1 day:             " H:MM" (hours space-padded to width 2)
+//	= 1 day, no hours:   "1 day, N min"
+//	= 1 day, with hours: "1 day,  H:MM"
+//	> 1 day, no hours:   "N days, N min"
+//	> 1 day, with hours: "N days,  H:MM"
+//
+// The hour component is always space-padded to width 2 (e.g. " 1:23"), and
+// when the remaining hour count is zero the minutes-only fallback is used
+// even in the presence of a leading day count, matching reference uptime
+// output.
 func formatDuration(seconds float64) string {
 	total := int64(seconds)
 	mins := total / 60
@@ -132,25 +139,32 @@ func formatDuration(seconds float64) string {
 	remHours := hours % 24
 	remMins := mins % 60
 
+	var dayPart string
 	switch {
-	case hours == 0:
-		return fmt.Sprintf("%d min", mins)
-	case days == 0:
-		return fmt.Sprintf("%d:%02d", hours, remMins)
 	case days == 1:
-		return fmt.Sprintf("1 day, %d:%02d", remHours, remMins)
-	default:
-		return fmt.Sprintf("%d days, %d:%02d", days, remHours, remMins)
+		dayPart = "1 day, "
+	case days > 1:
+		dayPart = fmt.Sprintf("%d days, ", days)
 	}
+
+	var hourPart string
+	if remHours > 0 {
+		hourPart = fmt.Sprintf("%2d:%02d", remHours, remMins)
+	} else {
+		hourPart = fmt.Sprintf("%d min", remMins)
+	}
+
+	return dayPart + hourPart
 }
 
 // formatPretty converts a duration in seconds to the pretty uptime format
 // produced by the -p flag.
 //
-// Shows the highest non-zero unit and the next unit down (if non-zero):
+// Every non-zero unit, from the largest down to minutes, is included and
+// chained with ", " — not just the top two:
 //
-//	"up 1 week, 4 days"   (not hours/minutes when weeks are the primary unit)
-//	"up 1 day, 2 hours"   (not minutes when days are the primary unit)
+//	"up 1 week, 4 days, 16 hours, 28 minutes"
+//	"up 1 day, 2 hours, 3 minutes"
 //	"up 2 hours, 30 minutes"
 //
 // Units: decades (10 years), years (365 days), weeks (7 days), days, hours,
@@ -176,39 +190,27 @@ func formatPretty(seconds float64) string {
 		return fmt.Sprintf("%d %ss", n, unit)
 	}
 
-	var primary, secondary string
-	switch {
-	case updecades > 0:
-		primary = pp(updecades, "decade")
-		if upyears > 0 {
-			secondary = pp(upyears, "year")
-		}
-	case upyears > 0:
-		primary = pp(upyears, "year")
-		if upweeks > 0 {
-			secondary = pp(upweeks, "week")
-		}
-	case upweeks > 0:
-		primary = pp(upweeks, "week")
-		if updays > 0 {
-			secondary = pp(updays, "day")
-		}
-	case updays > 0:
-		primary = pp(updays, "day")
-		if uphours > 0 {
-			secondary = pp(uphours, "hour")
-		}
-	case uphours > 0:
-		primary = pp(uphours, "hour")
-		if upminutes > 0 {
-			secondary = pp(upminutes, "minute")
-		}
-	default:
-		primary = pp(upminutes, "minute")
+	var parts []string
+	if updecades > 0 {
+		parts = append(parts, pp(updecades, "decade"))
+	}
+	if upyears > 0 {
+		parts = append(parts, pp(upyears, "year"))
+	}
+	if upweeks > 0 {
+		parts = append(parts, pp(upweeks, "week"))
+	}
+	if updays > 0 {
+		parts = append(parts, pp(updays, "day"))
+	}
+	if uphours > 0 {
+		parts = append(parts, pp(uphours, "hour"))
+	}
+	// Minutes are always shown when non-zero, and also when they are the
+	// only unit available (uptime under one minute).
+	if upminutes > 0 || len(parts) == 0 {
+		parts = append(parts, pp(upminutes, "minute"))
 	}
 
-	if secondary != "" {
-		return "up " + primary + ", " + secondary
-	}
-	return "up " + primary
+	return "up " + strings.Join(parts, ", ")
 }

--- a/builtins/uptime/uptime_test.go
+++ b/builtins/uptime/uptime_test.go
@@ -26,13 +26,15 @@ func TestFormatDuration(t *testing.T) {
 		{"30 seconds", 30, "0 min"},
 		{"1 minute", 60, "1 min"},
 		{"59 minutes", 3540, "59 min"},
-		{"1 hour", 3600, "1:00"},
-		{"1 hour 30 min", 5400, "1:30"},
+		{"1 hour", 3600, " 1:00"},
+		{"1 hour 30 min", 5400, " 1:30"},
 		{"23 hours 59 min", 86340, "23:59"},
-		{"exactly 1 day", 86400, "1 day, 0:00"},
-		{"1 day 2 hours 3 min", 93780, "1 day, 2:03"},
-		{"2 days", 172800, "2 days, 0:00"},
+		{"exactly 1 day", 86400, "1 day, 0 min"},
+		{"1 day 2 hours 3 min", 93780, "1 day,  2:03"},
+		{"2 days", 172800, "2 days, 0 min"},
 		{"11 days 16 hours 28 min", 1009680, "11 days, 16:28"},
+		{"1 day 5 min (no hours)", 86700, "1 day, 5 min"},
+		{"9 hours", 32400, " 9:00"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -59,11 +61,11 @@ func TestFormatPretty(t *testing.T) {
 		{"1 day", 86400, "up 1 day"},
 		{"2 days", 172800, "up 2 days"},
 		{"1 day 1 hour", 90000, "up 1 day, 1 hour"},
-		{"1 day 1 hour 1 minute", 90060, "up 1 day, 1 hour"},
+		{"1 day 1 hour 1 minute", 90060, "up 1 day, 1 hour, 1 minute"},
 		{"1 week", 604800, "up 1 week"},
 		{"2 weeks", 1209600, "up 2 weeks"},
 		{"1 week 4 days", 950400, "up 1 week, 4 days"},
-		{"11 days 16 hours 28 minutes", 1009680, "up 1 week, 4 days"},
+		{"11 days 16 hours 28 minutes", 1009680, "up 1 week, 4 days, 16 hours, 28 minutes"},
 		{"1 year", 31536000, "up 1 year"},
 		{"1 year 2 weeks", 32745600, "up 1 year, 2 weeks"},
 		{"1 decade", 315360000, "up 1 decade"},
@@ -97,6 +99,6 @@ func TestFormatDefault(t *testing.T) {
 			LoadAvailable: false,
 		}
 		got := formatDefault(now, info)
-		assert.Equal(t, " 15:36:09 up 1:30", got)
+		assert.Equal(t, " 15:36:09 up  1:30", got)
 	})
 }

--- a/tests/scenarios/cmd/uptime/basic/default.yaml
+++ b/tests/scenarios/cmd/uptime/basic/default.yaml
@@ -1,0 +1,9 @@
+description: uptime default output includes the "up" duration segment
+skip_assert_against_bash: true
+input:
+  script: |+
+    uptime
+expect:
+  stdout_contains: ["up "]
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/uptime/basic/pretty.yaml
+++ b/tests/scenarios/cmd/uptime/basic/pretty.yaml
@@ -1,0 +1,9 @@
+description: uptime -p prints pretty format starting with "up "
+skip_assert_against_bash: true
+input:
+  script: |+
+    uptime -p
+expect:
+  stdout_contains: ["up "]
+  stderr: ""
+  exit_code: 0


### PR DESCRIPTION
## Summary
- Fixed three formatting divergences from real GNU/procps-ng `uptime`:
  - Missing space-padding on single-digit hours in the default duration format (`up  1:23`, not `up 1:23`).
  - Missing "N days, M min" fallback when remaining hours is 0 (was rendering "N days, 0:00").
  - `-p`/`--pretty` mode dropped all but the top two non-zero units instead of chaining every non-zero unit.
- Corrected existing unit test tables that baked in the old, incorrect output.

## Test plan
- [x] `make fmt`
- [x] `go test ./builtins/uptime/... ./builtins/tests/uptime/...`
- [x] `go test ./tests/... -run TestShellScenarios`
- [x] Added new scenario tests under `tests/scenarios/cmd/uptime/basic/`