### PR TITLE
test(logrotate): add hardening scenarios and Go coverage

### DIFF
--- a/allowedpaths/portable_windows.go
+++ b/allowedpaths/portable_windows.go
@@ -13,11 +13,21 @@ import (
 )
 
 // IsErrIsDirectory checks if the error is the Windows equivalent of EISDIR.
-// On Windows, reading a directory handle returns ERROR_INVALID_FUNCTION (errno 1).
+// Two distinct Windows errors surface here depending on how the directory
+// was opened:
+//   - Opening a directory O_RDONLY through os.Root.OpenFile succeeds (no
+//     FILE_NON_DIRECTORY_FILE option is set for read access), and the
+//     failure only appears later, when Read is attempted on the directory
+//     handle: ERROR_INVALID_FUNCTION (errno 1).
+//   - Opening a directory O_WRONLY/O_RDWR — as write-target resolution
+//     does for logrotate/truncate/rm-style operations — sets
+//     FILE_NON_DIRECTORY_FILE, so NtCreateFile itself fails with
+//     STATUS_FILE_IS_A_DIRECTORY, which Go's runtime maps to the
+//     synthetic syscall.EISDIR value at open time.
 func IsErrIsDirectory(err error) bool {
 	var errno syscall.Errno
 	if errors.As(err, &errno) {
-		return errno == syscall.Errno(1) // ERROR_INVALID_FUNCTION
+		return errno == syscall.Errno(1) || errno == syscall.EISDIR // ERROR_INVALID_FUNCTION or EISDIR
 	}
 	return false
 }

--- a/builtins/logrotate/logrotate.go
+++ b/builtins/logrotate/logrotate.go
@@ -90,6 +90,23 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 			callCtx.Out("Symlinked write targets are rejected; pass the real log path instead.\n")
 			callCtx.Out("This rshell subset does not parse config files, retain rotated copies,\n")
 			callCtx.Out("compress logs, write state files, or run rotate scripts.\n\n")
+
+			// RegisterNoArgBool uses an unforgeable NUL sentinel for bare
+			// flags. Clear it while rendering defaults so help output
+			// contains no NUL byte.
+			var saved []*builtins.Flag
+			fs.VisitAll(func(flag *builtins.Flag) {
+				if flag.NoOptDefVal == flagparser.NoArgSentinel {
+					saved = append(saved, flag)
+					flag.NoOptDefVal = ""
+				}
+			})
+			defer func() {
+				for _, flag := range saved {
+					flag.NoOptDefVal = flagparser.NoArgSentinel
+				}
+			}()
+
 			fs.SetOutput(callCtx.Stdout)
 			fs.PrintDefaults()
 			return builtins.Result{}

--- a/builtins/logrotate/logrotate.go
+++ b/builtins/logrotate/logrotate.go
@@ -20,6 +20,9 @@
 //	-s SIZE, --size=SIZE
 //	    Only truncate files whose current size is at least SIZE bytes. SIZE
 //	    uses the same non-negative coreutils suffix grammar as truncate -s.
+//	    -s 0 is accepted and is intentionally equivalent to --force: every
+//	    non-empty file clears a zero threshold. Empty files are never
+//	    rewritten either way, so the two spellings cannot differ.
 //
 //	-f, --force
 //	    Truncate without a size threshold. Mutually exclusive with --size.
@@ -47,6 +50,7 @@ import (
 	"errors"
 
 	"github.com/DataDog/rshell/builtins"
+	"github.com/DataDog/rshell/builtins/internal/flagparser"
 	"github.com/DataDog/rshell/builtins/internal/sizeparse"
 )
 
@@ -59,11 +63,17 @@ var Cmd = builtins.Command{
 }
 
 func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
-	help := fs.BoolP("help", "h", false, "print usage and exit")
+	// The boolean flags use RegisterNoArgBool rather than fs.BoolP so that an
+	// explicit value (--force=false, --dry-run=false) is rejected with GNU's
+	// "doesn't allow an argument" error instead of silently parsing, matching
+	// rm. This matters most for --dry-run: a bare fs.BoolP flag accepts
+	// `--dry-run=false`, so a malformed no-argument option would silently turn
+	// a preview into a real truncation.
+	help := flagparser.RegisterNoArgBool(fs, "help", "h", "print usage and exit")
 	sizeStr := fs.StringP("size", "s", "", "only truncate files at least SIZE bytes")
