### PR TITLE
fix(interp): create redirect files with 0666 & ~umask

### DIFF
--- a/interp/runner_redir_remediation.go
+++ b/interp/runner_redir_remediation.go
@@ -16,8 +16,13 @@ import (
 )
 
 // redirectFilePerm is the permission bits used when creating redirect target
-// files. Matches the default umask-applied mode produced by bash.
-const redirectFilePerm os.FileMode = 0644
+// files. 0666 lets the process umask determine the final mode (open(2) applies
+// mode & ~umask), matching bash's >FILE behaviour and Sandbox.Truncate.
+// Hardcoding 0644 here would instead bake in the result for umask 022 only,
+// producing a non-group-writable file on hosts with a 002 umask.
+// On Windows there is no umask; Go maps the mode to the read-only attribute
+// (perm&0200), which both 0644 and 0666 set, so this value is inert there.
+const redirectFilePerm os.FileMode = 0666
 
 // statFileMode returns the fs.FileMode for path via the sandbox.
 // When r.sandbox is nil, it returns os.ErrNotExist so the caller skips the

--- a/interp/runner_redir_umask_unix_test.go
+++ b/interp/runner_redir_umask_unix_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build unix
+
+package interp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemediationRedirect_Umask verifies that files created by write
+// redirections get 0666 & ~umask, matching bash, rather than a hardcoded mode.
+//
+// Both umask values matter: at 022 the buggy hardcoded 0644 coincides with the
+// correct result, so only the 002 case actually catches the divergence.
+//
+// syscall.Umask is process-global, so this test must not run in parallel and
+// must restore the previous value.
+func TestRemediationRedirect_Umask(t *testing.T) {
+	cases := []struct {
+		name  string
+		umask int
+		want  os.FileMode
+	}{
+		{name: "umask022", umask: 0o022, want: 0o644},
+		{name: "umask002", umask: 0o002, want: 0o664},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Deliberately not t.Parallel(): umask is process-global.
+			dir := t.TempDir()
+
+			old := syscall.Umask(tc.umask)
+			defer syscall.Umask(old)
+
+			script := "echo trunc > trunc.txt\n" +
+				"echo clob >| clob.txt\n" +
+				"echo app >> app.txt\n" +
+				"echo all &> all.txt\n" +
+				"echo appall &>> appall.txt\n"
+
+			r, _, stderr := newRemediationRunner(t, dir)
+			require.NoError(t, r.Run(context.Background(), parseScript(t, script)),
+				"stderr=%q", stderr.String())
+
+			for _, name := range []string{"trunc.txt", "clob.txt", "app.txt", "all.txt", "appall.txt"} {
+				info, err := os.Stat(filepath.Join(dir, name))
+				require.NoError(t, err)
+				perm := info.Mode().Perm()
+				assert.Equal(t, tc.want, perm,
+					"%s: expected %04o (0666 & ~%04o), got %04o", name, tc.want, tc.umask, perm)
+			}
+		})
+	}
+}

--- a/interp/runner_redir_umask_windows_test.go
+++ b/interp/runner_redir_umask_windows_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package interp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemediationRedirect_Umask on Windows just verifies redirect-created
+// files exist and are writable. Windows has no Unix-style umask; Go maps the
+// mode to the read-only attribute via perm&0200, which redirectFilePerm sets.
+func TestRemediationRedirect_Umask(t *testing.T) {
+	dir := t.TempDir()
+
+	script := "echo trunc > trunc.txt\n" +
+		"echo clob >| clob.txt\n" +
+		"echo app >> app.txt\n" +
+		"echo all &> all.txt\n" +
+		"echo appall &>> appall.txt\n"
+
+	r, _, stderr := newRemediationRunner(t, dir)
+	require.NoError(t, r.Run(context.Background(), parseScript(t, script)),
+		"stderr=%q", stderr.String())
+
+	for _, name := range []string{"trunc.txt", "clob.txt", "app.txt", "all.txt", "appall.txt"} {
+		info, err := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, err)
+		assert.NotZero(t, info.Mode().Perm()&0o200, "%s must not be read-only", name)
+	}
+}


### PR DESCRIPTION
`interp/runner_redir_remediation.go` hardcoded `redirectFilePerm = 0644` for files created by `>`, `>|`, `>>`, `&>`, and `&>>`. That is the *result* of `0666 & ~umask` for umask 022 only. bash passes `0666` to `open(2)` and lets the kernel apply the umask — and `Sandbox.Truncate` in this same codebase already does exactly that, so the two write paths in one runner disagreed.

At umask 002:

```
redir.txt  -rw-r--r--   rshell redirect  (wrong)
trunc.txt  -rw-rw-r--   rshell truncate  (correct)
bashredir  -rw-rw-r--   bash             (correct)
```

## Changes

- `redirectFilePerm` is now `0666`; both call sites already share the constant, so this covers all five operators.
- New umask tests for every redirect operator asserting `0644` at umask 022 and `0664` at umask 002. Only the 002 case catches the bug — verified the new test fails against the old constant and passes after the fix. `syscall.Umask` is process-global, so the test is non-parallel and restores the prior value with `defer`.

## Windows

Inert, confirmed rather than assumed: `writeopen_windows.go` calls `os.Root.OpenFile`, which reaches `syscall.Open`, whose only use of `perm` is `if perm&S_IWRITE == 0 { attrs = FILE_ATTRIBUTE_READONLY }`. Both 0644 and 0666 set 0200, so the attribute is unchanged. A Windows counterpart test asserts the files are created and not read-only.

## Testing

- `go test ./interp/... ./allowedpaths/... ./builtins/tests/truncate/...` — pass.
- `go test ./tests/` — pass.
- `RSHELL_BASH_TEST=1 go test ./tests/ -run TestShellScenariosAgainstBash` — pass (25.9s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)