### PR TITLE
test(xargs): cover remediation gating for rm/truncate via xargs dispatch

### DIFF
--- a/tests/scenarios/cmd/rm/basic/xargs_exec.yaml
+++ b/tests/scenarios/cmd/rm/basic/xargs_exec.yaml
@@ -1,0 +1,21 @@
+# Tests that rm invoked as xargs's target command still goes through the
+# same remediation-gated CallContext.RunCommand dispatch, mirroring the
+# truncate/basic/find_exec.yaml coverage for the find -exec dispatch path.
+description: rm invoked via xargs works in remediation mode.
+setup:
+  files:
+    - path: a.txt
+      content: "a\n"
+    - path: b.txt
+      content: "b\n"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    printf 'a.txt\nb.txt\n' | xargs rm
+    [ -f a.txt ] || [ -f b.txt ] || echo gone
+expect:
+  stdout: |+
+    gone
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/rm/errors/xargs_readonly_mode.yaml
+++ b/tests/scenarios/cmd/rm/errors/xargs_readonly_mode.yaml
@@ -1,0 +1,19 @@
+# Security test: rm invoked as xargs's target command must stay gated behind
+# remediation mode. xargs dispatches sub-commands through the same
+# CallContext.RunCommand path as top-level dispatch (see xargs.go), so this
+# proves the gate is not bypassable by routing rm through xargs.
+description: rm invoked via xargs without remediation mode fails with "capability not available".
+setup:
+  files:
+    - path: f.txt
+      content: "data"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    printf 'f.txt\n' | xargs rm
+expect:
+  stdout: |+
+  stderr: |+
+    rm: filesystem capability not available (remediation mode required)
+  exit_code: 123
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/rm/errors/xargs_readonly_mode.yaml
+++ b/tests/scenarios/cmd/rm/errors/xargs_readonly_mode.yaml
@@ -2,7 +2,7 @@
 # remediation mode. xargs dispatches sub-commands through the same
 # CallContext.RunCommand path as top-level dispatch (see xargs.go), so this
 # proves the gate is not bypassable by routing rm through xargs.
-description: rm invoked via xargs without remediation mode fails with "capability not available".
+description: rm invoked via xargs without remediation mode fails with "capability not available" and leaves the file untouched.
 setup:
   files:
     - path: f.txt
@@ -11,8 +11,11 @@ input:
   allowed_paths: ["$DIR"]
   script: |+
     printf 'f.txt\n' | xargs rm
+    code=$?
+    cat f.txt
+    exit $code
 expect:
-  stdout: |+
+  stdout: "data"
   stderr: |+
     rm: filesystem capability not available (remediation mode required)
   exit_code: 123

--- a/tests/scenarios/cmd/truncate/basic/xargs_exec.yaml
+++ b/tests/scenarios/cmd/truncate/basic/xargs_exec.yaml
@@ -1,0 +1,19 @@
+# Tests the xargs dispatch path (CallContext.RunCommand), mirroring the
+# find -exec coverage in truncate/basic/find_exec.yaml for the other
+# non-top-level command dispatch path.
+description: truncate invoked via xargs works in remediation mode.
+setup:
+  files:
+    - path: big.log
+      content: "lots of log data"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    printf 'big.log\n' | xargs truncate -s 0
+    wc -c < big.log
+expect:
+  stdout: |+
+    0
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/truncate/errors/xargs_readonly_mode.yaml
+++ b/tests/scenarios/cmd/truncate/errors/xargs_readonly_mode.yaml
@@ -1,0 +1,19 @@
+# Security test: truncate invoked as xargs's target command must stay gated
+# behind remediation mode. xargs dispatches sub-commands through the same
+# CallContext.RunCommand path as top-level dispatch (see xargs.go), so this
+# proves the gate is not bypassable by routing truncate through xargs.
+description: truncate invoked via xargs without remediation mode fails with "capability not available".
+setup:
+  files:
+    - path: f.txt
+      content: "data"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    printf 'f.txt\n' | xargs truncate -s 0
+expect:
+  stdout: |+
+  stderr: |+
+    truncate: filesystem capability not available (remediation mode required)
+  exit_code: 123
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/truncate/errors/xargs_readonly_mode.yaml
+++ b/tests/scenarios/cmd/truncate/errors/xargs_readonly_mode.yaml
@@ -2,7 +2,7 @@
 # behind remediation mode. xargs dispatches sub-commands through the same
 # CallContext.RunCommand path as top-level dispatch (see xargs.go), so this
 # proves the gate is not bypassable by routing truncate through xargs.
-description: truncate invoked via xargs without remediation mode fails with "capability not available".
+description: truncate invoked via xargs without remediation mode fails with "capability not available" and leaves the file untouched.
 setup:
   files:
     - path: f.txt
@@ -11,8 +11,11 @@ input:
   allowed_paths: ["$DIR"]
   script: |+
     printf 'f.txt\n' | xargs truncate -s 0
+    code=$?
+    cat f.txt
+    exit $code
 expect:
-  stdout: |+
+  stdout: "data"
   stderr: |+
     truncate: filesystem capability not available (remediation mode required)
   exit_code: 123


### PR DESCRIPTION
## Summary
- Test-coverage gap: no test proved that mutating builtins (`rm`, `truncate`) invoked as `xargs`'s target command remain gated by remediation mode, despite the code appearing correct by inspection.
- Added 4 scenario tests covering both the permitted (remediation mode on) and rejected (remediation mode off, with proof of no mutation) cases for both builtins.
- Sanity-checked by temporarily disabling the gate in `rm`/`truncate` — the new rejection tests failed as expected, then the change was reverted, confirming the tests are meaningful.

No production code changes — the underlying gating was already correct.

## Test plan
- [x] `make fmt`
- [x] `go test ./tests/... -run TestShellScenarios`
- [x] Sanity check: broke the gate locally, confirmed new tests fail, reverted