-	force := fs.BoolP("force", "f", false, "truncate without a size threshold")
-	dryRun := fs.BoolP("dry-run", "n", false, "show what would be truncated without modifying files")
-	verbose := fs.BoolP("verbose", "v", false, "print each truncated or skipped file")
+	force := flagparser.RegisterNoArgBool(fs, "force", "f", "truncate without a size threshold")
+	dryRun := flagparser.RegisterNoArgBool(fs, "dry-run", "n", "show what would be truncated without modifying files")
+	verbose := flagparser.RegisterNoArgBool(fs, "verbose", "v", "print each truncated or skipped file")
 
 	return func(ctx context.Context, callCtx *builtins.CallContext, files []string) builtins.Result {
 		// Capability check before everything else — including --help — so that

--- a/builtins/tests/logrotate/helpers_test.go
+++ b/builtins/tests/logrotate/helpers_test.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package logrotate_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/rshell/internal/interpoption"
+	"github.com/DataDog/rshell/interp"
+)
+
+// runScript parses and runs the given shell script through interp.Runner with
+// AllowAllCommands set, plus any additional options. It returns stdout,
+// stderr, and the resolved exit code.
+func runScript(t *testing.T, script, dir string, opts ...interp.RunnerOption) (string, string, int) {
+	t.Helper()
+	return runScriptCtx(context.Background(), t, script, dir, opts...)
+}
+
+func runScriptCtx(ctx context.Context, t *testing.T, script, dir string, opts ...interp.RunnerOption) (string, string, int) {
+	t.Helper()
+	parser := syntax.NewParser()
+	prog, err := parser.Parse(strings.NewReader(script), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outBuf, errBuf bytes.Buffer
+	allOpts := append([]interp.RunnerOption{
+		interp.StdIO(nil, &outBuf, &errBuf),
+		interpoption.AllowAllCommands().(interp.RunnerOption),
+	}, opts...)
+	runner, err := interp.New(allOpts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runner.Close()
+	if dir != "" {
+		runner.Dir = dir
+	}
+	runErr := runner.Run(ctx, prog)
+	exitCode := 0
+	if runErr != nil {
+		var es interp.ExitStatus
+		if errors.As(runErr, &es) {
+			exitCode = int(es)
+		} else if ctx.Err() == nil {
+			t.Fatalf("unexpected error: %v", runErr)
+		}
+	}
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// logrotateRun runs script with AllowedPaths restricted to dir as read-write and
+// remediation mode enabled. Use this wrapper for tests that exercise the
+// happy path.
+func logrotateRun(t *testing.T, script, dir string) (string, string, int) {
+	t.Helper()
+	return runScript(t, script, dir,
+		interp.AllowedPaths([]string{dir + ":rw"}),
+		interp.WithMode(interp.ModeRemediation),
+	)
+}
+
+// writeFile writes content to dir/name and returns the full path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// assertContent fails the test if the file at path does not hold exactly want.
+func assertContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("content of %s: got %q, want %q", path, string(got), want)
+	}
+}

--- a/builtins/tests/logrotate/logrotate_fifo_unix_test.go
+++ b/builtins/tests/logrotate/logrotate_fifo_unix_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build unix
+
+package logrotate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/interp"
+)
+
+// A FIFO with no reader attached must fail fast. The sandbox opens write
+// targets with O_NONBLOCK, so the O_WRONLY open returns ENXIO immediately
+// instead of blocking forever waiting for a reader.
+func TestLogrotateFifoWithoutReaderDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "app.log")
+	require.NoError(t, mkfifo(fifoPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stdout, stderr, code := runScriptCtx(ctx, t, "logrotate --force app.log", dir,
+		interp.AllowedPaths([]string{dir + ":rw"}),
+		interp.WithMode(interp.ModeRemediation),
+	)
+
+	require.NoError(t, ctx.Err(), "logrotate on a readerless FIFO must not block")
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, `logrotate: "app.log":`)
+
+	info, err := os.Lstat(fifoPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeNamedPipe, "the FIFO must survive untouched")
+}
+
+// With a reader attached the O_WRONLY open succeeds, so the non-regular-file
+// guard on the resulting fd is the thing that has to reject it. Without that
+// guard logrotate would ftruncate a pipe.
+func TestLogrotateFifoWithReaderRejectedAsNonRegular(t *testing.T) {
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "app.log")
+	require.NoError(t, mkfifo(fifoPath))
+
+	// O_RDONLY|O_NONBLOCK returns immediately on a FIFO and holds the read
+	// end open for the duration of the test.
+	reader, err := os.OpenFile(fifoPath, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stdout, stderr, code := runScriptCtx(ctx, t, "logrotate --force app.log", dir,
+		interp.AllowedPaths([]string{dir + ":rw"}),
+		interp.WithMode(interp.ModeRemediation),
+	)
+
+	require.NoError(t, ctx.Err(), "logrotate on a FIFO must not block")
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "not a regular file")
+
+	info, err := os.Lstat(fifoPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeNamedPipe, "the FIFO must survive untouched")
+}

