### PR TITLE
fix(allowedpaths): normalize ENXIO on write opens to "not a regular file"

### DIFF
--- a/allowedpaths/internal/writeopen/errors.go
+++ b/allowedpaths/internal/writeopen/errors.go
@@ -12,6 +12,18 @@ import "errors"
 // resolution and open.
 var ErrSymlinkWriteTarget = errors.New("symlinks are not supported as write targets")
 
+// ErrNotRegularFile reports that a write target is not a regular file.
+//
+// It is returned both by the post-open fstat guard and by the open itself
+// when the kernel refuses the open with ENXIO. ENXIO is not exclusively
+// "FIFO opened O_WRONLY|O_NONBLOCK with no reader attached" — some device
+// nodes report it too — but every ENXIO case here describes a non-regular
+// target, which is the only thing rshell's write paths accept. Normalizing
+// it keeps the message identical regardless of whether a reader happened to
+// be attached at open time, and avoids leaking the raw platform errno text
+// ("device not configured" on macOS, "no such device or address" on Linux).
+var ErrNotRegularFile = errors.New("not a regular file")
+
 // ErrIsDirectory reports that Unlink's target is a directory.
 var ErrIsDirectory = errors.New("is a directory")
 

--- a/allowedpaths/internal/writeopen/writeopen_unix.go
+++ b/allowedpaths/internal/writeopen/writeopen_unix.go
@@ -82,8 +82,16 @@ func OpenFile(rootFile *os.File, _ *os.Root, relPath string, flag int, perm os.F
 }
 
 func writePathError(relPath string, err error) error {
-	if errors.Is(err, unix.ELOOP) {
+	switch {
+	case errors.Is(err, unix.ELOOP):
 		err = ErrSymlinkWriteTarget
+	case errors.Is(err, unix.ENXIO):
+		// See ErrNotRegularFile: ENXIO on a write open always means the
+		// target is not a regular file (readerless FIFO, or a device node
+		// with no backing device). Remapping it keeps the message stable
+		// and platform-independent. os.ErrNotExist is deliberately left
+		// untouched — truncate -c relies on errors.Is against it.
+		err = ErrNotRegularFile
 	}
 	return &os.PathError{Op: "openat", Path: relPath, Err: err}
 }

--- a/allowedpaths/portable.go
+++ b/allowedpaths/portable.go
@@ -23,6 +23,8 @@ func PortableErrMsg(err error) string {
 	switch {
 	case errors.Is(err, writeopen.ErrSymlinkWriteTarget):
 		return writeopen.ErrSymlinkWriteTarget.Error()
+	case errors.Is(err, writeopen.ErrNotRegularFile):
+		return writeopen.ErrNotRegularFile.Error()
 	case errors.Is(err, fs.ErrNotExist):
 		return "no such file or directory"
 	case errors.Is(err, fs.ErrPermission):

--- a/allowedpaths/sandbox.go
+++ b/allowedpaths/sandbox.go
@@ -609,8 +609,15 @@ func (s *Sandbox) Truncate(path string, cwd string, size int64, create bool) err
 	// mode & ~umask). This matches GNU truncate and bash >FILE behaviour.
 	f, err := ar.openWriteFile(relPath, flag, 0666)
 	if err != nil {
-		// Return the raw error so callers can use errors.Is against
-		// fs.ErrNotExist / fs.ErrPermission. Wrapping would hide
+		// A non-regular target (readerless FIFO, device node) fails at open
+		// rather than at the fstat guard below. Rewrap it as the same
+		// caller-facing error the guard produces so the message does not
+		// depend on whether a reader happened to be attached.
+		if errors.Is(err, writeopen.ErrNotRegularFile) {
+			return &os.PathError{Op: "truncate", Path: path, Err: writeopen.ErrNotRegularFile}
+		}
+		// Otherwise return the raw error so callers can use errors.Is
+		// against fs.ErrNotExist / fs.ErrPermission. Wrapping would hide
 		// os.ErrNotExist behind a fresh errors.New value, breaking the
 		// truncate -c silent-skip path.
 		return err
@@ -624,7 +631,7 @@ func (s *Sandbox) Truncate(path string, cwd string, size int64, create bool) err
 	}
 	if !info.Mode().IsRegular() {
 		f.Close()
-		return &os.PathError{Op: "truncate", Path: path, Err: errors.New("not a regular file")}
+		return &os.PathError{Op: "truncate", Path: path, Err: writeopen.ErrNotRegularFile}
 	}
 	truncErr := f.Truncate(size)
 	// Surface a deferred Close error only when Truncate itself succeeded;
@@ -669,6 +676,12 @@ func (s *Sandbox) TruncateToZeroIfAtLeast(path string, cwd string, minSize int64
 	flag := os.O_WRONLY | syscall.O_NONBLOCK
 	f, err := ar.openWriteFile(relPath, flag, 0)
 	if err != nil {
+		// Same normalization as Truncate: a non-regular target can fail at
+		// open (ENXIO) or at the fstat guard below depending on whether a
+		// reader is attached; both must report the same error.
+		if errors.Is(err, writeopen.ErrNotRegularFile) {
+			return 0, false, &os.PathError{Op: "truncate", Path: path, Err: writeopen.ErrNotRegularFile}
+		}
 		return 0, false, err
 	}
 	info, err := f.Stat()
@@ -678,7 +691,7 @@ func (s *Sandbox) TruncateToZeroIfAtLeast(path string, cwd string, minSize int64
 	}
 	if !info.Mode().IsRegular() {
 		f.Close()
-		return 0, false, &os.PathError{Op: "truncate", Path: path, Err: errors.New("not a regular file")}
+		return 0, false, &os.PathError{Op: "truncate", Path: path, Err: writeopen.ErrNotRegularFile}
 	}
 
 	sizeBefore := info.Size()

--- a/interp/builtin_truncate_fifo_pentest_test.go
+++ b/interp/builtin_truncate_fifo_pentest_test.go
@@ -8,6 +8,7 @@
 package interp_test
 
 import (
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -18,6 +19,10 @@ import (
 	"github.com/DataDog/rshell/interp"
 )
 
+// fifoTruncateError is the single, platform-independent message truncate must
+// print for a FIFO write target, whether or not a reader is attached.
+const fifoTruncateError = "truncate: \"pipe\": not a regular file\n"
+
 // TestTruncatePentestFIFOTarget verifies the O_NONBLOCK+fstat guard that
 // protects against a FIFO-swap attack:
 //
@@ -27,7 +32,9 @@ import (
 //     fstat-on-fd check would reject the non-regular file before ftruncate runs.
 //
 // This test exercises case 1: a FIFO with no reader returns an error, not a
-// hang, and leaves the named pipe untouched.
+// hang, and leaves the named pipe untouched. The message is asserted exactly:
+// the raw ENXIO errno text is platform-specific ("device not configured" on
+// macOS, "no such device or address" on Linux) and must never reach the user.
 func TestTruncatePentestFIFOTarget(t *testing.T) {
 	dir := t.TempDir()
 	fifoPath := filepath.Join(dir, "pipe")
@@ -36,9 +43,72 @@ func TestTruncatePentestFIFOTarget(t *testing.T) {
 	// No goroutine opens the read end — so O_WRONLY|O_NONBLOCK must fail
 	// immediately with ENXIO rather than blocking.
 	_, stderr, code := runScript(t, "truncate -s 0 pipe", dir,
-		interp.AllowedPaths([]string{dir}),
+		interp.AllowedPaths([]string{dir + ":rw"}),
 		interp.WithMode(interp.ModeRemediation),
 	)
 	assert.Equal(t, 1, code, "truncate on a FIFO with no reader must fail")
-	assert.Contains(t, stderr, "pipe", "error must reference the target path")
+	assert.Equal(t, fifoTruncateError, stderr)
+}
+
+// TestTruncatePentestFIFOTargetWithReader exercises case 2 above: a reader is
+// attached, so open(2) succeeds and the post-open fstat guard is what rejects
+// the target. The user-visible message must be byte-identical to the
+// no-reader case — otherwise the same command against the same path would
+// produce different output depending on an unrelated process, violating the
+// determinism requirement in docs/RULES.md.
+func TestTruncatePentestFIFOTargetWithReader(t *testing.T) {
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "pipe")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0600))
+
+	// Open the read end with O_RDONLY|O_NONBLOCK: on a FIFO this returns
+	// immediately (POSIX guarantees a non-blocking read-end open never waits
+	// for a writer), so there is no goroutine to tear down and the test
+	// cannot hang. Holding the fd for the duration of the run guarantees the
+	// writer-side open below succeeds instead of failing with ENXIO.
+	reader, err := os.OpenFile(fifoPath, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reader.Close() })
+
+	_, stderr, code := runScript(t, "truncate -s 0 pipe", dir,
+		interp.AllowedPaths([]string{dir + ":rw"}),
+		interp.WithMode(interp.ModeRemediation),
+	)
+	assert.Equal(t, 1, code, "truncate on a FIFO with a reader must fail")
+	assert.Equal(t, fifoTruncateError, stderr,
+		"the message must not depend on whether a reader is attached")
+}
+
+// TestLogrotatePentestFIFOTarget and its reader-attached twin pin the same
+// determinism property for logrotate, which shares Sandbox's
+// TruncateToZeroIfAtLeast write-open path.
+func TestLogrotatePentestFIFOTarget(t *testing.T) {
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "pipe")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0600))
+
+	_, stderr, code := runScript(t, "logrotate --force pipe", dir,
+		interp.AllowedPaths([]string{dir + ":rw"}),
+		interp.WithMode(interp.ModeRemediation),
+	)
+	assert.Equal(t, 1, code, "logrotate on a FIFO with no reader must fail")
+	assert.Equal(t, "logrotate: \"pipe\": not a regular file\n", stderr)
+}
+
+func TestLogrotatePentestFIFOTargetWithReader(t *testing.T) {
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "pipe")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0600))
+
+	reader, err := os.OpenFile(fifoPath, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reader.Close() })
+
+	_, stderr, code := runScript(t, "logrotate --force pipe", dir,
+		interp.AllowedPaths([]string{dir + ":rw"}),
+		interp.WithMode(interp.ModeRemediation),
+	)
+	assert.Equal(t, 1, code, "logrotate on a FIFO with a reader must fail")
+	assert.Equal(t, "logrotate: \"pipe\": not a regular file\n", stderr,
+		"the message must not depend on whether a reader is attached")
 }


