### PR TITLE
fix(builtins): escape control bytes in error message operands

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -13,8 +13,10 @@ import (
 	"io/fs"
 	"os"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/spf13/pflag"
 
@@ -383,6 +385,36 @@ func (c *CallContext) Outf(format string, a ...any) {
 // Errf writes a formatted string to stderr.
 func (c *CallContext) Errf(format string, a ...any) {
 	fmt.Fprintf(c.Stderr, format, a...)
+}
+
+// SafeOperand escapes control characters in s — newlines, tabs, ESC, and
+// other non-printable bytes — so the result can be interpolated into a
+// single-quoted error message (e.g. "cmd: extra operand '%s'") without
+// letting a crafted operand forge additional diagnostic lines or inject
+// terminal/log control sequences into stderr. It intentionally does not
+// escape the single quote itself or otherwise shell-quote the value; it
+// only neutralizes bytes that are dangerous in a raw stderr stream,
+// mirroring the "literal" tier of GNU coreutils' quotearg rather than its
+// full shell-quoting modes.
+func SafeOperand(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteString(`\t`)
+		case unicode.IsControl(r):
+			fmt.Fprintf(&b, `\x%02x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // IsBrokenPipe reports whether err is a broken-pipe (EPIPE) error,

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -391,11 +391,14 @@ func (c *CallContext) Errf(format string, a ...any) {
 // other non-printable bytes — so the result can be interpolated into a
 // single-quoted error message (e.g. "cmd: extra operand '%s'") without
 // letting a crafted operand forge additional diagnostic lines or inject
-// terminal/log control sequences into stderr. It intentionally does not
-// escape the single quote itself or otherwise shell-quote the value; it
-// only neutralizes bytes that are dangerous in a raw stderr stream,
-// mirroring the "literal" tier of GNU coreutils' quotearg rather than its
-// full shell-quoting modes.
+// terminal/log control sequences into stderr. It also escapes Unicode line/
+// paragraph separators (U+2028, U+2029) and format characters (e.g. the
+// bidi override U+202E), since unicode.IsControl doesn't cover those but
+// Unicode-aware log viewers still act on them to split or visually reorder
+// the diagnostic. It intentionally does not escape the single quote itself
+// or otherwise shell-quote the value; it only neutralizes runes that are
+// dangerous in a raw stderr stream, mirroring the "literal" tier of GNU
+// coreutils' quotearg rather than its full shell-quoting modes.
 func SafeOperand(s string) string {
 	var b strings.Builder
 	for _, r := range s {
@@ -408,8 +411,12 @@ func SafeOperand(s string) string {
 			b.WriteString(`\r`)
 		case r == '\t':
 			b.WriteString(`\t`)
-		case unicode.IsControl(r):
-			fmt.Fprintf(&b, `\x%02x`, r)
+		case unicode.IsControl(r) || unicode.In(r, unicode.Zl, unicode.Zp, unicode.Cf):
+			if r > 0xff {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				fmt.Fprintf(&b, `\x%02x`, r)
+			}
 		default:
 			b.WriteRune(r)
 		}

--- a/builtins/df/df.go
+++ b/builtins/df/df.go
@@ -262,7 +262,7 @@ func makeFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if len(args) > 0 {
-			callCtx.Errf("df: extra operand '%s'\n", args[0])
+			callCtx.Errf("df: extra operand '%s'\n", builtins.SafeOperand(args[0]))
 			callCtx.Errf("Try 'df --help' for more information.\n")
 			return builtins.Result{Code: 1}
 		}
@@ -272,7 +272,7 @@ func makeFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// other work so configs / scripts that accidentally name the
 		// same type in both lists fail loudly.
 		if dup := overlappingType(*f.includeTypes, *f.excludeTypes); dup != "" {
-			callCtx.Errf("df: file system type '%s' both selected and excluded\n", dup)
+			callCtx.Errf("df: file system type '%s' both selected and excluded\n", builtins.SafeOperand(dup))
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/df/df_test.go
+++ b/builtins/df/df_test.go
@@ -214,6 +214,19 @@ func TestDfExtraOperand(t *testing.T) {
 	assert.Contains(t, stderr, "extra operand")
 }
 
+// TestDfExtraOperandEscapesControlBytes verifies that a crafted operand
+// containing a newline and an ANSI escape sequence is neutralized before
+// being written to stderr, rather than letting it forge additional
+// diagnostic lines or inject terminal control sequences.
+func TestDfExtraOperandEscapesControlBytes(t *testing.T) {
+	script := "df \"evil\nrshell: forged line\x1b[31m\"\n"
+	_, stderr, code := dfRun(t, script)
+	assert.Equal(t, 1, code)
+	assert.NotContains(t, stderr, "evil\nrshell: forged line")
+	assert.NotContains(t, stderr, "\x1b[31m")
+	assert.Contains(t, stderr, `evil\nrshell: forged line\x1b[31m`)
+}
+
 func TestDfMultipleExtraOperands(t *testing.T) {
 	_, stderr, code := dfRun(t, "df /tmp /var")
 	assert.Equal(t, 1, code)

--- a/builtins/du/du.go
+++ b/builtins/du/du.go
@@ -405,13 +405,13 @@ func walk(
 		return 0, false, ctx.Err()
 	}
 	if depth > maxRecursionDepth {
-		callCtx.Errf("du: recursion depth limit exceeded at '%s'\n", reportPath)
+		callCtx.Errf("du: recursion depth limit exceeded at '%s'\n", builtins.SafeOperand(reportPath))
 		return 0, false, errFailed
 	}
 
 	info, err := statEntry(ctx, callCtx, fsPath, opts.dereference)
 	if err != nil {
-		callCtx.Errf("du: cannot access '%s': %s\n", reportPath, callCtx.PortableErr(err))
+		callCtx.Errf("du: cannot access '%s': %s\n", builtins.SafeOperand(reportPath), callCtx.PortableErr(err))
 		return 0, false, err
 	}
 
@@ -453,7 +453,7 @@ func walk(
 			if opts.dereference {
 				if firstPath, seen := ancestorIDs[id]; seen {
 					callCtx.Errf("du: File system loop detected; '%s' is part of the same file system loop as '%s'.\n",
-						reportPath, firstPath)
+						builtins.SafeOperand(reportPath), builtins.SafeOperand(firstPath))
 					return 0, true, errFailed
 				}
 				// Push this directory onto the ancestor map for the duration
@@ -524,7 +524,7 @@ func walkChildren(
 ) (fileChildren, subdirChildren int64, failedAny bool) {
 	dh, err := callCtx.OpenDir(ctx, fsPath)
 	if err != nil {
-		callCtx.Errf("du: cannot read directory '%s': %s\n", reportPath, callCtx.PortableErr(err))
+		callCtx.Errf("du: cannot read directory '%s': %s\n", builtins.SafeOperand(reportPath), callCtx.PortableErr(err))
 		return 0, 0, true
 	}
 	defer dh.Close()
@@ -538,7 +538,7 @@ func walkChildren(
 			if readErr == nil || errors.Is(readErr, io.EOF) {
 				return fileChildren, subdirChildren, failedAny
 			}
-			callCtx.Errf("du: error reading directory '%s': %s\n", reportPath, callCtx.PortableErr(readErr))
+			callCtx.Errf("du: error reading directory '%s': %s\n", builtins.SafeOperand(reportPath), callCtx.PortableErr(readErr))
 			return fileChildren, subdirChildren, true
 		}
 		ent := entries[0]
@@ -554,7 +554,7 @@ func walkChildren(
 			fileChildren = saturatingAdd(fileChildren, childSize)
 		}
 		if readErr != nil && !errors.Is(readErr, io.EOF) {
-			callCtx.Errf("du: error reading directory '%s': %s\n", reportPath, callCtx.PortableErr(readErr))
+			callCtx.Errf("du: error reading directory '%s': %s\n", builtins.SafeOperand(reportPath), callCtx.PortableErr(readErr))
 			return fileChildren, subdirChildren, true
 		}
 	}

--- a/builtins/find/eval.go
+++ b/builtins/find/eval.go
@@ -148,7 +148,7 @@ func evalEmpty(ec *evalContext) bool {
 	if ec.info.IsDir() {
 		empty, err := ec.callCtx.IsDirEmpty(ec.ctx, ec.printPath)
 		if err != nil {
-			ec.callCtx.Errf("find: '%s': %s\n", ec.printPath, ec.callCtx.PortableErr(err))
+			ec.callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(ec.printPath), ec.callCtx.PortableErr(err))
 			ec.failed = true
 			return false
 		}
@@ -187,7 +187,7 @@ func evalNewer(ec *evalContext, refPath string) bool {
 				refInfo, err = ec.callCtx.LstatFile(ec.ctx, refPath)
 			}
 			if err != nil {
-				ec.callCtx.Errf("find: '%s': %s\n", refPath, ec.callCtx.PortableErr(err))
+				ec.callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(refPath), ec.callCtx.PortableErr(err))
 				ec.newerErrors[refPath] = true
 				return false
 			}
@@ -305,7 +305,7 @@ func evalExecLike(ec *evalContext, e *expr, name, replacement, dir string) evalR
 	}
 	cmd := strings.ReplaceAll(e.execCmd, "{}", replacement)
 	if ec.callCtx.CommandAllowed != nil && !ec.callCtx.CommandAllowed(cmd) {
-		ec.callCtx.Errf("find: %s: '%s': command not allowed\n", name, cmd)
+		ec.callCtx.Errf("find: %s: '%s': command not allowed\n", name, builtins.SafeOperand(cmd))
 		ec.failed = true
 		return evalResult{}
 	}
@@ -315,7 +315,7 @@ func evalExecLike(ec *evalContext, e *expr, name, replacement, dir string) evalR
 	}
 	exitCode, err := ec.callCtx.RunCommand(ec.ctx, dir, cmd, args)
 	if err != nil {
-		ec.callCtx.Errf("find: '%s': %s\n", cmd, err)
+		ec.callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(cmd), err)
 		ec.failed = true
 		return evalResult{}
 	}

--- a/builtins/find/expr.go
+++ b/builtins/find/expr.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/rshell/builtins"
 )
 
 // AST limits to prevent resource exhaustion.
@@ -164,7 +166,7 @@ func parseExpression(args []string) (parseResult, error) {
 		return parseResult{}, err
 	}
 	if p.pos < len(p.args) {
-		return parseResult{}, fmt.Errorf("find: unexpected argument '%s'", p.args[p.pos])
+		return parseResult{}, fmt.Errorf("find: unexpected argument '%s'", builtins.SafeOperand(p.args[p.pos]))
 	}
 	return parseResult{expr: e, maxDepth: p.maxDepth, minDepth: p.minDepth}, nil
 }
@@ -187,7 +189,7 @@ func (p *parser) expect(s string) error {
 		return fmt.Errorf("find: expected '%s'", s)
 	}
 	if p.args[p.pos] != s {
-		return fmt.Errorf("find: expected '%s', got '%s'", s, p.args[p.pos])
+		return fmt.Errorf("find: expected '%s', got '%s'", s, builtins.SafeOperand(p.args[p.pos]))
 	}
 	p.pos++
 	return nil
@@ -353,7 +355,7 @@ func (p *parser) parsePrimary() (*expr, error) {
 	case "-false":
 		return &expr{kind: exprFalse}, nil
 	default:
-		return nil, fmt.Errorf("find: unknown predicate '%s'", tok)
+		return nil, fmt.Errorf("find: unknown predicate '%s'", builtins.SafeOperand(tok))
 	}
 }
 
@@ -394,7 +396,7 @@ func (p *parser) parseTypePredicate() (*expr, error) {
 		if c == ',' {
 			if expectType {
 				// Leading or consecutive comma.
-				return nil, fmt.Errorf("find: Unknown argument to -type: %s", val)
+				return nil, fmt.Errorf("find: Unknown argument to -type: %s", builtins.SafeOperand(val))
 			}
 			expectType = true
 			continue
@@ -403,16 +405,16 @@ func (p *parser) parseTypePredicate() (*expr, error) {
 		case 'b', 'c', 'f', 'd', 'l', 'p', 's':
 			if !expectType {
 				// Adjacent type chars without comma (e.g. "fd").
-				return nil, fmt.Errorf("find: Unknown argument to -type: %s", val)
+				return nil, fmt.Errorf("find: Unknown argument to -type: %s", builtins.SafeOperand(val))
 			}
 			expectType = false
 		default:
-			return nil, fmt.Errorf("find: Unknown argument to -type: %s", val)
+			return nil, fmt.Errorf("find: Unknown argument to -type: %s", builtins.SafeOperand(val))
 		}
 	}
 	if expectType {
 		// Trailing comma.
-		return nil, fmt.Errorf("find: Unknown argument to -type: %s", val)
+		return nil, fmt.Errorf("find: Unknown argument to -type: %s", builtins.SafeOperand(val))
 	}
 	return &expr{kind: exprType, strVal: val}, nil
 }
@@ -454,7 +456,7 @@ func (p *parser) parseNumericPredicate(kind exprKind) (*expr, error) {
 			err = nil
 		}
 		if err != nil {
-			return nil, fmt.Errorf("find: invalid argument '%s' to %s", val, kind.String())
+			return nil, fmt.Errorf("find: invalid argument '%s' to %s", builtins.SafeOperand(val), kind.String())
 		}
 	}
 	return &expr{kind: kind, numVal: n, numCmp: cmp}, nil
@@ -472,11 +474,11 @@ func (p *parser) parseDepthOption(isMax bool) (*expr, error) {
 	// Reject non-decimal forms like "+1" or "-1" that strconv.Atoi accepts.
 	// GNU find requires a positive decimal integer.
 	if len(val) > 0 && (val[0] == '+' || val[0] == '-') {
-		return nil, fmt.Errorf("find: invalid argument '%s' to %s", val, name)
+		return nil, fmt.Errorf("find: invalid argument '%s' to %s", builtins.SafeOperand(val), name)
 	}
 	n, err := strconv.Atoi(val)
 	if err != nil || n < 0 {
-		return nil, fmt.Errorf("find: invalid argument '%s' to %s", val, name)
+		return nil, fmt.Errorf("find: invalid argument '%s' to %s", builtins.SafeOperand(val), name)
 	}
 	if isMax {
 		p.maxDepth = n
@@ -511,7 +513,7 @@ func (p *parser) parsePermPredicate() (*expr, error) {
 	}
 
 	if len(modeStr) == 0 {
-		return nil, fmt.Errorf("find: invalid mode '%s'", val)
+		return nil, fmt.Errorf("find: invalid mode '%s'", builtins.SafeOperand(val))
 	}
 
 	// Try octal parse first.
@@ -520,12 +522,12 @@ func (p *parser) parsePermPredicate() (*expr, error) {
 		// Try symbolic mode parse.
 		mode64, serr := parseSymbolicMode(modeStr)
 		if serr != nil {
-			return nil, fmt.Errorf("find: invalid mode '%s'", val)
+			return nil, fmt.Errorf("find: invalid mode '%s'", builtins.SafeOperand(val))
 		}
 		mode = mode64
 	}
 	if mode > 07777 {
-		return nil, fmt.Errorf("find: invalid mode '%s'", val)
+		return nil, fmt.Errorf("find: invalid mode '%s'", builtins.SafeOperand(val))
 	}
 
 	return &expr{kind: exprPerm, permVal: uint32(mode), permCmp: cmpMode}, nil
@@ -751,7 +753,7 @@ func parseSize(s string) (sizeUnit, error) {
 	}
 
 	if len(numStr) == 0 {
-		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", s)
+		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", builtins.SafeOperand(s))
 	}
 
 	// Check for unit suffix.
@@ -764,15 +766,15 @@ func parseSize(s string) (sizeUnit, error) {
 	}
 
 	if len(numStr) == 0 {
-		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", s)
+		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", builtins.SafeOperand(s))
 	}
 
 	n, err := strconv.ParseInt(numStr, 10, 64)
 	if err != nil {
-		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", s)
+		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", builtins.SafeOperand(s))
 	}
 	if n < 0 {
-		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", s)
+		return sizeUnit{}, fmt.Errorf("find: invalid argument '%s' to -size", builtins.SafeOperand(s))
 	}
 	su.n = n
 	return su, nil

--- a/builtins/find/find.go
+++ b/builtins/find/find.go
@@ -189,7 +189,7 @@ optLoop:
 			continue
 		}
 		if callCtx.CommandAllowed != nil && !callCtx.CommandAllowed(cmd) {
-			callCtx.Errf("find: '%s': command not allowed\n", cmd)
+			callCtx.Errf("find: '%s': command not allowed\n", builtins.SafeOperand(cmd))
 			return builtins.Result{Code: 1}
 		}
 	}
@@ -230,7 +230,7 @@ optLoop:
 					continue
 				}
 			}
-			callCtx.Errf("find: '%s': %s\n", ref, callCtx.PortableErr(err))
+			callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(ref), callCtx.PortableErr(err))
 			eagerNewerErrors[ref] = true
 			failed = true
 		}
@@ -384,7 +384,7 @@ func walkPath(
 		startInfo, err = callCtx.LstatFile(ctx, startPath)
 	}
 	if err != nil {
-		callCtx.Errf("find: '%s': %s\n", startPath, callCtx.PortableErr(err))
+		callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(startPath), callCtx.PortableErr(err))
 		return walkResult{failed: true}
 	}
 
@@ -414,7 +414,7 @@ func walkPath(
 					idOK = true
 					if firstPath, seen := ancestorIDs[id]; seen {
 						callCtx.Errf("find: File system loop detected; '%s' is part of the same file system loop as '%s'.\n",
-							path, firstPath)
+							builtins.SafeOperand(path), builtins.SafeOperand(firstPath))
 						failed = true
 						return true, nil, nil
 					}
@@ -427,7 +427,7 @@ func walkPath(
 			}
 			if !idOK {
 				if ancestorPaths[path] {
-					callCtx.Errf("find: File system loop detected; '%s' has already been visited.\n", path)
+					callCtx.Errf("find: File system loop detected; '%s' has already been visited.\n", builtins.SafeOperand(path))
 					failed = true
 					return true, nil, nil
 				}
@@ -506,7 +506,7 @@ func walkPath(
 	if !isLoop && !startPrune && startInfo.IsDir() && 0 < opts.maxDepth {
 		dir, openErr := callCtx.OpenDir(ctx, startPath)
 		if openErr != nil {
-			callCtx.Errf("find: '%s': %s\n", startPath, callCtx.PortableErr(openErr))
+			callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(startPath), callCtx.PortableErr(openErr))
 			return walkResult{failed: true}
 		}
 		iterStack = append(iterStack, &dirIterator{
@@ -534,7 +534,7 @@ func walkPath(
 		dirEntries, readErr := top.dir.ReadDir(1)
 		if readErr != nil {
 			if readErr != io.EOF {
-				callCtx.Errf("find: '%s': %s\n", top.parentPath, callCtx.PortableErr(readErr))
+				callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(top.parentPath), callCtx.PortableErr(readErr))
 				failed = true
 			}
 			top.done = true
@@ -555,14 +555,14 @@ func walkPath(
 				childInfo, err = callCtx.LstatFile(ctx, childPath)
 			}
 			if err != nil {
-				callCtx.Errf("find: '%s': %s\n", childPath, callCtx.PortableErr(err))
+				callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(childPath), callCtx.PortableErr(err))
 				failed = true
 				continue
 			}
 		} else {
 			childInfo, err = callCtx.LstatFile(ctx, childPath)
 			if err != nil {
-				callCtx.Errf("find: '%s': %s\n", childPath, callCtx.PortableErr(err))
+				callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(childPath), callCtx.PortableErr(err))
 				failed = true
 				continue
 			}
@@ -583,7 +583,7 @@ func walkPath(
 		if childInfo.IsDir() && !prune && top.depth < opts.maxDepth {
 			dir, openErr := callCtx.OpenDir(ctx, childPath)
 			if openErr != nil {
-				callCtx.Errf("find: '%s': %s\n", childPath, callCtx.PortableErr(openErr))
+				callCtx.Errf("find: '%s': %s\n", builtins.SafeOperand(childPath), callCtx.PortableErr(openErr))
 				failed = true
 				continue
 			}

--- a/builtins/free/free.go
+++ b/builtins/free/free.go
@@ -111,7 +111,7 @@ func makeFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if len(args) > 0 {
-			callCtx.Errf("free: extra operand '%s'\n", args[0])
+			callCtx.Errf("free: extra operand '%s'\n", builtins.SafeOperand(args[0]))
 			callCtx.Errf("Try 'free --help' for more information.\n")
 			return builtins.Result{Code: 1}
 		}

--- a/builtins/head/head.go
+++ b/builtins/head/head.go
@@ -131,11 +131,11 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// GNU's left-to-right rule. E.g. `head -c bad -n nope` reports
 		// the byte error; `head -n nope -c bad` reports the line one.
 		if reportLinesInvalidFirst(linesFlag, bytesFlag) {
-			callCtx.Errf("head: invalid number of lines: '%s'\n", linesFlag.invalid)
+			callCtx.Errf("head: invalid number of lines: '%s'\n", builtins.SafeOperand(linesFlag.invalid))
 			return builtins.Result{Code: 1}
 		}
 		if bytesFlag.hasInvalid {
-			callCtx.Errf("head: invalid number of bytes: '%s'\n", bytesFlag.invalid)
+			callCtx.Errf("head: invalid number of bytes: '%s'\n", builtins.SafeOperand(bytesFlag.invalid))
 			return builtins.Result{Code: 1}
 		}
 
@@ -167,7 +167,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// the linesFlag when neither was set, which always parses.
 		count, ok := parseCount(countStr)
 		if !ok {
-			callCtx.Errf("head: invalid number of %s: '%s'\n", modeLabel, countStr)
+			callCtx.Errf("head: invalid number of %s: '%s'\n", modeLabel, builtins.SafeOperand(countStr))
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/help/help.go
+++ b/builtins/help/help.go
@@ -70,12 +70,12 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 				return builtins.Result{}
 			}
 			if callCtx.CommandAllowed != nil && !callCtx.CommandAllowed(name) {
-				callCtx.Errf("help: no help topics match '%s'\n", name)
+				callCtx.Errf("help: no help topics match '%s'\n", builtins.SafeOperand(name))
 				return builtins.Result{Code: 1}
 			}
 			meta, ok := builtins.Meta(name)
 			if !ok {
-				callCtx.Errf("help: no help topics match '%s'\n", name)
+				callCtx.Errf("help: no help topics match '%s'\n", builtins.SafeOperand(name))
 				return builtins.Result{Code: 1}
 			}
 

--- a/builtins/ls/ls.go
+++ b/builtins/ls/ls.go
@@ -220,7 +220,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 			}
 			info, err := callCtx.LstatFile(ctx, p)
 			if err != nil {
-				callCtx.Errf("ls: cannot access '%s': %s\n", p, callCtx.PortableErr(err))
+				callCtx.Errf("ls: cannot access '%s': %s\n", builtins.SafeOperand(p), callCtx.PortableErr(err))
 				failed = true
 				continue
 			}
@@ -318,7 +318,7 @@ type pathArg struct {
 
 func listDir(ctx context.Context, callCtx *builtins.CallContext, dir string, opts *options, depth int, now time.Time) error {
 	if depth > maxRecursionDepth {
-		callCtx.Errf("ls: recursion depth limit exceeded at '%s'\n", dir)
+		callCtx.Errf("ls: recursion depth limit exceeded at '%s'\n", builtins.SafeOperand(dir))
 		return errFailed
 	}
 
@@ -353,7 +353,7 @@ func listDir(ctx context.Context, callCtx *builtins.CallContext, dir string, opt
 	}
 	entries, truncated, err := readDir(ctx, callCtx, dir, readOffset, effectiveLimit)
 	if err != nil {
-		callCtx.Errf("ls: cannot open directory '%s': %s\n", dir, callCtx.PortableErr(err))
+		callCtx.Errf("ls: cannot open directory '%s': %s\n", builtins.SafeOperand(dir), callCtx.PortableErr(err))
 		return err
 	}
 
@@ -382,7 +382,7 @@ func listDir(ctx context.Context, callCtx *builtins.CallContext, dir string, opt
 		}
 		info, infoErr := e.Info()
 		if infoErr != nil {
-			callCtx.Errf("ls: cannot access '%s': %s\n", joinPath(dir, name), callCtx.PortableErr(infoErr))
+			callCtx.Errf("ls: cannot access '%s': %s\n", builtins.SafeOperand(joinPath(dir, name)), callCtx.PortableErr(infoErr))
 			failed = true
 			continue
 		}
@@ -469,7 +469,7 @@ func listDir(ctx context.Context, callCtx *builtins.CallContext, dir string, opt
 	// allowing recursion after truncation would let an adversarial tree
 	// (e.g. 1000 subdirs × 1000 subdirs × ...) trigger unbounded traversal.
 	if truncated && !paginationActive {
-		callCtx.Errf("ls: warning: directory '%s': too many entries (exceeded %d limit), output truncated\n", dir, MaxDirEntries)
+		callCtx.Errf("ls: warning: directory '%s': too many entries (exceeded %d limit), output truncated\n", builtins.SafeOperand(dir), MaxDirEntries)
 		return errFailed
 	}
 

--- a/builtins/lsof/lsof.go
+++ b/builtins/lsof/lsof.go
@@ -158,7 +158,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if len(args) > 0 {
-			callCtx.Errf("lsof: extra operand '%s'\n", args[0])
+			callCtx.Errf("lsof: extra operand '%s'\n", builtins.SafeOperand(args[0]))
 			callCtx.Errf("Try 'lsof --help' for more information.\n")
 			return builtins.Result{Code: 1}
 		}

--- a/builtins/printf/printf.go
+++ b/builtins/printf/printf.go
@@ -531,7 +531,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
 				// Bash treats overflow as a warning, not an error: exit code stays 0.
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 			} else {
 				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
@@ -548,7 +548,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		val, err := parseUintArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 			} else {
 				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
@@ -564,7 +564,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		val, err := parseUintArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 			} else {
 				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
@@ -580,7 +580,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		val, err := parseUintArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 			} else {
 				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
@@ -596,7 +596,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		val, err := parseUintArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 			} else {
 				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
@@ -612,7 +612,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		fa, err := parseFloatArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 				goFmt.WriteByte('e')
 				callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
@@ -630,7 +630,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		fa, err := parseFloatArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 				goFmt.WriteByte('E')
 				callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
@@ -648,7 +648,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		fa, err := parseFloatArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 				goFmt.WriteByte('f')
 				callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
@@ -666,7 +666,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		fa, err := parseFloatArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 				goFmt.WriteByte('f')
 				callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
@@ -686,7 +686,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		fa, err := parseFloatArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 				goFmt.WriteByte('g')
 				callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
@@ -704,7 +704,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 		fa, err := parseFloatArg(arg)
 		if err != nil && arg != "" {
 			if isRangeErr(err) {
-				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
+				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", builtins.SafeOperand(arg))
 				goFmt.WriteByte('G')
 				callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false

--- a/builtins/printf/printf.go
+++ b/builtins/printf/printf.go
@@ -533,7 +533,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				// Bash treats overflow as a warning, not an error: exit code stays 0.
 				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
 			} else {
-				callCtx.Errf("printf: '%s': invalid number\n", arg)
+				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
 			// Bash uses the clamped/prefix value and sets exit code only for non-overflow.
 			goFmt.WriteByte('d')
@@ -550,7 +550,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 			if isRangeErr(err) {
 				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
 			} else {
-				callCtx.Errf("printf: '%s': invalid number\n", arg)
+				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
 			goFmt.WriteByte('o')
 			callCtx.Out(fmt.Sprintf(goFmt.String(), val))
@@ -566,7 +566,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 			if isRangeErr(err) {
 				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
 			} else {
-				callCtx.Errf("printf: '%s': invalid number\n", arg)
+				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
 			goFmt.WriteByte('d')
 			callCtx.Out(fmt.Sprintf(goFmt.String(), val))
@@ -582,7 +582,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 			if isRangeErr(err) {
 				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
 			} else {
-				callCtx.Errf("printf: '%s': invalid number\n", arg)
+				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
 			goFmt.WriteByte('x')
 			callCtx.Out(fmt.Sprintf(goFmt.String(), val))
@@ -598,7 +598,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 			if isRangeErr(err) {
 				callCtx.Errf("printf: warning: %s: Numerical result out of range\n", arg)
 			} else {
-				callCtx.Errf("printf: '%s': invalid number\n", arg)
+				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			}
 			goFmt.WriteByte('X')
 			callCtx.Out(fmt.Sprintf(goFmt.String(), val))
@@ -617,7 +617,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
 			}
-			callCtx.Errf("printf: '%s': invalid number\n", arg)
+			callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			goFmt.WriteByte('e')
 			callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 			return false, i, true
@@ -635,7 +635,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
 			}
-			callCtx.Errf("printf: '%s': invalid number\n", arg)
+			callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			goFmt.WriteByte('E')
 			callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 			return false, i, true
@@ -653,7 +653,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
 			}
-			callCtx.Errf("printf: '%s': invalid number\n", arg)
+			callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			goFmt.WriteByte('f')
 			callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 			return false, i, true
@@ -671,7 +671,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
 			}
-			callCtx.Errf("printf: '%s': invalid number\n", arg)
+			callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 		}
 		// Go doesn't have %F; use %f and fix Inf/NaN casing to match bash.
 		goFmt.WriteByte('f')
@@ -691,7 +691,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
 			}
-			callCtx.Errf("printf: '%s': invalid number\n", arg)
+			callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			goFmt.WriteByte('g')
 			callCtx.Out(bashFloat(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 			return false, i, true
@@ -709,7 +709,7 @@ func processSpecifier(callCtx *builtins.CallContext, s string, args []string, ar
 				callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 				return false, i, false
 			}
-			callCtx.Errf("printf: '%s': invalid number\n", arg)
+			callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(arg))
 			goFmt.WriteByte('G')
 			callCtx.Out(bashFloatUpper(fmt.Sprintf(goFmt.String(), fa.f), flagStr))
 			return false, i, true
@@ -774,11 +774,11 @@ func getIntArg(args []string, idx *int, callCtx *builtins.CallContext) (int, boo
 		if prefix := extractIntPrefix(s); prefix != "" {
 			pv, perr := strconv.ParseInt(prefix, 0, strconv.IntSize)
 			if perr == nil {
-				callCtx.Errf("printf: '%s': invalid number\n", s)
+				callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(s))
 				return int(pv), true
 			}
 		}
-		callCtx.Errf("printf: '%s': invalid number\n", s)
+		callCtx.Errf("printf: '%s': invalid number\n", builtins.SafeOperand(s))
 		return 0, true
 	}
 	return int(v), false

--- a/builtins/printf/printf_pentest_test.go
+++ b/builtins/printf/printf_pentest_test.go
@@ -58,6 +58,21 @@ func TestPentestIntHugeNumber(t *testing.T) {
 	assert.Contains(t, stderr, "Numerical result out of range")
 }
 
+// strconv.ParseInt detects overflow greedily while scanning the digit run,
+// so it returns ErrRange even when garbage follows the digits (e.g. a
+// crafted "<huge-digits>\nFORGED" operand). The range-warning branch must
+// escape the operand just like the invalid-number branch does, or the
+// embedded newline/ESC bytes would forge a diagnostic line / inject
+// terminal control sequences into stderr.
+func TestPentestIntOverflowEscapesInjectedControlBytes(t *testing.T) {
+	script := "printf \"%d\\n\" \"99999999999999999999\nFORGED\x1b[31m\""
+	_, stderr, code := cmdRun(t, script)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stderr, `99999999999999999999\nFORGED\x1b[31m`)
+	assert.NotContains(t, stderr, "99999999999999999999\nFORGED")
+	assert.NotContains(t, stderr, "\x1b[31m")
+}
+
 func TestPentestIntNegativeOne(t *testing.T) {
 	stdout, _, code := cmdRun(t, `printf "%d\n" -1`)
 	assert.Equal(t, 0, code)

--- a/builtins/rm/rm.go
+++ b/builtins/rm/rm.go
@@ -147,7 +147,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 func removeFile(ctx context.Context, callCtx *builtins.CallContext, path string, verbose bool) error {
 	info, err := callCtx.LstatFile(ctx, path)
 	if err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
-		callCtx.Errf("rm: cannot remove '%s': Is a directory\n", path)
+		callCtx.Errf("rm: cannot remove '%s': Is a directory\n", builtins.SafeOperand(path))
 		return errors.New("is a directory")
 	}
 	if hasTrailingDirSyntax(path) {
@@ -170,10 +170,10 @@ func removeFile(ctx context.Context, callCtx *builtins.CallContext, path string,
 		target, serr := callCtx.StatFile(ctx, path)
 		switch {
 		case serr == nil && target.IsDir():
-			callCtx.Errf("rm: cannot remove '%s': Is a directory\n", path)
+			callCtx.Errf("rm: cannot remove '%s': Is a directory\n", builtins.SafeOperand(path))
 			return errors.New("is a directory")
 		case serr == nil:
-			callCtx.Errf("rm: cannot remove '%s': Not a directory\n", path)
+			callCtx.Errf("rm: cannot remove '%s': Not a directory\n", builtins.SafeOperand(path))
 			return errors.New("not a directory")
 		default:
 			// StatFile failed for a reason unrelated to the target's type —
@@ -181,13 +181,13 @@ func removeFile(ctx context.Context, callCtx *builtins.CallContext, path string,
 			// symlink whose target escapes every configured AllowedPaths
 			// root (permission denied). Propagate the real error instead of
 			// misreporting it as "Not a directory".
-			callCtx.Errf("rm: cannot remove '%s': %s\n", path, callCtx.PortableErr(serr))
+			callCtx.Errf("rm: cannot remove '%s': %s\n", builtins.SafeOperand(path), callCtx.PortableErr(serr))
 			return serr
 		}
 	}
 
 	if err := callCtx.Remove(ctx, path); err != nil {
-		callCtx.Errf("rm: cannot remove '%s': %s\n", path, callCtx.PortableErr(err))
+		callCtx.Errf("rm: cannot remove '%s': %s\n", builtins.SafeOperand(path), callCtx.PortableErr(err))
 		return err
 	}
 

--- a/builtins/safe_operand_test.go
+++ b/builtins/safe_operand_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package builtins
+
+import "testing"
+
+func TestSafeOperand(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "foo.txt", "foo.txt"},
+		{"newline", "foo\nbar", `foo\nbar`},
+		{"carriage return", "foo\rbar", `foo\rbar`},
+		{"tab", "foo\tbar", `foo\tbar`},
+		{"esc ansi sequence", "foo\x1b[31mRED\x1b[0m", `foo\x1b[31mRED\x1b[0m`},
+		{"backslash", `foo\bar`, `foo\\bar`},
+		{"bell and other control bytes", "foo\x07\x00bar", `foo\x07\x00bar`},
+		{"unicode preserved", "café🎉", "café🎉"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SafeOperand(tt.in); got != tt.want {
+				t.Fatalf("SafeOperand(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafeOperandNeverEmitsRawControlBytes(t *testing.T) {
+	in := "line1\nline2\rline3\x1b[2Jline4"
+	got := SafeOperand(in)
+	for _, r := range got {
+		if r == '\n' || r == '\r' || r == 0x1b {
+			t.Fatalf("SafeOperand output still contains a raw control byte: %q", got)
+		}
+	}
+}

--- a/builtins/safe_operand_test.go
+++ b/builtins/safe_operand_test.go
@@ -22,6 +22,10 @@ func TestSafeOperand(t *testing.T) {
 		{"backslash", `foo\bar`, `foo\\bar`},
 		{"bell and other control bytes", "foo\x07\x00bar", `foo\x07\x00bar`},
 		{"unicode preserved", "café🎉", "café🎉"},
+		{"unicode line separator U+2028", "foo bar", `foo\u2028bar`},
+		{"unicode paragraph separator U+2029", "foo bar", `foo\u2029bar`},
+		{"unicode bidi override U+202E", "foo‮bar", `foo\u202ebar`},
+		{"unicode zero width space U+200B", "foo​bar", `foo\u200bbar`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -38,6 +42,16 @@ func TestSafeOperandNeverEmitsRawControlBytes(t *testing.T) {
 	for _, r := range got {
 		if r == '\n' || r == '\r' || r == 0x1b {
 			t.Fatalf("SafeOperand output still contains a raw control byte: %q", got)
+		}
+	}
+}
+
+func TestSafeOperandNeverEmitsRawSeparatorsOrFormatChars(t *testing.T) {
+	in := "line1 line2 line3‮line4"
+	got := SafeOperand(in)
+	for _, r := range got {
+		if r == ' ' || r == ' ' || r == '‮' {
+			t.Fatalf("SafeOperand output still contains a raw Unicode separator/format char: %q", got)
 		}
 	}
 }

--- a/builtins/sort/sort.go
+++ b/builtins/sort/sort.go
@@ -353,7 +353,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// GNU sort -c rejects multiple file operands.
 		if checkEnabled {
 			if len(files) > 1 {
-				callCtx.Errf("sort: extra operand %q not allowed with -c\n", files[1])
+				callCtx.Errf("sort: extra operand '%s' not allowed with -c\n", builtins.SafeOperand(files[1]))
 				return builtins.Result{Code: 2}
 			}
 			file := files[0]

--- a/builtins/tail/tail.go
+++ b/builtins/tail/tail.go
@@ -188,11 +188,11 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// appeared first in argv (smaller invalidPos), matching GNU's
 		// left-to-right rule.
 		if reportLinesInvalidFirst(linesFlag, bytesFlag) {
-			callCtx.Errf("tail: invalid number of lines: '%s'\n", linesFlag.invalid)
+			callCtx.Errf("tail: invalid number of lines: '%s'\n", builtins.SafeOperand(linesFlag.invalid))
 			return builtins.Result{Code: 1}
 		}
 		if bytesFlag.hasInvalid {
-			callCtx.Errf("tail: invalid number of bytes: '%s'\n", bytesFlag.invalid)
+			callCtx.Errf("tail: invalid number of bytes: '%s'\n", builtins.SafeOperand(bytesFlag.invalid))
 			return builtins.Result{Code: 1}
 		}
 
@@ -220,7 +220,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// which always parses.
 		cm, ok := parseCount(countStr)
 		if !ok {
-			callCtx.Errf("tail: invalid number of %s: '%s'\n", modeLabel, countStr)
+			callCtx.Errf("tail: invalid number of %s: '%s'\n", modeLabel, builtins.SafeOperand(countStr))
 			return builtins.Result{Code: 1}
 		}
 		// GNU tail uses sticky offset semantics: once any -n or -c flag uses

--- a/builtins/testcmd/testcmd.go
+++ b/builtins/testcmd/testcmd.go
@@ -505,7 +505,7 @@ func isUnaryFileOp(op string) bool {
 
 func (p *parser) consumeUnaryOperand(op string) (string, bool) {
 	if p.pos >= len(p.args) {
-		p.callCtx.Errf("%s: '%s': unary operator expected\n", p.cmdName, op)
+		p.callCtx.Errf("%s: '%s': unary operator expected\n", p.cmdName, builtins.SafeOperand(op))
 		p.err = true
 		return "", false
 	}
@@ -534,7 +534,7 @@ func (p *parser) parseBinaryExpr() bool {
 	left := p.advance()
 	op := p.advance()
 	if p.pos >= len(p.args) {
-		p.callCtx.Errf("%s: missing argument after '%s'\n", p.cmdName, op)
+		p.callCtx.Errf("%s: missing argument after '%s'\n", p.cmdName, builtins.SafeOperand(op))
 		p.err = true
 		return false
 	}
@@ -558,7 +558,7 @@ func (p *parser) parseBinaryExpr() bool {
 	case "-o":
 		return left != "" || right != ""
 	default:
-		p.callCtx.Errf("%s: unknown binary operator '%s'\n", p.cmdName, op)
+		p.callCtx.Errf("%s: unknown binary operator '%s'\n", p.cmdName, builtins.SafeOperand(op))
 		p.err = true
 		return false
 	}

--- a/builtins/tr/tr.go
+++ b/builtins/tr/tr.go
@@ -107,22 +107,22 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if *deleteFlag && *squeeze && len(operands) < 2 {
-			callCtx.Errf("tr: missing operand after '%s'\nTwo strings must be given when both deleting and squeezing repeats.\n", operands[0])
+			callCtx.Errf("tr: missing operand after '%s'\nTwo strings must be given when both deleting and squeezing repeats.\n", builtins.SafeOperand(operands[0]))
 			return builtins.Result{Code: 1}
 		}
 
 		if *deleteFlag && !*squeeze && len(operands) > 1 {
-			callCtx.Errf("tr: extra operand '%s'\nOnly one string may be given when deleting without squeezing repeats.\n", operands[1])
+			callCtx.Errf("tr: extra operand '%s'\nOnly one string may be given when deleting without squeezing repeats.\n", builtins.SafeOperand(operands[1]))
 			return builtins.Result{Code: 1}
 		}
 
 		if !*deleteFlag && len(operands) < 2 && !*squeeze {
-			callCtx.Errf("tr: missing operand after '%s'\n", operands[0])
+			callCtx.Errf("tr: missing operand after '%s'\n", builtins.SafeOperand(operands[0]))
 			return builtins.Result{Code: 1}
 		}
 
 		if len(operands) > 2 {
-			callCtx.Errf("tr: extra operand '%s'\n", operands[2])
+			callCtx.Errf("tr: extra operand '%s'\n", builtins.SafeOperand(operands[2]))
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/uname/uname.go
+++ b/builtins/uname/uname.go
@@ -91,7 +91,7 @@ func makeFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if len(args) > 0 {
-			callCtx.Errf("uname: extra operand '%s'\n", args[0])
+			callCtx.Errf("uname: extra operand '%s'\n", builtins.SafeOperand(args[0]))
 			callCtx.Errf("Try 'uname --help' for more information.\n")
 			return builtins.Result{Code: 1}
 		}

--- a/builtins/uniq/uniq.go
+++ b/builtins/uniq/uniq.go
@@ -210,7 +210,7 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		}
 
 		if len(args) > 1 {
-			callCtx.Errf("uniq: extra operand %q\n", args[1])
+			callCtx.Errf("uniq: extra operand '%s'\n", builtins.SafeOperand(args[1]))
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/uniq/uniq_test.go
+++ b/builtins/uniq/uniq_test.go
@@ -536,6 +536,21 @@ func TestUniqExtraOperand(t *testing.T) {
 	assert.Contains(t, stderr, "extra operand")
 }
 
+// TestUniqExtraOperandEscapesControlBytes verifies that a crafted extra
+// operand containing a newline and an ANSI escape sequence cannot forge
+// additional stderr lines or inject terminal control sequences — the
+// dangerous bytes must come through escaped, not raw.
+func TestUniqExtraOperandEscapesControlBytes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "a\n")
+	script := "uniq a.txt \"evil\nrshell: forged line\x1b[31m\"\n"
+	_, stderr, code := cmdRun(t, script, dir)
+	assert.Equal(t, 1, code)
+	assert.NotContains(t, stderr, "evil\nrshell: forged line")
+	assert.NotContains(t, stderr, "\x1b[31m")
+	assert.Contains(t, stderr, `evil\nrshell: forged line\x1b[31m`)
+}
+
 func TestUniqInvalidAllRepeatedMethod(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "in.txt", "a\n")

--- a/builtins/uptime/uptime.go
+++ b/builtins/uptime/uptime.go
@@ -74,7 +74,7 @@ func makeFlags(fs *builtins.FlagSet, getInfo func() (sysinfo.Info, error)) built
 		}
 
 		if len(args) > 0 {
-			callCtx.Errf("uptime: extra operand '%s'\n", args[0])
+			callCtx.Errf("uptime: extra operand '%s'\n", builtins.SafeOperand(args[0]))
 			callCtx.Errf("Try 'uptime --help' for more information.\n")
 			return builtins.Result{Code: 1}
 		}

--- a/builtins/vmstat/vmstat.go
+++ b/builtins/vmstat/vmstat.go
@@ -173,7 +173,7 @@ func unitDivisor(s string) (int64, error) {
 	case "M":
 		return 1_048_576, nil
 	default:
-		return 0, fmt.Errorf("invalid unit '%s' (expected k, K, m, or M)", s)
+		return 0, fmt.Errorf("invalid unit '%s' (expected k, K, m, or M)", builtins.SafeOperand(s))
 	}
 }
 
@@ -191,7 +191,7 @@ func parseSamplingArgs(args []string) (delay time.Duration, count int, err error
 		return 0, 0, errors.New("count is required when delay is specified")
 	}
 	if len(args) > 2 {
-		return 0, 0, fmt.Errorf("extra operand '%s'", args[2])
+		return 0, 0, fmt.Errorf("extra operand '%s'", builtins.SafeOperand(args[2]))
 	}
 	d, err := parsePositiveUint32(args[0], "delay")
 	if err != nil {
@@ -199,7 +199,7 @@ func parseSamplingArgs(args []string) (delay time.Duration, count int, err error
 	}
 	c, err := parsePositiveUint32(args[1], "count")
 	if err != nil {
-		return 0, 0, fmt.Errorf("invalid count '%s'", args[1])
+		return 0, 0, fmt.Errorf("invalid count '%s'", builtins.SafeOperand(args[1]))
 	}
 	intervals := c - 1
 	maxSeconds := uint64(maxSamplingDuration / time.Second)
@@ -211,7 +211,7 @@ func parseSamplingArgs(args []string) (delay time.Duration, count int, err error
 	// platform int width; math.MaxInt32 is a fixed, platform-independent
 	// upper bound that is always safely representable as an int.
 	if c > uint64(math.MaxInt32) {
-		return 0, 0, fmt.Errorf("invalid count '%s'", args[1])
+		return 0, 0, fmt.Errorf("invalid count '%s'", builtins.SafeOperand(args[1]))
 	}
 	count = int(c)
 	return time.Duration(d) * time.Second, count, nil
@@ -219,7 +219,7 @@ func parseSamplingArgs(args []string) (delay time.Duration, count int, err error
 
 func validateStatsArgs(args []string) error {
 	if len(args) > 2 {
-		return fmt.Errorf("extra operand '%s'", args[2])
+		return fmt.Errorf("extra operand '%s'", builtins.SafeOperand(args[2]))
 	}
 	if len(args) > 0 {
 		if _, err := parsePositiveUint32(args[0], "delay"); err != nil {
@@ -229,7 +229,7 @@ func validateStatsArgs(args []string) error {
 	if len(args) == 2 {
 		c, err := parsePositiveUint32(args[1], "count")
 		if err != nil || c > uint64(math.MaxInt32) {
-			return fmt.Errorf("invalid count '%s'", args[1])
+			return fmt.Errorf("invalid count '%s'", builtins.SafeOperand(args[1]))
 		}
 	}
 	return nil
@@ -238,7 +238,7 @@ func validateStatsArgs(args []string) error {
 func parsePositiveUint32(arg, name string) (uint64, error) {
 	v, err := strconv.ParseUint(arg, 10, 32)
 	if err != nil || v == 0 {
-		return 0, fmt.Errorf("invalid %s '%s'", name, arg)
+		return 0, fmt.Errorf("invalid %s '%s'", name, builtins.SafeOperand(arg))
 	}
 	return v, nil
 }


### PR DESCRIPTION
## Summary
- Add `builtins.SafeOperand`, a minimal control-byte escaper (newlines, tabs, ESC, other control bytes, backslash) modeled on GNU coreutils' `quotearg` "literal" tier, preserving the repo's single-quote error wording convention.
- Route every builtin error site that interpolates a raw user-supplied string (operand, filename, flag value) into a single-quoted stderr message through `SafeOperand`, across `df`, `free`, `lsof`, `uname`, `uptime`, `tr`, `vmstat`, `uniq`, `sort`, `testcmd`, `printf`, `tail`, `head`, `help`, `du`, `find` (`find.go`/`eval.go`/`expr.go`), `rm`, and `ls`.

Without this fix, a crafted operand containing a newline or ANSI escape sequence would be copied verbatim into stderr, letting a script forge fake diagnostic lines or inject terminal/log control sequences — risky since rshell's stderr may be consumed or logged verbatim by an automated agent.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit tests for `SafeOperand` (`builtins/safe_operand_test.go`)
- [x] New regression tests proving newline/ANSI bytes in an operand are escaped rather than passed through raw, for `uniq` and `df`
- [x] `make fmt`
- [ ] `RSHELL_BASH_TEST=1 go test ./tests/ -run TestShellScenariosAgainstBash` — fails in this environment on a clean checkout too (`bash: /work/runner.sh: No such file or directory`), confirmed pre-existing/unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)