### PR TITLE
telemetry: tag run span with elevatable commands list

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -762,6 +762,7 @@ func (r *Runner) setRunOptionTags(span *telemetry.Span) {
 	}
 	sort.Strings(allowedCommands)
 	span.SetTag("rshell.run.options.allowed_commands", strings.Join(allowedCommands, ","))
+	span.SetTag("rshell.run.options.elevatable_commands", strings.Join(r.elevatableCommandsList(), ","))
 
 	allowedServices := r.allowedSystemServicesList()
 	serviceEntries := make([]string, 0, len(allowedServices))

--- a/interp/tracing_test.go
+++ b/interp/tracing_test.go
@@ -109,7 +109,7 @@ func TestRunSpanInvokedViaCLI(t *testing.T) {
 // TestRunSpanCommandAndOptions verifies that the run span records the raw
 // script text supplied via [Script], plus the effective [RunnerOption]
 // configuration (mode, timeout, proc path, host prefix, allowed paths,
-// allowed commands, and allowed system services).
+// allowed commands, elevatable commands, and allowed system services).
 func TestRunSpanCommandAndOptions(t *testing.T) {
 	tel, ct := newCapturingTelemetry(t)
 
@@ -119,6 +119,10 @@ func TestRunSpanCommandAndOptions(t *testing.T) {
 		Script(script),
 		AllowedPaths([]string{dir + ":rw"}),
 		AllowedCommands([]string{"rshell:echo"}),
+		SelectiveElevation([]string{"rshell:echo"}, func(_ context.Context, _ string, run func()) error {
+			run()
+			return nil
+		}),
 		AllowedSystemServices([]SystemServiceControlGrant{
 			{Service: "foo.service", Actions: []SystemServiceAction{SystemServiceRead}},
 		}),
@@ -146,6 +150,7 @@ func TestRunSpanCommandAndOptions(t *testing.T) {
 	assert.Equal(t, dir+":rw", runSpan.Meta["rshell.run.options.allowed_paths"])
 	assert.Equal(t, "false", runSpan.Meta["rshell.run.options.allow_all_commands"])
 	assert.Equal(t, "echo", runSpan.Meta["rshell.run.options.allowed_commands"])
+	assert.Equal(t, "echo", runSpan.Meta["rshell.run.options.elevatable_commands"])
 	assert.Equal(t, "foo.service:read", runSpan.Meta["rshell.run.options.allowed_system_services"])
 	assert.Equal(t, "false", runSpan.Meta["rshell.run.options.systemd_target_configured"])
 }


### PR DESCRIPTION
Add rshell.run.options.elevatable_commands to the run span, alongside the existing allowed_commands/allowed_system_services tags, so the SelectiveElevation configuration is observable in traces the same way other RunnerOption settings are.

### What does this PR do?

<!-- A brief description of the change. -->

### Motivation

<!-- Why is this change needed? Link to related issues if applicable. -->

### Testing

<!-- How was this tested? -->

### Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
