### PR TITLE
fix(uniq): match sibling builtins' extra operand error wording

### DIFF
--- a/builtins/uniq/uniq.go
+++ b/builtins/uniq/uniq.go
@@ -210,7 +210,8 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if len(args) > 1 {
-			callCtx.Errf("uniq: extra operand %q\n", args[1])
+			callCtx.Errf("uniq: extra operand '%s'\n", args[1])
+			callCtx.Errf("Try 'uniq --help' for more information.\n")
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/uniq/uniq_test.go
+++ b/builtins/uniq/uniq_test.go
@@ -533,7 +533,7 @@ func TestUniqExtraOperand(t *testing.T) {
 	writeFile(t, dir, "b.txt", "b\n")
 	_, stderr, code := cmdRun(t, "uniq a.txt b.txt", dir)
 	assert.Equal(t, 1, code)
-	assert.Contains(t, stderr, "extra operand")
+	assert.Equal(t, "uniq: extra operand 'b.txt'\nTry 'uniq --help' for more information.\n", stderr)
 }
 
 func TestUniqInvalidAllRepeatedMethod(t *testing.T) {

--- a/tests/scenarios/cmd/uniq/errors/extra_operand.yaml
+++ b/tests/scenarios/cmd/uniq/errors/extra_operand.yaml
@@ -1,4 +1,8 @@
 description: uniq rejects extra positional operands.
+# GNU uniq's real usage is `uniq [OPTION]... [INPUT [OUTPUT]]` — the second
+# operand is a destination file, not an error, so bash writes deduped output
+# into b.txt and exits 0. rshell intentionally rejects it instead.
+skip_assert_against_bash: true
 setup:
   files:
     - path: a.txt

--- a/tests/scenarios/cmd/uniq/errors/extra_operand.yaml
+++ b/tests/scenarios/cmd/uniq/errors/extra_operand.yaml
@@ -1,0 +1,17 @@
+description: uniq rejects extra positional operands.
+setup:
+  files:
+    - path: a.txt
+      content: "a\n"
+    - path: b.txt
+      content: "b\n"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    uniq a.txt b.txt
+expect:
+  stdout: |+
+  stderr: |+
+    uniq: extra operand 'b.txt'
+    Try 'uniq --help' for more information.
+  exit_code: 1


### PR DESCRIPTION
## Summary
- `uniq`'s "extra operand" error used Go's `%q` double-quote formatting and lacked the trailing "Try 'uniq --help' for more information." line that every sibling builtin (`df`, `free`, `lsof`, `uname`, `uptime`, `tr`) includes.
- Fixed to use the repo-wide `'%s'` single-quote convention plus the missing help hint line.

## Test plan
- [x] `make fmt`
- [x] `go test ./builtins/uniq/...`
- [x] Pinned the exact corrected wording in `TestUniqExtraOperand` and a new scenario test (`tests/scenarios/cmd/uniq/errors/extra_operand.yaml`)