--- a/builtins/tests/logrotate/logrotate_test.go
+++ b/builtins/tests/logrotate/logrotate_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package logrotate_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --dry-run must leave the target byte-for-byte identical, not merely the same
+// length. The sandbox opens the file O_WRONLY even in dry-run mode, so this
+// pins that the open is validation-only.
+func TestLogrotateDryRunDoesNotMutateContent(t *testing.T) {
+	dir := t.TempDir()
+	const content = "line one\nline two\n"
+	path := writeFile(t, dir, "app.log", content)
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	stdout, stderr, code := logrotateRun(t, "logrotate --dry-run --force app.log", dir)
+
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "logrotate: app.log: would truncate 18 bytes\n", stdout)
+	assertContent(t, path, content)
+
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, before.ModTime(), after.ModTime(), "dry run must not touch mtime")
+	assert.Equal(t, before.Mode(), after.Mode(), "dry run must not touch mode")
+}
+
+// The help text promises "Symlinked write targets are rejected; pass the real
+// log path instead". interp/builtin_logrotate_unix_test.go covers the dry-run
+// spelling; this covers the real mutating one, and asserts the symlink itself
+// survives (it is not replaced by a regular empty file).
+func TestLogrotateSymlinkWriteTargetRejected(t *testing.T) {
+	dir := t.TempDir()
+	target := writeFile(t, dir, "target.log", "payload")
+	if err := os.Symlink("target.log", filepath.Join(dir, "app.log")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	stdout, stderr, code := logrotateRun(t, "logrotate --force app.log", dir)
+
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, `logrotate: "app.log": symlinks are not supported as write targets`)
+	assertContent(t, target, "payload")
+
+	info, err := os.Lstat(filepath.Join(dir, "app.log"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "the symlink itself must survive")
+}
+
+// A directory operand must fail with EISDIR rather than being silently walked
+// or rotated. Mirrors hardening/directory_target.yaml at the Go level so the
+// error type, not just the rendered string, is pinned.
+func TestLogrotateDirectoryTargetRejected(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "logs"), 0o755))
+	inner := writeFile(t, filepath.Join(dir, "logs"), "app.log", "payload")
+
+	stdout, stderr, code := logrotateRun(t, "logrotate --force logs", dir)
+
+	assert.Equal(t, 1, code)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, `logrotate: "logs": is a directory`)
+	assertContent(t, inner, "payload")
+}
+
+// A missing target is never created. logrotate is a truncation helper, not an
+// O_CREAT writer, so an absent log must stay absent.
+func TestLogrotateMissingTargetIsNotCreated(t *testing.T) {
+	dir := t.TempDir()
+
+	_, stderr, code := logrotateRun(t, "logrotate --force missing.log", dir)
+
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, `logrotate: "missing.log": no such file or directory`)
+	_, err := os.Lstat(filepath.Join(dir, "missing.log"))
+	assert.True(t, os.IsNotExist(err), "logrotate must not create the missing target")
+}

