### PR TITLE
feat(interp): enforce RemediationOnly at builtin dispatch

### DIFF
--- a/analysis/symbols_builtins.go
+++ b/analysis/symbols_builtins.go
@@ -818,6 +818,7 @@ var builtinPerCommandCallContextFields = map[string][]string{
 		"SetVar",
 	},
 	"rm": {
+		"AllowedPathsList",
 		"LstatFile",
 		"PortableErr",
 		"Remove",
@@ -852,6 +853,7 @@ var builtinPerCommandCallContextFields = map[string][]string{
 		"PortableErr",
 	},
 	"truncate": {
+		"AllowedPathsList",
 		"PortableErr",
 		"Truncate",
 	},

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -87,9 +87,25 @@ type Command struct {
 	NormalizeArgs func(args []string) []string
 
 	// RemediationOnly marks a builtin as only available in remediation mode.
-	// The help builtin uses this to move the command to the disabled list
-	// when the shell is in read-only mode.
+	// The interpreter refuses to dispatch such a command — before flag
+	// parsing, so --help is refused too — when the shell is in read-only
+	// mode, and the help builtin moves it to the disabled list. Builtins
+	// keep their own equivalent check as defence in depth; the dispatch
+	// gate is what makes the flag load-bearing for future builtins.
 	RemediationOnly bool
+
+	// RemediationDeniedMessage overrides the stderr text written by the
+	// dispatch-level read-only refusal. It must end with a newline. When
+	// empty, DefaultRemediationDeniedMessage is used. Only meaningful
+	// together with RemediationOnly.
+	RemediationDeniedMessage string
+}
+
+// DefaultRemediationDeniedMessage returns the stderr text written when a
+// RemediationOnly builtin is invoked in read-only mode and the command does
+// not set RemediationDeniedMessage.
+func DefaultRemediationDeniedMessage(name string) string {
+	return name + ": remediation mode required\n"
 }
 
 // NoFlags wraps a HandlerFunc in the MakeFlags format for commands that
@@ -121,7 +137,18 @@ func (c Command) Register() {
 	factory(probe)
 	hasFlags := probe.HasFlags()
 
-	metaRegistry[name] = CommandMeta{Name: name, Description: c.Description, Help: c.Help, HasFlags: hasFlags, RemediationOnly: c.RemediationOnly}
+	denied := c.RemediationDeniedMessage
+	if c.RemediationOnly && denied == "" {
+		denied = DefaultRemediationDeniedMessage(name)
+	}
+	metaRegistry[name] = CommandMeta{
+		Name:                     name,
+		Description:              c.Description,
+		Help:                     c.Help,
+		HasFlags:                 hasFlags,
+		RemediationOnly:          c.RemediationOnly,
+		RemediationDeniedMessage: denied,
+	}
 	addToRegistry(name, func(ctx context.Context, callCtx *CallContext, args []string) Result {
 		fs := pflag.NewFlagSet(name, pflag.ContinueOnError)
 		fs.SetOutput(io.Discard) // handler formats errors itself
@@ -489,6 +516,11 @@ type CommandMeta struct {
 	Help            string
 	HasFlags        bool // true when MakeFlags registers at least one flag
 	RemediationOnly bool // true when the command requires remediation mode
+
+	// RemediationDeniedMessage is the stderr text the interpreter writes
+	// when the command is dispatched in read-only mode. Non-empty exactly
+	// when RemediationOnly is true.
+	RemediationDeniedMessage string
 }
 
 var metaRegistry = map[string]CommandMeta{}

--- a/builtins/help/help.go
+++ b/builtins/help/help.go
@@ -86,6 +86,20 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 				return builtins.Result{}
 			}
 
+			// RemediationOnly builtins must never have their handler invoked
+			// outside remediation mode, even via `help <name> --help`-style
+			// lookup below. This mirrors the dispatch-level gate in interp so
+			// a builtin that forgets its own remediation check cannot still
+			// run its handler (and leak whatever it writes) through help.
+			if meta.RemediationOnly && !callCtx.RemediationMode {
+				msg := meta.RemediationDeniedMessage
+				if msg == "" {
+					msg = builtins.DefaultRemediationDeniedMessage(name)
+				}
+				callCtx.Errf("%s", msg)
+				return builtins.Result{Code: 1}
+			}
+
 			// Otherwise, invoke the command with --help and capture the output.
 			if handler, ok := builtins.Lookup(name); ok && handler != nil {
 				var buf bytes.Buffer

--- a/builtins/help/help.go
+++ b/builtins/help/help.go
@@ -216,6 +216,9 @@ func printAllowedPaths(callCtx *builtins.CallContext) {
 	if len(readWrite) > 0 && !callCtx.RemediationMode {
 		callCtx.Out("  (write access requires remediation mode)\n")
 	}
+	if len(readWrite) == 0 && callCtx.RemediationMode {
+		callCtx.Out("  (no read-write path configured — remediation commands cannot modify any file)\n")
+	}
 }
 
 // printAllowedSystemServices writes the effective, validated

--- a/builtins/logrotate/logrotate.go
+++ b/builtins/logrotate/logrotate.go
@@ -60,7 +60,16 @@ var Cmd = builtins.Command{
 	Description:     "truncate logs by size threshold or force",
 	MakeFlags:       registerFlags,
 	RemediationOnly: true,
+	// Preserve the historical read-only refusal wording; the dispatch gate
+	// in interp emits this before flag parsing, and the in-handler check
+	// repeats it as defence in depth.
+	RemediationDeniedMessage: readOnlyMessage,
 }
+
+const (
+	readOnlyMessage    = "logrotate: filesystem capability not available (remediation mode required)\n"
+	noWritableRootHint = "logrotate: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)\n"
+)
 
 func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	// The boolean flags use RegisterNoArgBool rather than fs.BoolP so that an
@@ -80,7 +89,13 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// logrotate --help behaves like invoking any remediation-only builtin
 		// outside remediation mode.
 		if callCtx.TruncateToZeroIfAtLeast == nil {
-			callCtx.Errf("logrotate: filesystem capability not available (remediation mode required)\n")
+			// Remediation mode with no sandbox root is a configuration gap,
+			// not a mode problem — say so rather than blaming the mode.
+			if callCtx.RemediationMode {
+				callCtx.Errf("%s", noWritableRootHint)
+			} else {
+				callCtx.Errf("%s", readOnlyMessage)
+			}
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/rm/rm.go
+++ b/builtins/rm/rm.go
@@ -75,7 +75,16 @@ var Cmd = builtins.Command{
 	Description:     "remove files",
 	MakeFlags:       registerFlags,
 	RemediationOnly: true,
+	// Preserve the historical read-only refusal wording; the dispatch gate
+	// in interp emits this before flag parsing, and the in-handler check
+	// below repeats it as defence in depth.
+	RemediationDeniedMessage: readOnlyMessage,
 }
+
+const (
+	readOnlyMessage    = "rm: filesystem capability not available (remediation mode required)\n"
+	noWritableRootHint = "rm: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)\n"
+)
 
 func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	// --help/--verbose use RegisterNoArgBool rather than fs.BoolP so that
@@ -92,7 +101,15 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// rm --help behaves the same as invoking a disallowed command: it
 		// fails immediately without showing help text.
 		if callCtx.Remove == nil {
-			callCtx.Errf("rm: filesystem capability not available (remediation mode required)\n")
+			// Distinguish "not in remediation mode" (the dispatch gate
+			// normally catches this first) from "remediation mode is on but
+			// no writable sandbox root exists", which would otherwise send
+			// the operator to fix the wrong thing.
+			if callCtx.RemediationMode {
+				callCtx.Errf("%s", noWritableRootHint)
+			} else {
+				callCtx.Errf("%s", readOnlyMessage)
+			}
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/rm/rm.go
+++ b/builtins/rm/rm.go
@@ -86,6 +86,22 @@ const (
 	noWritableRootHint = "rm: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)\n"
 )
 
+// hasWritableRoot reports whether the sandbox has at least one AllowedPaths
+// root configured with :rw access. callCtx.Remove being non-nil only means a
+// sandbox exists, not that it grants any writable root, since AllowedPaths
+// wires the sandbox even for an empty list or read-only-only entries.
+func hasWritableRoot(callCtx *builtins.CallContext) bool {
+	if callCtx.AllowedPathsList == nil {
+		return false
+	}
+	for _, p := range callCtx.AllowedPathsList() {
+		if p.Access == builtins.AllowedPathReadWrite {
+			return true
+		}
+	}
+	return false
+}
+
 func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	// --help/--verbose use RegisterNoArgBool rather than fs.BoolP so that
 	// an explicit value (rm --verbose=false file, rm --help=false file) is
@@ -100,16 +116,19 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// Capability check before everything else — including --help — so that
 		// rm --help behaves the same as invoking a disallowed command: it
 		// fails immediately without showing help text.
-		if callCtx.Remove == nil {
-			// Distinguish "not in remediation mode" (the dispatch gate
-			// normally catches this first) from "remediation mode is on but
-			// no writable sandbox root exists", which would otherwise send
-			// the operator to fix the wrong thing.
-			if callCtx.RemediationMode {
-				callCtx.Errf("%s", noWritableRootHint)
-			} else {
-				callCtx.Errf("%s", readOnlyMessage)
-			}
+		//
+		// callCtx.Remove is wired whenever remediation mode is on and any
+		// AllowedPaths option was configured at all — even an explicit empty
+		// list or read-only-only roots — so a nil check alone cannot detect
+		// "remediation mode is on but no writable root exists". Check
+		// AllowedPathsList directly so that case gets the same guidance
+		// instead of falling through to a per-file "permission denied".
+		if !callCtx.RemediationMode {
+			callCtx.Errf("%s", readOnlyMessage)
+			return builtins.Result{Code: 1}
+		}
+		if callCtx.Remove == nil || !hasWritableRoot(callCtx) {
+			callCtx.Errf("%s", noWritableRootHint)
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/systemctl/systemctl.go
+++ b/builtins/systemctl/systemctl.go
@@ -34,7 +34,12 @@ var Cmd = builtins.Command{
 	Description:     "inspect and control explicitly authorized systemd units",
 	MakeFlags:       makeFlags,
 	RemediationOnly: true,
+	// The dispatch gate in interp emits this before flag parsing; the
+	// in-handler check below repeats it as defence in depth.
+	RemediationDeniedMessage: readOnlyMessage,
 }
+
+const readOnlyMessage = "systemctl: remediation mode required\n"
 
 type flags struct {
 	all       *bool
@@ -63,7 +68,7 @@ func (options flags) run(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// inspection and help behind the same mode boundary as mutations, before
 		// consulting grants or touching the manager.
 		if !callCtx.RemediationMode {
-			callCtx.Errf("systemctl: remediation mode required\n")
+			callCtx.Errf("%s", readOnlyMessage)
 			return builtins.Result{Code: 1}
 		}
 		if *options.help {

--- a/builtins/truncate/truncate.go
+++ b/builtins/truncate/truncate.go
@@ -104,6 +104,22 @@ var errInvalidSize = sizeparse.ErrInvalid
 // can hint that these forms are intentionally not supported.
 var errRelativeSize = sizeparse.ErrRelative
 
+// hasWritableRoot reports whether the sandbox has at least one AllowedPaths
+// root configured with :rw access. callCtx.Truncate being non-nil only means
+// a sandbox exists, not that it grants any writable root, since AllowedPaths
+// wires the sandbox even for an empty list or read-only-only entries.
+func hasWritableRoot(callCtx *builtins.CallContext) bool {
+	if callCtx.AllowedPathsList == nil {
+		return false
+	}
+	for _, p := range callCtx.AllowedPathsList() {
+		if p.Access == builtins.AllowedPathReadWrite {
+			return true
+		}
+	}
+	return false
+}
+
 func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 	help := fs.BoolP("help", "h", false, "print usage and exit")
 	sizeStr := fs.StringP("size", "s", "", "set file size to SIZE bytes")
@@ -113,14 +129,19 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// Capability check before everything else — including --help — so that
 		// truncate --help behaves the same as invoking a disallowed command:
 		// it fails immediately without showing help text.
-		if callCtx.Truncate == nil {
-			// Remediation mode with no sandbox root is a configuration gap,
-			// not a mode problem — say so rather than blaming the mode.
-			if callCtx.RemediationMode {
-				callCtx.Errf("%s", noWritableRootHint)
-			} else {
-				callCtx.Errf("%s", readOnlyMessage)
-			}
+		//
+		// callCtx.Truncate is wired whenever remediation mode is on and any
+		// AllowedPaths option was configured at all — even an explicit empty
+		// list or read-only-only roots — so a nil check alone cannot detect
+		// "remediation mode is on but no writable root exists". Check
+		// AllowedPathsList directly so that case gets the same guidance
+		// instead of falling through to a per-file "permission denied".
+		if !callCtx.RemediationMode {
+			callCtx.Errf("%s", readOnlyMessage)
+			return builtins.Result{Code: 1}
+		}
+		if callCtx.Truncate == nil || !hasWritableRoot(callCtx) {
+			callCtx.Errf("%s", noWritableRootHint)
 			return builtins.Result{Code: 1}
 		}
 

--- a/builtins/truncate/truncate.go
+++ b/builtins/truncate/truncate.go
@@ -84,7 +84,16 @@ var Cmd = builtins.Command{
 	Description:     "shrink or extend file size",
 	MakeFlags:       registerFlags,
 	RemediationOnly: true,
+	// Preserve the historical read-only refusal wording; the dispatch gate
+	// in interp emits this before flag parsing, and the in-handler check
+	// repeats it as defence in depth.
+	RemediationDeniedMessage: readOnlyMessage,
 }
+
+const (
+	readOnlyMessage    = "truncate: filesystem capability not available (remediation mode required)\n"
+	noWritableRootHint = "truncate: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)\n"
+)
 
 // errInvalidSize is returned by parseSize for any non-numeric, malformed,
 // or out-of-range input.
@@ -105,7 +114,13 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 		// truncate --help behaves the same as invoking a disallowed command:
 		// it fails immediately without showing help text.
 		if callCtx.Truncate == nil {
-			callCtx.Errf("truncate: filesystem capability not available (remediation mode required)\n")
+			// Remediation mode with no sandbox root is a configuration gap,
+			// not a mode problem — say so rather than blaming the mode.
+			if callCtx.RemediationMode {
+				callCtx.Errf("%s", noWritableRootHint)
+			} else {
+				callCtx.Errf("%s", readOnlyMessage)
+			}
 			return builtins.Result{Code: 1}
 		}
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -50,6 +50,27 @@ Every command MUST register `-h` / `--help` as a flag. When `--help` is passed:
 
 Do not write help output to stderr. Help is not an error.
 
+### Remediation-Only Commands
+
+A builtin that must not run outside remediation mode MUST set
+`RemediationOnly: true` on its `builtins.Command`. The interpreter enforces the
+flag at dispatch, before the handler runs and therefore before flag parsing, so
+`--help` is refused exactly like any other invocation. The refusal text comes
+from `RemediationDeniedMessage` (defaulting to `<name>: remediation mode
+required`).
+
+Commands MUST additionally keep their own equivalent check inside the handler.
+Two layers are intentional: the dispatch gate covers a builtin that forgets its
+check, and the in-handler check keeps the builtin correct when called outside
+the interpreter. `TestRemediationOnlyBuiltinsRefusedInReadOnlyMode` iterates
+the registry, so a new remediation-only builtin is covered automatically.
+
+When a remediation capability closure (`Remove`, `Truncate`,
+`TruncateToZeroIfAtLeast`) is nil *while* `CallContext.RemediationMode` is
+true, the cause is a missing writable `AllowedPaths` root, not the mode.
+Commands MUST distinguish the two cases so the operator is not sent to fix the
+wrong thing.
+
 ### File Access — Safe Wrappers Only
 
 Builtins MUST access the filesystem exclusively through the narrow, sandboxed

--- a/interp/remediation_only_dispatch_test.go
+++ b/interp/remediation_only_dispatch_test.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package interp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/rshell/builtins"
+)
+
+// newReadOnlyRunner creates a runner in the default read-only mode with dir
+// configured read-write in AllowedPaths and every command allowed. The
+// read-write root is deliberate: it proves the refusal comes from the mode
+// gate, not from a missing sandbox root.
+func newReadOnlyRunner(t *testing.T, dir string) (*Runner, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	r, err := New(
+		allowAllCommandsOpt(),
+		StdIO(nil, &stdout, &stderr),
+		AllowedPaths([]string{dir + ":rw"}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	r.Dir = dir
+	return r, &stdout, &stderr
+}
+
+// remediationOnlyNames returns every registered builtin whose metadata marks
+// it remediation-only.
+func remediationOnlyNames(t *testing.T) []string {
+	t.Helper()
+	// Builtin registration is lazy (registerOnce, driven by New); force it so
+	// the registry is populated even if no runner has been built yet.
+	registerBuiltins()
+	var names []string
+	for _, name := range builtins.Names() {
+		meta, ok := builtins.Meta(name)
+		require.True(t, ok, "no metadata registered for builtin %q", name)
+		if meta.RemediationOnly {
+			names = append(names, name)
+		}
+	}
+	require.NotEmpty(t, names, "expected at least one remediation-only builtin")
+	return names
+}
+
+// TestRemediationOnlyBuiltinsRefusedInReadOnlyMode iterates the builtin
+// registry and asserts that every command flagged RemediationOnly is refused
+// when the shell runs in read-only mode. This is what makes the flag
+// load-bearing: a future remediation-only builtin that forgets its own
+// capability check is still refused by the dispatch gate, and this test fails
+// if that gate ever stops firing.
+func TestRemediationOnlyBuiltinsRefusedInReadOnlyMode(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range remediationOnlyNames(t) {
+		t.Run(name, func(t *testing.T) {
+			// Bare invocation and --help must behave identically: the
+			// refusal happens before flag parsing, so no usage text leaks.
+			for _, script := range []string{name, name + " --help"} {
+				r, stdout, stderr := newReadOnlyRunner(t, dir)
+				// A non-zero exit surfaces as an error from Run; the exit
+				// code itself is asserted below.
+				_ = r.Run(context.Background(), parseScript(t, script))
+
+				assert.Equal(t, uint8(1), r.exit.code, "script %q should exit 1", script)
+				assert.Empty(t, stdout.String(), "script %q must not print help or other stdout", script)
+				assert.NotEmpty(t, stderr.String(), "script %q must explain the refusal on stderr", script)
+				assert.True(t, strings.HasPrefix(stderr.String(), name+": "),
+					"script %q stderr %q should be prefixed with the command name", script, stderr.String())
+				assert.Contains(t, strings.ToLower(stderr.String()), "remediation mode",
+					"script %q stderr %q should point at remediation mode", script, stderr.String())
+			}
+		})
+	}
+}
+
+// TestRemediationOnlyRefusalUsesRegisteredMessage verifies the dispatch gate
+// reproduces each command's own refusal wording byte-for-byte, so adding the
+// gate did not change any user-visible message.
+func TestRemediationOnlyRefusalUsesRegisteredMessage(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range remediationOnlyNames(t) {
+		meta, ok := builtins.Meta(name)
+		require.True(t, ok)
+		require.NotEmpty(t, meta.RemediationDeniedMessage,
+			"remediation-only builtin %q must carry a refusal message", name)
+
+		r, _, stderr := newReadOnlyRunner(t, dir)
+		_ = r.Run(context.Background(), parseScript(t, name))
+		assert.Equal(t, meta.RemediationDeniedMessage, stderr.String())
+	}
+}
+
+// TestRemediationOnlyBuiltinsAllowedInRemediationMode is the negative control:
+// the gate must not fire when remediation mode is on. The commands may still
+// fail for their own reasons (missing operands, unavailable systemd), but they
+// must not be refused with the read-only message.
+func TestRemediationOnlyBuiltinsAllowedInRemediationMode(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range remediationOnlyNames(t) {
+		t.Run(name, func(t *testing.T) {
+			meta, ok := builtins.Meta(name)
+			require.True(t, ok)
+
+			r, _, stderr := newRemediationRunner(t, dir)
+			_ = r.Run(context.Background(), parseScript(t, name+" --help"))
+			assert.NotEqual(t, meta.RemediationDeniedMessage, stderr.String(),
+				"%s must not be refused in remediation mode", name)
+		})
+	}
+}
+
+// TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck registers a
+// remediation-only builtin that deliberately performs no gating of its own —
+// the mistake a future contributor could make — and proves the dispatch gate
+// refuses it anyway, before the handler runs.
+func TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck(t *testing.T) {
+	registerBuiltins()
+	const name = "interptestremediationonly"
+
+	var ran bool
+	builtins.Command{
+		Name:        name,
+		Description: "test-only builtin that forgets its own remediation check",
+		MakeFlags: builtins.NoFlags(func(_ context.Context, callCtx *builtins.CallContext, _ []string) builtins.Result {
+			ran = true
+			callCtx.Out("should never run\n")
+			return builtins.Result{}
+		}),
+		RemediationOnly: true,
+	}.Register()
+
+	dir := t.TempDir()
+	r, stdout, stderr := newReadOnlyRunner(t, dir)
+	_ = r.Run(context.Background(), parseScript(t, name))
+
+	assert.False(t, ran, "handler must not be reached in read-only mode")
+	assert.Equal(t, uint8(1), r.exit.code)
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, builtins.DefaultRemediationDeniedMessage(name), stderr.String())
+}
+
+// TestRemediationDeniedMessageOnlySetForRemediationOnly guards the metadata
+// invariant in the other direction: a refusal message on a command that is not
+// remediation-only would be dead configuration.
+func TestRemediationDeniedMessageOnlySetForRemediationOnly(t *testing.T) {
+	for _, name := range builtins.Names() {
+		meta, ok := builtins.Meta(name)
+		require.True(t, ok)
+		if meta.RemediationOnly {
+			assert.True(t, strings.HasSuffix(meta.RemediationDeniedMessage, "\n"),
+				"%s refusal message must end with a newline", name)
+			continue
+		}
+		assert.Empty(t, meta.RemediationDeniedMessage,
+			"%s is not remediation-only but declares a refusal message", name)
+	}
+}

--- a/interp/remediation_only_dispatch_test.go
+++ b/interp/remediation_only_dispatch_test.go
@@ -8,7 +8,9 @@ package interp
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,13 +122,21 @@ func TestRemediationOnlyBuiltinsAllowedInRemediationMode(t *testing.T) {
 	}
 }
 
+// remediationOnlyGateTestSeq makes each
+// TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck invocation register a
+// distinct builtin name, since the process-wide registry panics on a
+// duplicate name and never forgets one: without this, running the test more
+// than once in the same binary (e.g. `-count=2` or a shuffled/stress rerun)
+// would panic on the second registration.
+var remediationOnlyGateTestSeq atomic.Int64
+
 // TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck registers a
 // remediation-only builtin that deliberately performs no gating of its own —
 // the mistake a future contributor could make — and proves the dispatch gate
 // refuses it anyway, before the handler runs.
 func TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck(t *testing.T) {
 	registerBuiltins()
-	const name = "interptestremediationonly"
+	name := fmt.Sprintf("interptestremediationonly%d", remediationOnlyGateTestSeq.Add(1))
 
 	var ran bool
 	builtins.Command{

--- a/interp/remediation_only_dispatch_test.go
+++ b/interp/remediation_only_dispatch_test.go
@@ -160,6 +160,36 @@ func TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck(t *testing.T) {
 	assert.Equal(t, builtins.DefaultRemediationDeniedMessage(name), stderr.String())
 }
 
+// TestRemediationOnlyGateCatchesHelpDispatch is the `help <name>` counterpart
+// to TestRemediationOnlyGateCatchesBuiltinWithoutOwnCheck: help.go looks up
+// and invokes a builtin's handler directly (to capture its --help output),
+// bypassing the interp dispatch gate entirely. A remediation-only builtin
+// that forgets its own check must still be refused when reached this way.
+func TestRemediationOnlyGateCatchesHelpDispatch(t *testing.T) {
+	registerBuiltins()
+	name := fmt.Sprintf("interptestremediationonlyhelp%d", remediationOnlyGateTestSeq.Add(1))
+
+	var ran bool
+	builtins.Command{
+		Name:        name,
+		Description: "test-only builtin that forgets its own remediation check",
+		MakeFlags: builtins.NoFlags(func(_ context.Context, callCtx *builtins.CallContext, _ []string) builtins.Result {
+			ran = true
+			callCtx.Out("should never run\n")
+			return builtins.Result{}
+		}),
+		RemediationOnly: true,
+	}.Register()
+
+	dir := t.TempDir()
+	r, stdout, stderr := newReadOnlyRunner(t, dir)
+	_ = r.Run(context.Background(), parseScript(t, "help "+name))
+
+	assert.False(t, ran, "handler must not be reached via help in read-only mode")
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, builtins.DefaultRemediationDeniedMessage(name), stderr.String())
+}
+
 // TestRemediationDeniedMessageOnlySetForRemediationOnly guards the metadata
 // invariant in the other direction: a refusal message on a command that is not
 // remediation-only would be dead configuration.

--- a/interp/runner_exec.go
+++ b/interp/runner_exec.go
@@ -572,6 +572,30 @@ func commandFlags(args []string) []string {
 	return flags
 }
 
+// remediationOnlyRefusal reports whether dispatching the named builtin must be
+// refused because it is registered as RemediationOnly while the shell runs in
+// read-only mode, and returns the stderr text to write when it must.
+//
+// Builtins carry their own equivalent check; this dispatch-level gate is
+// defence in depth that applies uniformly to every registered command,
+// including ones added later that forget to gate themselves. The message comes
+// from the command's metadata so the refusal text stays identical to the one
+// the builtin would have printed.
+func remediationOnlyRefusal(name string, remediationMode bool) (string, bool) {
+	if remediationMode {
+		return "", false
+	}
+	meta, ok := builtins.Meta(name)
+	if !ok || !meta.RemediationOnly {
+		return "", false
+	}
+	msg := meta.RemediationDeniedMessage
+	if msg == "" {
+		msg = builtins.DefaultRemediationDeniedMessage(name)
+	}
+	return msg, true
+}
+
 func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	name := args[0]
 	r.totalCount++
@@ -629,6 +653,17 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 	}
 
 	if isKnown {
+		// Enforce builtins.Command.RemediationOnly at dispatch, before the
+		// handler runs and therefore before flag parsing, so --help is
+		// refused exactly like any other invocation. Builtins repeat this
+		// check themselves; this gate is the layer that makes the flag
+		// load-bearing for a future builtin that forgets to.
+		if msg, denied := remediationOnlyRefusal(name, r.remediationMode); denied {
+			r.errf("%s", msg)
+			r.exit.code = 1
+			return
+		}
+
 		r.dispatchedCount++
 		var runCmdWithStdin func(context.Context, string, string, []string, io.Reader) (uint8, error)
 		runCmdWithStdin = func(ctx context.Context, dir string, cmdName string, cmdArgs []string, childStdin io.Reader) (uint8, error) {
@@ -638,6 +673,15 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 			cmdFn, ok := builtins.Lookup(cmdName)
 			if !ok {
 				return 127, fmt.Errorf("rshell: %s: unknown command", cmdName)
+			}
+			// Same remediation gate as the top-level dispatch above, applied
+			// to grandchildren spawned by find -exec / -execdir / xargs.
+			// Write to the same stderr the builtin's own check would have
+			// used and return its exit code, so the refusal is byte-for-byte
+			// what it was before the gate existed.
+			if msg, denied := remediationOnlyRefusal(cmdName, r.remediationMode); denied {
+				r.errf("%s", msg)
+				return 1, nil
 			}
 			child := &builtins.CallContext{
 				Stdout:  r.stdout,

--- a/tests/scenarios/cmd/help/allowed_paths_remediation_no_rw.yaml
+++ b/tests/scenarios/cmd/help/allowed_paths_remediation_no_rw.yaml
@@ -1,0 +1,20 @@
+description: In remediation mode with only read-only AllowedPaths, help says no read-write root is configured so remediation commands cannot write. Uses stdout_contains because the absolute paths resolve to the scenario tempdir.
+skip_assert_against_bash: true
+setup:
+  files:
+    - path: read-only/input.txt
+      content: |+
+        ro
+input:
+  mode: "remediation"
+  allowed_paths: ["read-only:ro"]
+  script: |+
+    help
+expect:
+  stdout_contains:
+    - "Allowed paths:"
+    - "Read-only:"
+    - "read-only"
+    - "(no read-write path configured — remediation commands cannot modify any file)"
+  stderr: |+
+  exit_code: 0

--- a/tests/scenarios/cmd/help/dynamic_dispatch_exit_code.yaml
+++ b/tests/scenarios/cmd/help/dynamic_dispatch_exit_code.yaml
@@ -1,11 +1,11 @@
-description: help always returns exit code 0 for `help <cmd>` even when the dispatched command's own --help handler would have exited 1 outside remediation mode — pinning current behavior of help.go's dynamic dispatch branch, which discards the nested handler's Result and always returns Result{}.
+description: help systemctl returns exit code 1 outside remediation mode — the RemediationOnly dispatch gate in help.go fires before the dynamic-dispatch branch that would otherwise discard the nested handler's Result and always return Result{}.
 skip_assert_against_bash: true
 input:
   script: |+
     help systemctl; echo $?
 expect:
-  stdout_contains:
-    - "systemctl: remediation mode required"
-    - "0"
+  stdout: |+
+    1
   stderr: |+
+    systemctl: remediation mode required
   exit_code: 0

--- a/tests/scenarios/cmd/help/dynamic_dispatch_remediation_gating.yaml
+++ b/tests/scenarios/cmd/help/dynamic_dispatch_remediation_gating.yaml
@@ -1,10 +1,10 @@
-description: help systemctl dispatches into systemctl's own remediation-mode gate — read-only mode returns the gate's refusal text (no manager access), remediation mode returns real usage text.
+description: help systemctl is refused by the same RemediationOnly dispatch gate as direct invocation, before systemctl's own handler ever runs — read-only mode returns the gate's refusal text on stderr with exit code 1, remediation mode returns real usage text.
 skip_assert_against_bash: true
 input:
   script: |+
     help systemctl
 expect:
-  stdout_contains:
-    - "systemctl: remediation mode required"
+  stdout: |+
   stderr: |+
-  exit_code: 0
+    systemctl: remediation mode required
+  exit_code: 1

--- a/tests/scenarios/cmd/logrotate/errors/remediation_no_writable_path.yaml
+++ b/tests/scenarios/cmd/logrotate/errors/remediation_no_writable_path.yaml
@@ -1,0 +1,12 @@
+# skip: rshell logrotate is a remediation-only truncation helper, not system logrotate.
+skip_assert_against_bash: true
+description: logrotate in remediation mode with no AllowedPaths configured blames the missing writable root, not the mode.
+input:
+  mode: "remediation"
+  script: |+
+    logrotate --force app.log
+expect:
+  stdout: |+
+  stderr: |+
+    logrotate: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)
+  exit_code: 1

--- a/tests/scenarios/cmd/rm/errors/remediation_no_writable_path.yaml
+++ b/tests/scenarios/cmd/rm/errors/remediation_no_writable_path.yaml
@@ -1,0 +1,11 @@
+description: rm in remediation mode with no AllowedPaths configured blames the missing writable root, not the mode.
+input:
+  mode: "remediation"
+  script: |+
+    rm f.txt
+expect:
+  stdout: |+
+  stderr: |+
+    rm: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)
+  exit_code: 1
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/rm/errors/remediation_readonly_root_no_writable_path.yaml
+++ b/tests/scenarios/cmd/rm/errors/remediation_readonly_root_no_writable_path.yaml
@@ -1,0 +1,16 @@
+description: rm in remediation mode with only a :ro AllowedPaths root blames the missing writable root, not a per-file permission error — the sandbox exists (Remove is wired) but grants no :rw entry.
+setup:
+  files:
+    - path: file.txt
+      content: "data\n"
+input:
+  allowed_paths: ["$DIR:ro"]
+  mode: "remediation"
+  script: |+
+    rm file.txt
+expect:
+  stdout: |+
+  stderr: |+
+    rm: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)
+  exit_code: 1
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/truncate/errors/remediation_no_writable_path.yaml
+++ b/tests/scenarios/cmd/truncate/errors/remediation_no_writable_path.yaml
@@ -1,0 +1,11 @@
+description: truncate in remediation mode with no AllowedPaths configured blames the missing writable root, not the mode.
+input:
+  mode: "remediation"
+  script: |+
+    truncate -s 0 f.txt
+expect:
+  stdout: |+
+  stderr: |+
+    truncate: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)
+  exit_code: 1
+skip_assert_against_bash: true

--- a/tests/scenarios/cmd/truncate/errors/remediation_readonly_root_no_writable_path.yaml
+++ b/tests/scenarios/cmd/truncate/errors/remediation_readonly_root_no_writable_path.yaml
@@ -1,0 +1,16 @@
+description: truncate in remediation mode with only a :ro AllowedPaths root blames the missing writable root, not a per-file permission error — the sandbox exists (Truncate is wired) but grants no :rw entry.
+setup:
+  files:
+    - path: f.txt
+      content: "data\n"
+input:
+  allowed_paths: ["$DIR:ro"]
+  mode: "remediation"
+  script: |+
+    truncate -s 0 f.txt
+expect:
+  stdout: |+
+  stderr: |+
+    truncate: no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)
+  exit_code: 1
+skip_assert_against_bash: true


### PR DESCRIPTION
`builtins.Command.RemediationOnly` looked like an access-control flag but was only read by `help`'s listing filter — each remediation-only builtin re-implemented its own gate. A future builtin that set the flag and forgot its own check would have run in read-only mode with no test catching it.

- Enforce the flag in `interp` at both builtin dispatch sites (top-level and the `find -exec` / `xargs` child path), before the handler runs and therefore before flag parsing, so `--help` is refused like any other invocation.
- The refusal text comes from command metadata (`RemediationDeniedMessage`), so every existing read-only rejection message and exit code is unchanged byte-for-byte. The per-builtin checks stay as defence in depth.
- Fix a misleading error: in remediation mode with no `AllowedPaths`, `rm`/`truncate`/`logrotate` blamed the mode. They now say `no writable path is configured (remediation mode requires an AllowedPaths entry with :rw)`, and `help`'s Allowed paths footer notes when remediation mode has no read-write root.
- New registry-iteration test in `interp` covers every current and future remediation-only builtin, including one registered deliberately without its own check.

Tests: `go test ./...` passes; `RSHELL_BASH_TEST=1 go test ./tests/ -run TestShellScenariosAgainstBash` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)