### PR TITLE
fix(privileged-helper): normalize overlapping path modes

### DIFF
--- a/privilegedhelper/verify.go
+++ b/privilegedhelper/verify.go
@@ -314,8 +314,11 @@ func intersectPaths(requested, configured []string) []string {
 	return result
 }
 
-// normalizeEffectivePaths merges duplicate paths, preferring read-write.
-// Parent and child paths remain distinct for Landlock validation.
+// normalizeEffectivePaths merges duplicate paths, preferring read-write:
+// ["/:ro", "/:rw"] and ["/:rw", "/:ro"] both become ["/:rw"].
+// Parent and child paths remain distinct. Landlock rejects
+// ["/tmp:rw", "/tmp/readonly:ro"] because its additive grants cannot make a
+// child read-only beneath a writable parent.
 func normalizeEffectivePaths(values []string) []string {
 	if values == nil {
 		return nil

--- a/privilegedhelper/verify.go
+++ b/privilegedhelper/verify.go
@@ -138,10 +138,7 @@ func (c *Credential) Verify(req ExecuteRequest, now time.Time) (*VerifiedCommand
 		effectiveAllowedSystemServices = intersectSystemServices(signedAllowedSystemServices, c.AllowedSystemServices)
 		effectiveElevatableCommands = intersectExact(inputs.ElevatableCommands, c.ElevatableCommands)
 	}
-	// Landlock grants are additive, so duplicate entries for the same path
-	// cannot retain separate read-only and read-write permissions. Collapse the
-	// final, authorized policy so a read-write grant wins only after any local
-	// policy intersection has been applied.
+	// Collapse duplicate paths after authorization because Landlock grants are additive.
 	effectiveAllowedPaths = normalizeEffectivePaths(effectiveAllowedPaths)
 	return &VerifiedCommand{
 		TaskID: task.GetTaskId(), Command: inputs.Command, Mode: mode,
@@ -317,10 +314,8 @@ func intersectPaths(requested, configured []string) []string {
 	return result
 }
 
-// normalizeEffectivePaths collapses duplicate normalized paths while
-// preserving their first-seen order. Distinct ancestor and descendant paths
-// remain separate so the Landlock layer can reject an unrepresentable
-// read-only path beneath a read-write path.
+// normalizeEffectivePaths merges duplicate paths, preferring read-write.
+// Parent and child paths remain distinct for Landlock validation.
 func normalizeEffectivePaths(values []string) []string {
 	if values == nil {
 		return nil
@@ -330,8 +325,7 @@ func normalizeEffectivePaths(values []string) []string {
 	for _, value := range values {
 		policy := parsePathPolicy(value)
 		if !path.IsAbs(policy.value) {
-			// Preserve malformed entries for the sandbox's fail-closed
-			// validation and diagnostics.
+			// Preserve invalid paths for fail-closed sandbox validation.
 			result = append(result, value)
 			continue
 		}

--- a/privilegedhelper/verify.go
+++ b/privilegedhelper/verify.go
@@ -138,6 +138,11 @@ func (c *Credential) Verify(req ExecuteRequest, now time.Time) (*VerifiedCommand
 		effectiveAllowedSystemServices = intersectSystemServices(signedAllowedSystemServices, c.AllowedSystemServices)
 		effectiveElevatableCommands = intersectExact(inputs.ElevatableCommands, c.ElevatableCommands)
 	}
+	// Landlock grants are additive, so duplicate entries for the same path
+	// cannot retain separate read-only and read-write permissions. Collapse the
+	// final, authorized policy so a read-write grant wins only after any local
+	// policy intersection has been applied.
+	effectiveAllowedPaths = normalizeEffectivePaths(effectiveAllowedPaths)
 	return &VerifiedCommand{
 		TaskID: task.GetTaskId(), Command: inputs.Command, Mode: mode,
 		AllowedCommands:       effectiveAllowedCommands,
@@ -307,6 +312,37 @@ func intersectPaths(requested, configured []string) []string {
 				// shadowing the mutually authorized write grant.
 				result[existing] = narrower
 			}
+		}
+	}
+	return result
+}
+
+// normalizeEffectivePaths collapses duplicate normalized paths while
+// preserving their first-seen order. Distinct ancestor and descendant paths
+// remain separate so the Landlock layer can reject an unrepresentable
+// read-only path beneath a read-write path.
+func normalizeEffectivePaths(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	indexes := make(map[string]int, len(values))
+	for _, value := range values {
+		policy := parsePathPolicy(value)
+		if !path.IsAbs(policy.value) {
+			// Preserve malformed entries for the sandbox's fail-closed
+			// validation and diagnostics.
+			result = append(result, value)
+			continue
+		}
+		index, exists := indexes[policy.value]
+		if !exists {
+			indexes[policy.value] = len(result)
+			result = append(result, value)
+			continue
+		}
+		if policy.readWrite {
+			result[index] = value
 		}
 	}
 	return result

--- a/privilegedhelper/verify_test.go
+++ b/privilegedhelper/verify_test.go
@@ -115,6 +115,21 @@ func TestRequestCredentialUsesSignedBackendPolicy(t *testing.T) {
 	require.Equal(t, []string{"rshell:truncate"}, verified.ElevatableCommands)
 }
 
+func TestRequestCredentialNormalizesSignedBackendAllowedPaths(t *testing.T) {
+	_, private := testCredential(t)
+	credential, err := NewRequestCredential([]CredentialKey{socketCredentialKey(t, private)})
+	require.NoError(t, err)
+
+	verified, err := credential.Verify(signedRequest(t, private, func(task *PrivateActionTask) {
+		task.GetSystemInputs().GetRemoteAction().AllowedPaths = []string{"/:ro", "/:rw"}
+	}), time.Now())
+	require.NoError(t, err)
+	require.True(t, credential.trustBackendPolicy)
+	require.Equal(t, []string{"/:rw"}, verified.AllowedPaths)
+	require.Equal(t, []string{"/:ro", "/:rw"}, verified.authorization.Signed.AllowedPaths)
+	require.Equal(t, []string{"/:rw"}, verified.authorization.Effective.AllowedPaths)
+}
+
 func TestServerWithoutCredentialUsesBareRequestKey(t *testing.T) {
 	_, private := testCredential(t)
 	executor := &testExecutor{}
@@ -195,6 +210,21 @@ func TestIntersectPathsCollapsesDuplicateModes(t *testing.T) {
 	require.Equal(t,
 		[]string{"/var/log:rw"},
 		intersectPaths([]string{"/:rw", "/:ro"}, []string{"/var/log:rw"}),
+	)
+}
+
+func TestNormalizeEffectivePaths(t *testing.T) {
+	require.Equal(t,
+		[]string{"/:rw"},
+		normalizeEffectivePaths([]string{"/:ro", "/:rw"}),
+	)
+	require.Equal(t,
+		[]string{"/:rw"},
+		normalizeEffectivePaths([]string{"/:rw", "/:ro"}),
+	)
+	require.Equal(t,
+		[]string{"/tmp:rw", "/tmp/readonly:ro"},
+		normalizeEffectivePaths([]string{"/tmp:rw", "/tmp/readonly:ro"}),
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?
Consider an EP with the following config:
```
/:ro
/:rw
```

Both refer to /. Because Landlock permissions are additive, their actual combined permission is read-write. So now we normalize them to be:
```
  /:rw
```
  - RW wins regardless of ordering:

    ["/:ro", "/:rw"] → ["/:rw"]
    ["/:rw", "/:ro"] → ["/:rw"]

  - It only merges identical normalized paths. It does not merge parent/child paths:

    ["/tmp:rw", "/tmp/readonly:ro"]

   allowing Landlock to reject that unrepresentable configuration.

  - It runs after local intersection so RW cannot bypass local policy. An RW entry can only survive if both the signed backend policy and local helper policy permit RW.
  - Invalid paths are preserved so the sandbox rejects them with its existing fail-closed validation instead of silently dropping them.

### Motivation

<!-- Why is this change needed? Link to related issues if applicable. -->

### Testing

<!-- How was this tested? -->

### Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