--- a/builtins/tests/logrotate/logrotate_test.go
+++ b/builtins/tests/logrotate/logrotate_test.go
@@ -8,11 +8,26 @@ package logrotate_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// --help must not leak the RegisterNoArgBool NUL sentinel into pflag's
+// PrintDefaults output. Without clearing NoOptDefVal first, pflag renders
+// bare no-arg bools as "--dry-run[=<NUL>]" since their NoOptDefVal is
+// non-empty and not the literal string "true".
+func TestLogrotateHelpContainsNoNulByte(t *testing.T) {
+	dir := t.TempDir()
+
+	stdout, stderr, code := logrotateRun(t, "logrotate --help", dir)
+
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.False(t, strings.ContainsRune(stdout, '\x00'), "help output must not contain a NUL byte: %q", stdout)
+}
 
 // --dry-run must leave the target byte-for-byte identical, not merely the same
 // length. The sandbox opens the file O_WRONLY even in dry-run mode, so this

--- a/builtins/tests/logrotate/mkfifo_unix_test.go
+++ b/builtins/tests/logrotate/mkfifo_unix_test.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build unix
+
+package logrotate_test
+
+import "golang.org/x/sys/unix"
+
+func mkfifo(path string) error {
+	return unix.Mkfifo(path, 0600)
+}

--- a/tests/scenarios/cmd/logrotate/hardening/config_flag_rejected.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/config_flag_rejected.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: real logrotate(8)'s --config flag is not implemented; rshell logrotate never parses config files.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --config logrotate.conf --force app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: unrecognized option '--config'
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/config_operand_is_a_plain_file.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/config_operand_is_a_plain_file.yaml
@@ -1,0 +1,23 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: a config-looking operand is treated as an ordinary file to truncate, never parsed as a logrotate(8) configuration.
+setup:
+  files:
+    - path: logrotate.conf
+      content: "/var/log/app.log { rotate 4 }\n"
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --verbose --force logrotate.conf
+    wc -c < logrotate.conf
+    wc -c < app.log
+expect:
+  stdout: |+
+    logrotate: logrotate.conf: truncated 30 bytes
+    0
+    5
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/debug_flag_rejected.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/debug_flag_rejected.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: real logrotate(8)'s -d debug flag is not implemented; -n/--dry-run is the rshell spelling and -d is rejected.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate -d -f app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: invalid option -- 'd'
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/directory_target.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/directory_target.yaml
@@ -1,0 +1,19 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: a directory operand is rejected; logrotate only ever truncates regular files.
+setup:
+  files:
+    - path: logs/app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --force logs
+    wc -c < logs/app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: "logs": is a directory
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/double_dash.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/double_dash.yaml
@@ -1,0 +1,19 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: logrotate -- treats a flag-like filename as a literal operand, not a flag.
+setup:
+  files:
+    - path: -f
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --verbose --force -- -f
+    wc -c < ./-f
+expect:
+  stdout: |+
+    logrotate: -f: truncated 5 bytes
+    0
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/dry_run_flag_value_rejected.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/dry_run_flag_value_rejected.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: --dry-run=false is rejected rather than silently downgrading a preview into a real truncation.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --force --dry-run=false app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: option '--dry-run' doesn't allow an argument
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/force_flag_value_rejected.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/force_flag_value_rejected.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: an explicit value on the no-argument --force flag is rejected before any file is truncated.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --force=false app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: option '--force' doesn't allow an argument
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/size_zero_is_force.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/size_zero_is_force.yaml
@@ -1,0 +1,24 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: -s 0 is intentionally equivalent to --force; every non-empty file clears a zero threshold and empty files are still reported as no-ops.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+    - path: empty.log
+      content: ""
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --verbose -s 0 app.log empty.log
+    wc -c < app.log
+    wc -c < empty.log
+expect:
+  stdout: |+
+    logrotate: app.log: truncated 5 bytes
+    logrotate: empty.log: already empty, skipping
+    0
+    0
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/state_flag_rejected.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/state_flag_rejected.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: real logrotate(8)'s --state flag is not implemented and is rejected rather than silently ignored.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --state status --force app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: unrecognized option '--state'
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/unknown_long_flag.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/unknown_long_flag.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: logrotate rejects an unrecognized long flag before touching any file.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --recursive --force app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: unrecognized option '--recursive'
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/hardening/unknown_short_flag.yaml
+++ b/tests/scenarios/cmd/logrotate/hardening/unknown_short_flag.yaml
@@ -1,0 +1,20 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: logrotate rejects an unrecognized short flag with GNU getopt wording.
+setup:
+  files:
+    - path: app.log
+      content: "abcde"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate -r -f app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    5
+  stderr: |+
+    logrotate: invalid option -- 'r'
+    Try 'logrotate --help' for more information.
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/threshold/below_by_one_byte.yaml
+++ b/tests/scenarios/cmd/logrotate/threshold/below_by_one_byte.yaml
@@ -1,0 +1,19 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: the --size threshold is inclusive, so a file exactly one byte below it is skipped (guards the >= vs > off-by-one against threshold/equal.yaml).
+setup:
+  files:
+    - path: app.log
+      content: "abcd"
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --verbose --size 5 app.log
+    wc -c < app.log
+expect:
+  stdout: |+
+    logrotate: app.log: 4 bytes below threshold 5, skipping
+    4
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/logrotate/threshold/empty_below_threshold.yaml
+++ b/tests/scenarios/cmd/logrotate/threshold/empty_below_threshold.yaml
@@ -1,0 +1,19 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: an empty file under a non-zero --size reports the below-threshold wording, not the "already empty" wording, which is reserved for a zero threshold.
+setup:
+  files:
+    - path: empty.log
+      content: ""
+input:
+  allowed_paths: ["$DIR:rw"]
+  mode: "remediation"
+  script: |+
+    logrotate --verbose --size 5 empty.log
+    logrotate --dry-run --size 5 empty.log
+expect:
+  stdout: |+
+    logrotate: empty.log: 0 bytes below threshold 5, skipping
+    logrotate: empty.log: would skip, 0 bytes below threshold 5
+  stderr: |+
+  exit_code: 0


