### PR TITLE
test: cover minor test-coverage gaps from remediation-mode audit

### DIFF
--- a/tests/scenarios/cmd/help/dynamic_dispatch.yaml
+++ b/tests/scenarios/cmd/help/dynamic_dispatch.yaml
@@ -1,0 +1,10 @@
+description: help <cmd> for a command without a static Help string dispatches to the command's own --help (help.go's dynamic capture-and-invoke branch).
+skip_assert_against_bash: true
+input:
+  script: |+
+    help ls
+expect:
+  stdout_contains:
+    - "Usage: ls [OPTION]... [FILE]..."
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/help/dynamic_dispatch_exit_code.yaml
+++ b/tests/scenarios/cmd/help/dynamic_dispatch_exit_code.yaml
@@ -1,0 +1,11 @@
+description: help always returns exit code 0 for `help <cmd>` even when the dispatched command's own --help handler would have exited 1 outside remediation mode — pinning current behavior of help.go's dynamic dispatch branch, which discards the nested handler's Result and always returns Result{}.
+skip_assert_against_bash: true
+input:
+  script: |+
+    help systemctl; echo $?
+expect:
+  stdout_contains:
+    - "systemctl: remediation mode required"
+    - "0"
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/help/dynamic_dispatch_remediation_gating.yaml
+++ b/tests/scenarios/cmd/help/dynamic_dispatch_remediation_gating.yaml
@@ -1,0 +1,10 @@
+description: help systemctl dispatches into systemctl's own remediation-mode gate — read-only mode returns the gate's refusal text (no manager access), remediation mode returns real usage text.
+skip_assert_against_bash: true
+input:
+  script: |+
+    help systemctl
+expect:
+  stdout_contains:
+    - "systemctl: remediation mode required"
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/help/dynamic_dispatch_remediation_mode.yaml
+++ b/tests/scenarios/cmd/help/dynamic_dispatch_remediation_mode.yaml
@@ -1,0 +1,12 @@
+description: help systemctl in remediation mode dispatches to systemctl's real --help usage text.
+skip_assert_against_bash: true
+input:
+  mode: remediation
+  script: |+
+    help systemctl
+expect:
+  stdout_contains:
+    - "Usage: systemctl [OPTION]... COMMAND [UNIT]..."
+    - "list-units"
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/errors/help_readonly_mode.yaml
+++ b/tests/scenarios/cmd/logrotate/errors/help_readonly_mode.yaml
@@ -1,0 +1,16 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: logrotate --help outside remediation mode is rejected by the same capability gate as --force, since the nil-capability check runs before --help is processed.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR"]
+  script: |+
+    logrotate --help
+expect:
+  stdout: |+
+  stderr: |+
+    logrotate: filesystem capability not available (remediation mode required)
+  exit_code: 1

--- a/tests/scenarios/cmd/logrotate/errors/partial_failure_continues.yaml
+++ b/tests/scenarios/cmd/logrotate/errors/partial_failure_continues.yaml
@@ -1,0 +1,21 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: logrotate continues processing remaining file operands after a per-file failure, truncating app.log despite missing.log failing, and exits 1 for the overall partial failure.
+setup:
+  files:
+    - path: app.log
+      content: "0123456789\n"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --force missing.log app.log
+    echo "exit:$?"
+    wc -c < app.log
+expect:
+  stdout: |+
+    exit:1
+    0
+  stderr: |+
+    logrotate: "missing.log": no such file or directory
+  exit_code: 0

--- a/tests/scenarios/cmd/ps/basic/field_aliases.yaml
+++ b/tests/scenarios/cmd/ps/basic/field_aliases.yaml
@@ -1,0 +1,11 @@
+description: ps -o %cpu,%mem accepts the procps %cpu/%mem alias spellings as equivalent to pcpu/pmem, resolving to the same %CPU/%MEM header columns.
+skip_assert_against_bash: true
+input:
+  script: |+
+    ps -o pid,%cpu,pcpu,%mem,pmem
+expect:
+  stdout_contains:
+    - "PID"
+    - "%CPU"
+    - "%MEM"
+  exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/ipv4_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/ipv4_only.yaml
@@ -1,0 +1,12 @@
+description: ss -4 filters to IPv4 sockets only; header still shows Netid/State.
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["/proc/net"]
+  script: |+
+    ss -an4
+expect:
+  stdout_contains:
+    - "Netid"
+    - "State"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/ipv4_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/ipv4_only.yaml
@@ -1,4 +1,4 @@
-description: ss -4 filters to IPv4 sockets only; header still shows Netid/State.
+description: ss -4 is accepted and runs end-to-end against a live /proc/net, producing a valid header. Filter correctness (that -4 actually drops IPv6 entries) is unit-tested against synthetic socketEntry values in ss_helpers_test.go, since live socket state isn't controllable in a scenario.
 skip_assert_against_bash: true
 input:
   allowed_paths: ["/proc/net"]
@@ -8,5 +8,5 @@ expect:
   stdout_contains:
     - "Netid"
     - "State"
-  stderr: ""
+  stderr: |+
   exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/ipv6_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/ipv6_only.yaml
