### PR TITLE
Add rshell security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+This document outlines the security policy for rshell and what to do if you discover a security vulnerability in the project.
+Please do not share vulnerability details in a public forum, including GitHub discussions, issues, or pull requests.
+Report them privately so Datadog can investigate, coordinate remediation, and publish details after an appropriate disclosure period.
+
+## Supported Versions
+
+Datadog recommends using the latest released version of rshell.
+Security advisories for rshell identify affected versions and patched versions when a vulnerability is disclosed.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in rshell, or any Datadog product, please submit details to the following email address:
+
+* [security@datadoghq.com](mailto:security@datadoghq.com)
+
+Please include the affected rshell version or commit, reproduction steps, expected impact, and any relevant proof-of-concept details.
+
+## Public Advisories
+
+Datadog follows a coordinated disclosure process for confirmed vulnerabilities.
+When public disclosure is appropriate, Datadog publishes a GitHub Security Advisory for this repository so users can find vulnerability history from the repository's Security tab.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"8c190bfa-3ea2-47bc-8e0f-495ef79c3e4b","source":"chat","resourceId":"ef0d5f41-631e-4575-bac4-d2afd8d522cb","workflowId":"082ca975-7948-4d9b-a8b5-f78227f5625d","codeChangeId":"082ca975-7948-4d9b-a8b5-f78227f5625d","sourceType":"slack"} -->
### What does this PR do?

Adds SECURITY.md with Datadog's private vulnerability reporting path for rshell and explains where public advisories are published after coordinated disclosure.

### Motivation

rshell is a customer-installable artifact, so reporters need a clear, private process for vulnerability reports rather than sharing details in public issues, discussions, or pull requests. The policy follows the same preferred pattern used by dd-trace-go: report vulnerabilities to security@datadoghq.com and use GitHub Security Advisories for public disclosure history when appropriate.

### Testing

- Ran `make fmt`.
- Ran `git diff --check`.
- Verified SECURITY.md includes the private reporting address, public-disclosure warning, supported-version guidance, and GitHub Security Advisory publication note.

### Changes

- Added root SECURITY.md.
- Directed vulnerability reports to security@datadoghq.com.
- Documented that public vulnerability history is published through GitHub Security Advisories when appropriate.

### Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ef0d5f41-631e-4575-bac4-d2afd8d522cb)

Comment @datadog to request changes