### PR TITLE
fix(rm): clear NoOptDefVal sentinel before printing help

### DIFF
--- a/builtins/rm/rm.go
+++ b/builtins/rm/rm.go
@@ -101,6 +101,23 @@ func registerFlags(fs *builtins.FlagSet) builtins.HandlerFunc {
 			callCtx.Out("Remove each FILE. Directories are never removed.\n")
 			callCtx.Out("Symlinks are removed without following them.\n")
 			callCtx.Outf("At most %d files may be removed per invocation.\n\n", MaxRemoveFiles)
+
+			// RegisterNoArgBool uses an unforgeable NUL sentinel for bare
+			// flags. Clear it while rendering defaults so help output
+			// contains no NUL byte.
+			var saved []*builtins.Flag
+			fs.VisitAll(func(flag *builtins.Flag) {
+				if flag.NoOptDefVal == flagparser.NoArgSentinel {
+					saved = append(saved, flag)
+					flag.NoOptDefVal = ""
+				}
+			})
+			defer func() {
+				for _, flag := range saved {
+					flag.NoOptDefVal = flagparser.NoArgSentinel
+				}
+			}()
+
 			fs.SetOutput(callCtx.Stdout)
 			fs.PrintDefaults()
 			return builtins.Result{}

--- a/builtins/tests/rm/rm_test.go
+++ b/builtins/tests/rm/rm_test.go
@@ -8,6 +8,7 @@ package rm_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,6 +91,18 @@ func TestRmHelp(t *testing.T) {
 	assert.Equal(t, 0, code)
 	assert.Contains(t, stdout, "Usage: rm")
 	assert.Contains(t, stdout, "--verbose")
+}
+
+// --help must not leak the RegisterNoArgBool NUL sentinel into pflag's
+// PrintDefaults output. Without clearing NoOptDefVal first, pflag renders
+// bare no-arg bools as "--verbose[=<NUL>]" since their NoOptDefVal is
+// non-empty and not the literal string "true".
+func TestRmHelpContainsNoNulByte(t *testing.T) {
+	dir := t.TempDir()
+	stdout, stderr, code := rmRun(t, "rm --help", dir)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stderr)
+	assert.False(t, strings.ContainsRune(stdout, '\x00'), "help output must not contain a NUL byte: %q", stdout)
 }
 
 func TestRmHelpReadOnlyModeFails(t *testing.T) {


### PR DESCRIPTION
## Summary
- `rm --help` was leaking a raw NUL byte into its output for `--help`/`--verbose`, because `RegisterNoArgBool`'s NUL sentinel (`NoOptDefVal`) wasn't cleared before `fs.PrintDefaults()` — pflag only suppresses inline rendering of `NoOptDefVal` for bool flags when it equals `"true"`.
- Applies the same fix pattern already used in `stat.go`/`df.go` and just landed in `logrotate.go` (PR #593 review comment): clear the sentinel on matching flags via `fs.VisitAll` right before printing defaults, then restore it via `defer`.

## Test plan
- [x] Added `TestRmHelpContainsNoNulByte`, verified it fails against the pre-fix code (via `git stash`) and passes with the fix
- [x] `make fmt` (clean)
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./builtins/tests/rm/...`
- [x] `cmd/rm/*` scenario tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)