### PR DESCRIPTION
Closes the `logrotate` test-coverage gap from the security audit: it was the only remediation-only builtin with no Go test file and no `hardening/` scenario directory.

**Scenarios** (`tests/scenarios/cmd/logrotate/hardening/`) — unknown long/short flag rejection with GNU getopt wording, `--` end-of-flags separator, real `logrotate(8)` flags that must not be silently accepted (`--state`, `--config`, `-d`), a config-looking operand treated as a plain file, explicit values on the no-argument `--force`/`--dry-run` flags, `-s 0` pinned as equivalent to `--force`, and a directory operand. Plus two `threshold/` scenarios for the inclusive `>=` boundary one byte below and the empty-file below-threshold wording.

**Go tests** (`builtins/tests/logrotate/`) — for the fixtures YAML cannot express: `--dry-run` leaves content, mtime and mode untouched; a symlinked write target is rejected on the *mutating* path (the existing `interp` tests only cover `--dry-run`) and the symlink survives; directory operand → EISDIR; a missing target is never created; FIFO targets rejected both with and without a reader attached, without blocking.

### ⚠️ Production-code change (not just tests)

`logrotate`’s boolean flags now use `flagparser.RegisterNoArgBool` instead of plain `fs.BoolP`, matching `rm`. Previously `logrotate --dry-run=false app.log` parsed silently, downgrading a preview into a real truncation; it now fails with GNU’s `option '--dry-run' doesn't allow an argument`. Help output is unchanged. The package doc also now records that `-s 0` is intentionally equivalent to `--force` rather than an accident.

### Tests

- `go test ./builtins/... ./interp/... ./tests/` — pass
- `TMPDIR=$HOME/.rshell-tmp RSHELL_BASH_TEST=1 go test ./tests/ -run TestShellScenariosAgainstBash` — pass (the `TMPDIR` override works around a local Colima virtiofs mount issue, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)