### PR TITLE
test(systemctl): add end-to-end scenario coverage for mutations, grant shapes, and list filters

### DIFF
--- a/tests/scenarios/cmd/systemctl/basic/duplicate_operands.yaml
+++ b/tests/scenarios/cmd/systemctl/basic/duplicate_operands.yaml
@@ -1,0 +1,15 @@
+# Repeated operands are deduplicated rather than rejected: validation raises no
+# duplicate error and the run reaches the normal authorization denial.
+skip_assert_against_bash: true
+description: systemctl accepts and deduplicates repeated unit operands
+input:
+  mode: remediation
+  script: |+
+    systemctl status api.service api.service api.service
+    systemctl restart api.service api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "read"
+    systemctl: system service "api.service" is not allowed for action "restart"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/basic/list_filters_empty_grants.yaml
+++ b/tests/scenarios/cmd/systemctl/basic/list_filters_empty_grants.yaml
@@ -1,0 +1,28 @@
+# With no read grant the filter surface is still parsed and still lists nothing.
+skip_assert_against_bash: true
+description: systemctl list filters never widen an empty read allowlist
+input:
+  mode: remediation
+  script: |+
+    systemctl list-units
+    systemctl --all
+    systemctl list-units --type=service --state=active
+    systemctl list-units --state=loaded,active,running
+    systemctl list-units --state=active --state=failed
+    systemctl -a -t service
+expect:
+  stdout: |+
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/systemctl/basic/list_type_filter_excludes_units.yaml
+++ b/tests/scenarios/cmd/systemctl/basic/list_type_filter_excludes_units.yaml
@@ -1,0 +1,24 @@
+# --type narrows the read-granted candidate set before the manager is consulted.
+skip_assert_against_bash: true
+description: systemctl --type excludes read-granted units of other types
+input:
+  mode: remediation
+  allowed_system_services:
+    - service: api.service
+      actions: [read]
+    - service: backup.timer
+      actions: [read]
+  script: |+
+    systemctl list-units --type=path
+    systemctl --type=mount,swap
+    systemctl -t socket
+expect:
+  stdout: |+
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/systemctl/basic/no_legend.yaml
+++ b/tests/scenarios/cmd/systemctl/basic/no_legend.yaml
@@ -1,0 +1,14 @@
+# --no-legend drops both the header row and the trailing restriction summary.
+skip_assert_against_bash: true
+description: systemctl --no-legend suppresses the list-units header and count
+input:
+  mode: remediation
+  script: |+
+    systemctl list-units --no-legend
+    systemctl --no-legend --all
+    echo done
+expect:
+  stdout: |+
+    done
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/systemctl/errors/disable_denied.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/disable_denied.yaml
@@ -1,0 +1,12 @@
+# Remediation mode alone does not bypass the exact unit/action allowlist.
+skip_assert_against_bash: true
+description: systemctl disable requires an exact disable grant
+input:
+  mode: remediation
+  script: |+
+    systemctl disable api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "disable"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/enable_denied.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/enable_denied.yaml
@@ -1,0 +1,12 @@
+# Remediation mode alone does not bypass the exact unit/action allowlist.
+skip_assert_against_bash: true
+description: systemctl enable requires an exact enable grant
+input:
+  mode: remediation
+  script: |+
+    systemctl enable api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "enable"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/exact_unit_name_required.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/exact_unit_name_required.yaml
@@ -1,0 +1,19 @@
+# "api" and "api.service" are different selectors; a grant never covers both.
+skip_assert_against_bash: true
+description: a grant for api.service does not match the suffix-less operand api
+input:
+  mode: remediation
+  allowed_system_services:
+    - service: api.service
+      actions: [read, start]
+  script: |+
+    systemctl status api
+    systemctl start api
+    systemctl status api.socket
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: invalid exact unit name "api"
+    systemctl: invalid exact unit name "api"
+    systemctl: system service "api.socket" is not allowed for action "read"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/filter_values_rejected.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/filter_values_rejected.yaml
@@ -1,0 +1,24 @@
+# Filter lists are bounded and every value must be a plain systemd token.
+skip_assert_against_bash: true
+description: systemctl rejects unsupported, empty, and over-long list filter values
+input:
+  mode: remediation
+  script: |+
+    systemctl list-units --type=bogus
+    systemctl list-units --type=service,bogus
+    systemctl list-units --type=
+    systemctl list-units --state=
+    systemctl list-units --state='act ive'
+    systemctl list-units --type=service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service
+    systemctl list-units --state=active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active,active
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: unsupported --type value "bogus"
+    systemctl: unsupported --type value "bogus"
+    systemctl: invalid --type value (empty)
+    systemctl: invalid --state value (empty)
+    systemctl: invalid --state value "act ive"
+    systemctl: too many --type values (maximum 32)
+    systemctl: too many --state values (maximum 32)
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/invalid_unit_names.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/invalid_unit_names.yaml
@@ -1,0 +1,26 @@
+# Every operand must be an exact, fully suffixed unit name of a supported type.
+skip_assert_against_bash: true
+description: systemctl rejects malformed unit operands before authorization
+input:
+  mode: remediation
+  script: |+
+    systemctl status foo.bogus
+    systemctl status foo
+    systemctl status .service
+    systemctl status foo.
+    systemctl status '@foo.service'
+    systemctl status 'a@b@c.service'
+    systemctl status ''
+    systemctl status
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: unsupported unit type "bogus" in "foo.bogus"
+    systemctl: invalid exact unit name "foo"
+    systemctl: invalid exact unit name ".service"
+    systemctl: invalid exact unit name "foo."
+    systemctl: invalid exact unit name "@foo.service"
+    systemctl: invalid exact unit name "a@b@c.service"
+    systemctl: unit name must not be empty
+    systemctl: at least one exact unit is required
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/list_units_operand_rejected.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/list_units_operand_rejected.yaml
@@ -1,0 +1,12 @@
+# list-units is enumeration-only; unit operands must never narrow or widen it.
+skip_assert_against_bash: true
+description: systemctl list-units rejects unit operands
+input:
+  mode: remediation
+  script: |+
+    systemctl list-units api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: list-units does not accept unit operands
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/mutate_grant_does_not_imply_read.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/mutate_grant_does_not_imply_read.yaml
@@ -1,0 +1,18 @@
+# status authorizes the read action, which a start grant never confers.
+skip_assert_against_bash: true
+description: a start-only grant does not authorize status or list-units inspection
+input:
+  mode: remediation
+  allowed_system_services:
+    - service: api.service
+      actions: [start]
+  script: |+
+    systemctl status api.service
+    systemctl list-units
+expect:
+  stdout: |+
+    UNIT LOAD ACTIVE SUB DESCRIPTION
+    0 units listed (restricted to units granted read access).
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "read"
+  exit_code: 0

