### PR TITLE
feat(interp): tag command spans with the flags used

### DIFF
--- a/analysis/symbols_interp.go
+++ b/analysis/symbols_interp.go
@@ -68,6 +68,7 @@ var interpAllowedSymbols = []string{
 	"strings.ContainsRune",        // 🟢 checks if a rune is in a string; pure function, no I/O.
 	"strings.NewReader",           // 🟢 wraps a string as an io.Reader; pure function, no I/O; used by ParseScript.
 	"strings.Index",               // 🟢 finds substring index; pure function, no I/O.
+	"strings.IndexByte",           // 🟢 finds byte in string; pure function, no I/O.
 	"strings.HasPrefix",           // 🟢 pure function for prefix matching; no I/O.
 	"strings.HasSuffix",           // 🟢 pure function for suffix matching; no I/O.
 	"strings.Join",                // 🟢 joins string slices; pure function, no I/O.
@@ -221,6 +222,7 @@ var interpPerModeSymbols = map[string][]string{
 		"strings.ContainsRune",        // 🟢 checks if a rune is in a string; pure function, no I/O.
 		"strings.NewReader",           // 🟢 wraps a string as an io.Reader; pure function, no I/O; used by ParseScript.
 		"strings.Index",               // 🟢 finds substring index; pure function, no I/O.
+		"strings.IndexByte",           // 🟢 finds byte in string; pure function, no I/O.
 		"strings.HasPrefix",           // 🟢 pure function for prefix matching; no I/O.
 		"strings.HasSuffix",           // 🟢 pure function for suffix matching; no I/O.
 		"strings.Join",                // 🟢 joins string slices; pure function, no I/O.

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -536,10 +536,22 @@ func (r *Runner) loopStmtsBroken(ctx context.Context, stmts []*syntax.Stmt) bool
 
 // commandFlags extracts the flag tokens (arguments beginning with "-") from
 // a command's arguments, for use as span telemetry. Only the flag name is
-// kept — a glued long-form value ("--file=x") is truncated at "=" so that
-// arbitrary argument values are never captured, just which flags were used.
-// Scanning stops at a literal "--" end-of-flags separator, and the lone "-"
-// token (conventionally stdin/stdout, not a flag) is skipped.
+// kept, never a value:
+//   - A value passed as a separate argument ("-r secret", "--file secret")
+//     is never captured, since it doesn't itself start with "-".
+//   - A value glued to a long flag with "=" ("--file=secret") is truncated
+//     at "=".
+//   - A value glued directly to a short flag with no separator at all
+//     ("-nsecret", "-n5") has no delimiter to strip, so the token is
+//     truncated to just the flag letter ("-n"). This also means a combined
+//     boolean cluster like "-la" is recorded as only its first flag ("-l"),
+//     since it's indistinguishable from a short flag plus a glued value at
+//     this generic, per-builtin-schema-unaware layer — completeness of the
+//     flag list is sacrificed to guarantee no value ever leaks.
+//
+// Scanning stops at a literal "--" end-of-flags separator, so nothing after
+// it (even if flag-shaped) is captured. The lone "-" token (conventionally
+// stdin/stdout, not a flag) is skipped.
 func commandFlags(args []string) []string {
 	var flags []string
 	for _, arg := range args {
@@ -551,6 +563,9 @@ func commandFlags(args []string) []string {
 		}
 		if eq := strings.IndexByte(arg, '='); eq >= 0 {
 			arg = arg[:eq]
+		}
+		if !strings.HasPrefix(arg, "--") && len(arg) > 2 {
+			arg = arg[:2]
 		}
 		flags = append(flags, arg)
 	}

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -594,7 +594,10 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	span.SetTag("rshell.command.has_stdin_pipe", r.stdin != r.runStdin)
 	span.SetTag("rshell.command.has_output_redirect", r.stdout != r.runStdout)
 	if flags := commandFlags(args[1:]); len(flags) > 0 {
-		span.SetTag("rshell.command.flags", strings.Join(flags, ","))
+		// Padded with a leading and trailing comma so a query for one exact
+		// flag (e.g. `*,-n,*`) can't false-positive match a longer flag that
+		// merely contains the same substring (e.g. "-name").
+		span.SetTag("rshell.command.flags", ","+strings.Join(flags, ",")+",")
 	}
 	defer func() {
 		span.SetTag("rshell.command.exit_code", int(r.exit.code))

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -13,6 +13,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"mvdan.cc/sh/v3/expand"
@@ -533,6 +534,29 @@ func (r *Runner) loopStmtsBroken(ctx context.Context, stmts []*syntax.Stmt) bool
 	return false
 }
 
+// commandFlags extracts the flag tokens (arguments beginning with "-") from
+// a command's arguments, for use as span telemetry. Only the flag name is
+// kept — a glued long-form value ("--file=x") is truncated at "=" so that
+// arbitrary argument values are never captured, just which flags were used.
+// Scanning stops at a literal "--" end-of-flags separator, and the lone "-"
+// token (conventionally stdin/stdout, not a flag) is skipped.
+func commandFlags(args []string) []string {
+	var flags []string
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if len(arg) < 2 || arg[0] != '-' {
+			continue
+		}
+		if eq := strings.IndexByte(arg, '='); eq >= 0 {
+			arg = arg[:eq]
+		}
+		flags = append(flags, arg)
+	}
+	return flags
+}
+
 func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	name := args[0]
 	r.totalCount++
@@ -554,6 +578,9 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	// both pipeline stages and file redirects.
 	span.SetTag("rshell.command.has_stdin_pipe", r.stdin != r.runStdin)
 	span.SetTag("rshell.command.has_output_redirect", r.stdout != r.runStdout)
+	if flags := commandFlags(args[1:]); len(flags) > 0 {
+		span.SetTag("rshell.command.flags", strings.Join(flags, ","))
+	}
 	defer func() {
 		span.SetTag("rshell.command.exit_code", int(r.exit.code))
 		span.Finish(nil)

--- a/interp/tracing_test.go
+++ b/interp/tracing_test.go
@@ -362,6 +362,46 @@ func TestCommandSpanArgc(t *testing.T) {
 	assert.Equal(t, float64(3), cmd.Metrics["rshell.command.argc"])
 }
 
+// TestCommandSpanFlags verifies that flag-shaped arguments are captured on
+// the span as a comma-joined list, with glued long-form values stripped and
+// positional (non-flag) arguments excluded.
+func TestCommandSpanFlags(t *testing.T) {
+	tel, ct := newCapturingTelemetry(t)
+
+	r, err := New(allowAllCommandsOpt(), StdIO(nil, io.Discard, io.Discard))
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	traceID := newTestTraceID()
+	require.NoError(t, runWithTracedContext(t, r, traceID, "echo -n --file=secret.txt arg1"))
+	tel.Stop()
+
+	spans := ct.spansForTrace(t, traceID)
+	cmd := findSpanByCommand(spans, "echo")
+	require.NotNil(t, cmd)
+	assert.Equal(t, "-n,--file", cmd.Meta["rshell.command.flags"])
+}
+
+// TestCommandSpanFlagsNone verifies that the flags tag is omitted entirely
+// when no arguments look like flags.
+func TestCommandSpanFlagsNone(t *testing.T) {
+	tel, ct := newCapturingTelemetry(t)
+
+	r, err := New(allowAllCommandsOpt(), StdIO(nil, io.Discard, io.Discard))
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	traceID := newTestTraceID()
+	require.NoError(t, runWithTracedContext(t, r, traceID, "echo a b c"))
+	tel.Stop()
+
+	spans := ct.spansForTrace(t, traceID)
+	cmd := findSpanByCommand(spans, "echo")
+	require.NotNil(t, cmd)
+	_, ok := cmd.Meta["rshell.command.flags"]
+	assert.False(t, ok)
+}
+
 // TestCommandSpanDisallowed verifies that a command blocked by AllowedCommands
 // is captured with is_allowed=false and exit_code=127, and that the is_known
 // tag is still populated regardless of the short-circuit.

--- a/interp/tracing_test.go
+++ b/interp/tracing_test.go
@@ -363,8 +363,10 @@ func TestCommandSpanArgc(t *testing.T) {
 }
 
 // TestCommandSpanFlags verifies that flag-shaped arguments are captured on
-// the span as a comma-joined list, with glued long-form values stripped and
-// positional (non-flag) arguments excluded.
+// the span as a leading/trailing-comma-padded list, with glued long-form
+// values stripped and positional (non-flag) arguments excluded. The padding
+// lets a dashboard query for one exact flag (e.g. "*,-n,*") match without
+// false-positiving on a longer flag containing the same substring.
 func TestCommandSpanFlags(t *testing.T) {
 	tel, ct := newCapturingTelemetry(t)
 
@@ -379,7 +381,7 @@ func TestCommandSpanFlags(t *testing.T) {
 	spans := ct.spansForTrace(t, traceID)
 	cmd := findSpanByCommand(spans, "echo")
 	require.NotNil(t, cmd)
-	assert.Equal(t, "-n,--file", cmd.Meta["rshell.command.flags"])
+	assert.Equal(t, ",-n,--file,", cmd.Meta["rshell.command.flags"])
 }
 
 // TestCommandSpanFlagsNone verifies that the flags tag is omitted entirely
@@ -400,6 +402,30 @@ func TestCommandSpanFlagsNone(t *testing.T) {
 	require.NotNil(t, cmd)
 	_, ok := cmd.Meta["rshell.command.flags"]
 	assert.False(t, ok)
+}
+
+// TestCommandSpanFlagsPaddingAvoidsSubstringCollision verifies that a
+// dashboard-style wildcard query anchored on both sides ("*,-n,*") matches
+// a call carrying "-n" but not a call carrying only a longer flag that
+// happens to contain "-n" as a substring, thanks to the leading/trailing
+// comma padding.
+func TestCommandSpanFlagsPaddingAvoidsSubstringCollision(t *testing.T) {
+	tel, ct := newCapturingTelemetry(t)
+
+	r, err := New(allowAllCommandsOpt(), StdIO(nil, io.Discard, io.Discard))
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close() })
+
+	traceID := newTestTraceID()
+	require.NoError(t, runWithTracedContext(t, r, traceID, "echo --filename x"))
+	tel.Stop()
+
+	spans := ct.spansForTrace(t, traceID)
+	cmd := findSpanByCommand(spans, "echo")
+	require.NotNil(t, cmd)
+	flags := cmd.Meta["rshell.command.flags"]
+	assert.Equal(t, ",--filename,", flags)
+	assert.NotContains(t, flags, ",-n,", "a bare -n query must not match a call that only used --filename")
 }
 
 // TestCommandFlagsNoValueLeak is a table-driven test over commandFlags

--- a/interp/tracing_test.go
+++ b/interp/tracing_test.go
@@ -402,6 +402,57 @@ func TestCommandSpanFlagsNone(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestCommandFlagsNoValueLeak is a table-driven test over commandFlags
+// directly (rather than through a full span) covering every way a flag's
+// value can be attached to it, to make sure the value itself is never
+// captured — only the flag name.
+func TestCommandFlagsNoValueLeak(t *testing.T) {
+	const secret = "s3cr3t"
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		// 1. Short flag, boolean-style, no value at all.
+		{"short flag alone", []string{"-r"}, []string{"-r"}},
+		// 1. Short flag with its value as a separate, space-delimited arg.
+		{"short flag with space value", []string{"-r", secret}, []string{"-r"}},
+		// 1. Short flag with its value glued on via "=".
+		{"short flag with equals value", []string{"-r=" + secret}, []string{"-r"}},
+		// 3. Short flag with its value glued on directly, no separator —
+		// the value has no delimiter to strip at, so only the flag letter
+		// is kept.
+		{"short flag with glued value", []string{"-r" + secret}, []string{"-r"}},
+		// 3. Combined short boolean cluster: indistinguishable from a
+		// glued value, so only the first flag letter is recorded.
+		{"combined short flags", []string{"-la"}, []string{"-l"}},
+		// 2. Long flag, boolean-style, no value at all.
+		{"long flag alone", []string{"--dry-run"}, []string{"--dry-run"}},
+		// 2. Long flag with its value as a separate, space-delimited arg.
+		{"long flag with space value", []string{"--dry-run", secret}, []string{"--dry-run"}},
+		// 2. Long flag with its value glued on via "=".
+		{"long flag with equals value", []string{"--dry-run=" + secret}, []string{"--dry-run"}},
+		// 3. "--" ends flag parsing; nothing after it is captured even if
+		// flag-shaped, so a positional value can't be smuggled through.
+		{"end of options terminator", []string{"--", "-r", secret}, nil},
+		// Lone "-" is a conventional stdin/stdout marker, not a flag.
+		{"lone dash", []string{"-"}, nil},
+		// Positional (non-flag) arguments are never captured.
+		{"positional args only", []string{"a", "b"}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := commandFlags(tt.args)
+			assert.Equal(t, tt.want, got)
+			for _, f := range got {
+				assert.NotContains(t, f, secret, "captured flag must never contain the flag's value")
+			}
+		})
+	}
+}
+
 // TestCommandSpanDisallowed verifies that a command blocked by AllowedCommands
 // is captured with is_allowed=false and exit_code=127, and that the is_known
 // tag is still populated regardless of the short-circuit.


### PR DESCRIPTION
## Summary
- Adds `rshell.command.flags` to the per-command tracer span in `interp/runner_exec.go`, a comma-joined list of flag tokens (e.g. `-n,--file`) seen in a builtin's arguments.
- Glued long-form values are stripped (`--file=secret.txt` → `--file`) so arbitrary argument values are never captured, only which flags were used. Scanning stops at `--`, and the lone `-` token is skipped.
- Tag is omitted entirely when no flag-shaped arguments are present.

## Example trace
https://app.datadoghq.com/apm/trace/138582038175341300?graphType=flamegraph&shouldShowLegend=true&spanID=16694918114362333452&timeHint=1785920825252&trace=AQAAAZ_RLSekL8sYvAAAAAAxNjg3MTQ4NTM0NDYyODU0NTcyNA&traceQuery=

## Test plan
- [x] `go test ./interp/...` passes, including new `TestCommandSpanFlags` / `TestCommandSpanFlagsNone`
- [x] `make fmt` / `gofmt -l .` clean