@@ -1,4 +1,4 @@
-description: ss -6 filters to IPv6 sockets only; header still shows Netid/State.
+description: ss -6 is accepted and runs end-to-end against a live /proc/net, producing a valid header. Filter correctness (that -6 actually drops IPv4 entries) is unit-tested against synthetic socketEntry values in ss_helpers_test.go, since live socket state isn't controllable in a scenario.
 skip_assert_against_bash: true
 input:
   allowed_paths: ["/proc/net"]
@@ -8,5 +8,5 @@ expect:
   stdout_contains:
     - "Netid"
     - "State"
-  stderr: ""
+  stderr: |+
   exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/ipv6_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/ipv6_only.yaml
@@ -1,0 +1,12 @@
+description: ss -6 filters to IPv6 sockets only; header still shows Netid/State.
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["/proc/net"]
+  script: |+
+    ss -an6
+expect:
+  stdout_contains:
+    - "Netid"
+    - "State"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/listening_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/listening_only.yaml
@@ -1,4 +1,4 @@
-description: ss -l restricts output to listening sockets; runs cleanly with a valid header.
+description: ss -l is accepted and runs end-to-end against a live /proc/net, producing a valid header. Filter correctness (that -l actually restricts to listening sockets) is unit-tested against synthetic socketEntry values in ss_helpers_test.go, since live socket state isn't controllable in a scenario.
 skip_assert_against_bash: true
 input:
   allowed_paths: ["/proc/net"]
@@ -8,5 +8,5 @@ expect:
   stdout_contains:
     - "Netid"
     - "State"
-  stderr: ""
+  stderr: |+
   exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/listening_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/listening_only.yaml
@@ -1,0 +1,12 @@
+description: ss -l restricts output to listening sockets; runs cleanly with a valid header.
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["/proc/net"]
+  script: |+
+    ss -l
+expect:
+  stdout_contains:
+    - "Netid"
+    - "State"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/tcp_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/tcp_only.yaml
@@ -1,0 +1,13 @@
+description: ss -t filters to TCP sockets only; header still shows Netid/State.
+skip_assert_against_bash: true
+input:
+  # /proc/net is required on Linux; on macOS/Windows ss uses sysctl/iphlpapi.
+  allowed_paths: ["/proc/net"]
+  script: |+
+    ss -tan
+expect:
+  stdout_contains:
+    - "Netid"
+    - "State"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/tcp_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/tcp_only.yaml
@@ -1,4 +1,4 @@
-description: ss -t filters to TCP sockets only; header still shows Netid/State.
+description: ss -t is accepted and runs end-to-end against a live /proc/net, producing a valid header. Filter correctness (that -t actually drops non-TCP entries) is unit-tested against synthetic socketEntry values in ss_helpers_test.go, since live socket state isn't controllable in a scenario.
 skip_assert_against_bash: true
 input:
   # /proc/net is required on Linux; on macOS/Windows ss uses sysctl/iphlpapi.
@@ -9,5 +9,5 @@ expect:
   stdout_contains:
     - "Netid"
     - "State"
-  stderr: ""
+  stderr: |+
   exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/udp_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/udp_only.yaml
@@ -1,0 +1,12 @@
+description: ss -u filters to UDP sockets only; header still shows Netid/State.
+skip_assert_against_bash: true
+input:
+  allowed_paths: ["/proc/net"]
+  script: |+
+    ss -uan
+expect:
+  stdout_contains:
+    - "Netid"
+    - "State"
+  stderr: ""
+  exit_code: 0

--- a/tests/scenarios/cmd/ss/filters/udp_only.yaml
+++ b/tests/scenarios/cmd/ss/filters/udp_only.yaml
@@ -1,4 +1,4 @@
-description: ss -u filters to UDP sockets only; header still shows Netid/State.
+description: ss -u is accepted and runs end-to-end against a live /proc/net, producing a valid header. Filter correctness (that -u actually drops non-UDP entries) is unit-tested against synthetic socketEntry values in ss_helpers_test.go, since live socket state isn't controllable in a scenario.
 skip_assert_against_bash: true
 input:
   allowed_paths: ["/proc/net"]
@@ -8,5 +8,5 @@ expect:
   stdout_contains:
     - "Netid"
     - "State"
-  stderr: ""
+  stderr: |+
   exit_code: 0


### PR DESCRIPTION
## Summary
Addresses several small, independent test-coverage gaps found during a full remediation-mode audit:
- `help <cmd>`'s dynamic dispatch branch (used when a builtin lacks a static help string) had zero coverage — added scenarios covering dispatch, remediation-gating through nested dispatch, and exit-code pinning.
- `ss` flag correctness (`-t`/`-u`/`-l`/`-4`/`-6`) had Go coverage but no scenario coverage — added scenario tests using header-presence assertions.
- `ps` field aliases (`%cpu`/`%mem`) — added a scenario proving they resolve correctly. (Sort-tiebreak coverage was skipped: no real process can be reliably forced into an "unavailable metric" state across CI environments.)
- `logrotate --help` outside remediation mode was untested — added a scenario proving it's rejected the same as `--force`.
- `logrotate`'s multi-file partial-failure continuation was untested — added a scenario proving one file's failure doesn't block a later file's success.

The `free -h` boundary test gap is intentionally left out here — it's addressed in #577.

No production code changes — all described behaviors were confirmed correct as documented.

## Test plan
- [x] `make fmt`
- [x] `go test ./builtins/... ./tests/...`