--- a/tests/scenarios/cmd/systemctl/errors/read_grant_does_not_imply_mutate.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/read_grant_does_not_imply_mutate.yaml
@@ -1,0 +1,25 @@
+# A read grant authorizes inspection only; every mutating verb needs its own action.
+skip_assert_against_bash: true
+description: a read-only grant does not authorize any systemctl mutation
+input:
+  mode: remediation
+  allowed_system_services:
+    - service: api.service
+      actions: [read]
+  script: |+
+    systemctl start api.service
+    systemctl stop api.service
+    systemctl reload api.service
+    systemctl restart api.service
+    systemctl enable api.service
+    systemctl disable api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "start"
+    systemctl: system service "api.service" is not allowed for action "stop"
+    systemctl: system service "api.service" is not allowed for action "reload"
+    systemctl: system service "api.service" is not allowed for action "restart"
+    systemctl: system service "api.service" is not allowed for action "enable"
+    systemctl: system service "api.service" is not allowed for action "disable"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/reload_denied.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/reload_denied.yaml
@@ -1,0 +1,12 @@
+# Remediation mode alone does not bypass the exact unit/action allowlist.
+skip_assert_against_bash: true
+description: systemctl reload requires an exact reload grant
+input:
+  mode: remediation
+  script: |+
+    systemctl reload api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "reload"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/restart_denied.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/restart_denied.yaml
@@ -1,0 +1,12 @@
+# Remediation mode alone does not bypass the exact unit/action allowlist.
+skip_assert_against_bash: true
+description: systemctl restart requires an exact restart grant
+input:
+  mode: remediation
+  script: |+
+    systemctl restart api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "restart"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/stop_denied.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/stop_denied.yaml
@@ -1,0 +1,12 @@
+# Remediation mode alone does not bypass the exact unit/action allowlist.
+skip_assert_against_bash: true
+description: systemctl stop requires an exact stop grant
+input:
+  mode: remediation
+  script: |+
+    systemctl stop api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: system service "api.service" is not allowed for action "stop"
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/too_many_operands.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/too_many_operands.yaml
@@ -1,0 +1,16 @@
+# The operand bound is checked on the raw argument list, before deduplication.
+skip_assert_against_bash: true
+description: systemctl rejects more than 32 unit operands, before deduplication
+input:
+  mode: remediation
+  script: |+
+    systemctl status u1.service u2.service u3.service u4.service u5.service u6.service u7.service u8.service u9.service u10.service u11.service u12.service u13.service u14.service u15.service u16.service u17.service u18.service u19.service u20.service u21.service u22.service u23.service u24.service u25.service u26.service u27.service u28.service u29.service u30.service u31.service u32.service u33.service
+    systemctl restart u1.service u2.service u3.service u4.service u5.service u6.service u7.service u8.service u9.service u10.service u11.service u12.service u13.service u14.service u15.service u16.service u17.service u18.service u19.service u20.service u21.service u22.service u23.service u24.service u25.service u26.service u27.service u28.service u29.service u30.service u31.service u32.service u33.service
+    systemctl status api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service api.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: too many unit operands (maximum 32)
+    systemctl: too many unit operands (maximum 32)
+    systemctl: too many unit operands (maximum 32)
+  exit_code: 1