### PR DESCRIPTION
A FIFO (or device node) write target made `truncate` / `logrotate` emit a raw, non-portable errno that also changed depending on whether a reader happened to be attached:

```
# no reader
truncate: "/tmp/rsh/fifo": openat fifo: device not configured   # macOS ENXIO; Linux says "no such device or address"
# reader attached
truncate: "/tmp/rsh/fifo": truncate /tmp/rsh/fifo: not a regular file
```

That is non-deterministic output and it escapes `PortableErr` — both violations of `docs/RULES.md`.

## Change

- New `writeopen.ErrNotRegularFile` sentinel; `writePathError` maps `unix.ENXIO` to it (ENXIO on a write open always means a non-regular target, which rshell never accepts here).
- `PortableErrMsg` renders it as `not a regular file`.
- `Sandbox.Truncate` / `Sandbox.TruncateToZeroIfAtLeast` rewrap it as the same `*os.PathError` their post-open `fstat` guard already produces.

Only `ENXIO` is remapped — `errors.Is(err, os.ErrNotExist)` is untouched, so `truncate -c`'s silent-skip path still works. Windows build is unaffected (`unix.ENXIO` is only referenced from `writeopen_unix.go`).

Both branches now print `truncate: "pipe": not a regular file`.

## Tests

The existing FIFO pentest test asserted only exit code 1 and a path substring, and used a read-only sandbox path — so it was passing on `permission denied` and never reached the FIFO logic. It now grants `:rw` and asserts the exact message, plus reader-attached variants and the equivalent pair for `logrotate` (no FIFO coverage existed there). The reader end is opened with `O_RDONLY|O_NONBLOCK` and closed via `t.Cleanup`, so there is no goroutine to hang or flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)