--- a/tests/scenarios/cmd/systemctl/errors/unit_name_too_long.yaml
+++ b/tests/scenarios/cmd/systemctl/errors/unit_name_too_long.yaml
@@ -1,0 +1,12 @@
+# systemd's unit-name payload limit is enforced before any grant lookup.
+skip_assert_against_bash: true
+description: systemctl rejects a unit name longer than 255 bytes
+input:
+  mode: remediation
+  script: |+
+    systemctl status aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.service
+expect:
+  stdout: |+
+  stderr: |+
+    systemctl: unit name "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" exceeds 255 bytes
+  exit_code: 1

--- a/tests/scenarios_test.go
+++ b/tests/scenarios_test.go
@@ -87,6 +87,18 @@ type input struct {
 	// Mode sets the runner execution mode. Accepted values: "read-only" (default), "remediation".
 	// "remediation" enables file-target output redirections (>, >>, 2>, &>, &>>) within read-write AllowedPaths.
 	Mode string `yaml:"mode"`
+	// AllowedSystemServices configures exact systemd unit/action grants for
+	// systemd-aware builtins. When omitted, no grant is configured and every
+	// systemd operation is denied, which is the default for every scenario.
+	// Scenarios must not rely on a live systemd manager: only grant shapes
+	// whose outcome is decided by policy before the manager is contacted.
+	AllowedSystemServices []systemServiceGrant `yaml:"allowed_system_services"`
+}
+
+// systemServiceGrant is the YAML form of interp.SystemServiceControlGrant.
+type systemServiceGrant struct {
+	Service string   `yaml:"service"`
+	Actions []string `yaml:"actions"`
 }
 
 // expected holds the expected output for a scenario.
@@ -255,6 +267,17 @@ func runScenario(t *testing.T, sc scenario) {
 	}
 	if sc.Input.Mode == string(interp.ModeRemediation) {
 		opts = append(opts, interp.WithMode(interp.ModeRemediation))
+	}
+	if sc.Input.AllowedSystemServices != nil {
+		grants := make([]interp.SystemServiceControlGrant, 0, len(sc.Input.AllowedSystemServices))
+		for _, grant := range sc.Input.AllowedSystemServices {
+			actions := make([]interp.SystemServiceAction, 0, len(grant.Actions))
+			for _, action := range grant.Actions {
+				actions = append(actions, interp.SystemServiceAction(action))
+			}
+			grants = append(grants, interp.SystemServiceControlGrant{Service: grant.Service, Actions: actions})
+		}
+		opts = append(opts, interp.AllowedSystemServices(grants))
 	}
 	runner, err := interp.New(opts...)
 	require.NoError(t, err, "failed to create runner")


### PR DESCRIPTION
Only ten `systemctl` scenarios existed. Every mutation verb except `start` and every list filter had no end-to-end coverage through the real runner (argument parsing, `AllowedSystemServices` policy, remediation gating, output formatting).

Adds 14 scenarios:

- **Mutation denials** — `stop`, `reload`, `restart`, `enable`, `disable`, mirroring `start_denied`.
- **Grant shapes** — read does not imply mutate; a `start` grant does not imply `read` (for `status` or `list-units`); a grant for `api.service` does not match `api` or `api.socket`.
- **Operand validation** — `list-units` rejects operands; the 32-operand bound (including that it is checked pre-deduplication); the 255-byte name bound; malformed names (`foo.bogus`, `foo`, `.service`, `foo.`, `@foo.service`, `a@b@c.service`, empty, none); duplicates are deduplicated, not rejected.
- **List filters** — `--type` / `--state` / `--all` / `--no-legend`, comma-separated and repeated forms, unsupported and empty values, and the 32-value bound.

Also adds an `allowed_system_services` field to the scenario harness (`tests/scenarios_test.go`) so grant-shape denials can be expressed declaratively. It maps directly to `interp.AllowedSystemServices` and defaults to no grants, so every existing scenario is unchanged. Test-only — no production code touched.

Paths that need a live systemd manager (a successful `start`, real `status` output, a populated `list-units`, and `--state` filtering, which runs on manager replies) are not expressible as scenarios and stay in `builtins/systemctl/systemctl_test.go` with its mock backend.

All new scenarios set `skip_assert_against_bash: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)