### PR TITLE
feat: narrow privileged execution with an unsigned Agent-supplied policy layer

### DIFF
--- a/docs/PRIVILEGED_HELPER.md
+++ b/docs/PRIVILEGED_HELPER.md
@@ -35,6 +35,44 @@ They authorize `journalctl` reads in either mode and `systemctl` or journal
 cleanup only in remediation mode. `elevatableCommands` remains a separate
 requirement when an operation needs effective UID 0.
 
+## Authorization layers
+
+The effective policy for a privileged request is the intersection of up to
+three independent layers, applied in this order: the signed backend task,
+the unsigned Agent-supplied policy carried on the request (see
+"Agent-supplied policy" below), and the optional local root-owned
+`policy.json` (see "Optional local policy" below). Any layer that is absent
+imposes no narrowing; a present layer only ever narrows what the preceding
+layers already allow.
+
+## Agent-supplied policy
+
+Every `ExecuteRequest` may carry an unsigned `agentPolicy` object alongside
+the signed envelope. This is how the Datadog Agent's Private Action Runner
+forwards its own `private_action_runner.restricted_shell.allowed_commands`,
+`allowed_paths`, and `allowed_system_services` `datadog.yaml` settings (plus
+an elevatable-commands equivalent) to the privileged path — the same
+operator settings that already narrow the non-privileged rshell path.
+
+Because `agentPolicy` is unsigned and supplied by a process the helper does
+not fully trust, it can only narrow the signed backend policy and any local
+`policy.json` — it can never grant a permission beyond what those already
+allow. A request with no `agentPolicy` at all behaves exactly as if this
+field never existed: the effective policy is signed task ∩ optional
+`policy.json`.
+
+When `agentPolicy` is present, each of its four fields
+(`allowedCommands`, `allowedPaths`, `allowedSystemServices`,
+`elevatableCommands`) is applied independently, using the same nil-vs-empty
+convention as `policy.json` and the Agent's own non-privileged operator
+settings: a field that is entirely omitted (nil) leaves that axis
+unrestricted by this layer, deferring to the signed task and `policy.json`
+unchanged; a field that is explicitly present but empty is a kill switch that
+denies every grant on that axis. This lets an operator configure only some
+`datadog.yaml` settings — for example only `allowed_commands` — without
+accidentally denying every system service or path just because those
+settings were left unset.
+
 ## Optional local policy
 
 The systemd unit optionally loads `/etc/datadog-agent-rshell/policy.json`
@@ -43,14 +81,15 @@ helper starts without a local policy. The separate administrator-controlled
 privileged-rshell opt-in remains the gate for enabling the socket and is not
 represented by this file.
 
-Without a local policy, the helper authenticates the original task envelope
-with the bare public key supplied by the Agent and uses the signed backend
-`allowedCommands`, `allowedPaths`, `system_services`, and
-`elevatableCommands` values as the effective policy. The Agent supplies that
-key only after verifying it through the Director metadata flow.
+Without a local policy, the effective policy is the signed backend task
+intersected with any Agent-supplied policy on the request; the helper
+authenticates the original task envelope with the bare public key supplied by
+the Agent, which the Agent supplies only after verifying it through the
+Director metadata flow.
 
-When present, the file is a root-owned authorization policy that narrows those
-signed backend values. Its minimal form is:
+When present, the file is a root-owned authorization policy that further
+narrows those values, beneath both the signed task and any Agent-supplied
+policy. Its minimal form is:
 
 ```json
 {
@@ -67,10 +106,14 @@ signed backend values. Its minimal form is:
 
 Service names and actions are intersected exactly; `*` retains every action
 granted by the other policy. Omitting `allowedSystemServices` from a local
-policy denies every systemd action. The Agent's ordinary
-`private_action_runner.restricted_shell.allowed_system_services` setting does
-not currently apply to privileged requests, so use this root-owned policy for
-local restrictions.
+policy denies every systemd action, matching the analogous convention for
+`agentPolicy` described above. The Agent's ordinary
+`private_action_runner.restricted_shell.allowed_system_services` setting (and
+its `allowed_commands`/`allowed_paths` counterparts) now applies to privileged
+requests too, via the Agent-supplied policy layer. `policy.json` remains
+available as an additional, root-owned layer that only ever narrows further
+beneath signed ∩ agent policy — useful when local restrictions must not be
+expressible from, or overridable by, the Agent's own configuration.
 
 The file must be written atomically by a root-owned installer or configuration
 path and must not be group- or world-writable. For compatibility, it may also
@@ -106,10 +149,13 @@ has type `TUF_DIRECTOR`.
 The helper writes one-line JSON diagnostics to standard error, which systemd
 records in the service journal. Successful verification logs the task,
 organization, runner, action, expiration, effective-permissions value, trusted
-key count, and the signed, local, and effective command, path, system-service,
-and elevation policies. Verification failures log the failure and non-secret
-key metadata plus the configured local policy. Execution completion logs only
-the task ID and exit code.
+key count, and the signed, Agent-supplied, local, and effective command,
+path, system-service, and elevation policies. A request with no
+Agent-supplied policy logs an all-empty `agent` policy, matching how an
+absent `policy.json` logs an all-empty `local` policy. Verification failures
+log the failure, non-secret key metadata, the request's Agent-supplied
+policy, and the configured local policy. Execution completion logs only the
+task ID and exit code.
 
 Diagnostics deliberately exclude command text, signatures, public-key PEM
 contents, stdout, and stderr. Those values are unnecessary for policy

--- a/privilegedhelper/protocol.go
+++ b/privilegedhelper/protocol.go
@@ -56,6 +56,43 @@ type ExecuteRequest struct {
 	Version          int             `json:"version"`
 	Envelope         SignedEnvelope  `json:"envelope"`
 	VerificationKeys []CredentialKey `json:"verificationKeys,omitempty"`
+	AgentPolicy      *AgentPolicy    `json:"agentPolicy,omitempty"`
+}
+
+// AgentPolicy is an unsigned, Agent-supplied authorization narrowing sent
+// alongside the signed task envelope. It represents the Private Action
+// Runner's local datadog.yaml restricted_shell.allowed_* operator settings,
+// the same operator settings that already narrow the non-privileged rshell
+// path. Because it is unsigned and supplied by a process the helper does not
+// fully trust, it can only narrow (intersect with) the signed backend policy
+// and any local root-owned policy.json — it can never grant a permission
+// beyond what those already allow.
+//
+// A nil ExecuteRequest.AgentPolicy means the Agent imposes no narrowing at
+// this layer at all: the effective policy is exactly signed task ∩ optional
+// policy.json, identical to the protocol's behavior before this field
+// existed.
+//
+// A non-nil AgentPolicy applies independently per field, mirroring the exact
+// nil-vs-empty convention Credential (policy.json) and the Agent's own
+// datadog.yaml operator settings already use elsewhere in this system: for
+// each of AllowedCommands, AllowedPaths, AllowedSystemServices, and
+// ElevatableCommands, a nil value means that axis is left unrestricted by
+// this layer (defer entirely to signed ∩ policy.json for that axis), while a
+// non-nil-but-empty value is an explicit kill switch that denies every grant
+// on that axis regardless of what the signed task or policy.json allow. This
+// lets an operator narrow only the axes they have configured — e.g. setting
+// only AllowedCommands — without accidentally denying every system service or
+// path just because those fields were left unset.
+//
+// These fields intentionally omit `omitempty`: Go's encoding/json treats nil
+// and empty slices/maps identically when omitempty is set, which would erase
+// the nil-vs-empty distinction this type depends on once it crosses the wire.
+type AgentPolicy struct {
+	AllowedCommands       []string            `json:"allowedCommands"`
+	AllowedPaths          []string            `json:"allowedPaths"`
+	AllowedSystemServices map[string][]string `json:"allowedSystemServices"`
+	ElevatableCommands    []string            `json:"elevatableCommands"`
 }
 
 // NewExecuteRequest wraps an original backend-signed task for transport to the

--- a/privilegedhelper/protocol_test.go
+++ b/privilegedhelper/protocol_test.go
@@ -6,6 +6,7 @@
 package privilegedhelper
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -42,6 +43,34 @@ func mapKeys(values map[string]json.RawMessage) []string {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+// TestAgentPolicyWireRoundTripPreservesNilVsEmpty guards the field-level
+// nil-vs-empty convention AgentPolicy depends on: omitempty would collapse
+// nil and empty slices/maps into the same absent-field wire representation,
+// silently turning an explicit per-axis deny-all into "no narrowing" on
+// decode. AgentPolicy's fields deliberately omit omitempty to prevent this.
+func TestAgentPolicyWireRoundTripPreservesNilVsEmpty(t *testing.T) {
+	req := ExecuteRequest{
+		Version: ProtocolVersion,
+		AgentPolicy: &AgentPolicy{
+			AllowedCommands:       []string{"rshell:truncate"},
+			AllowedSystemServices: map[string][]string{}, // explicit empty: deny-all for this axis
+			// AllowedPaths and ElevatableCommands are left nil: unrestricted by this axis.
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, writeMessage(&buf, req))
+
+	var decoded ExecuteRequest
+	require.NoError(t, readMessage(&buf, &decoded))
+
+	require.NotNil(t, decoded.AgentPolicy)
+	require.Equal(t, []string{"rshell:truncate"}, decoded.AgentPolicy.AllowedCommands)
+	require.Nil(t, decoded.AgentPolicy.AllowedPaths, "nil AllowedPaths must survive the wire as nil, not empty")
+	require.NotNil(t, decoded.AgentPolicy.AllowedSystemServices, "explicit empty AllowedSystemServices must survive the wire as non-nil")
+	require.Empty(t, decoded.AgentPolicy.AllowedSystemServices)
+	require.Nil(t, decoded.AgentPolicy.ElevatableCommands)
 }
 
 func TestExecuteSignedTaskBuildsVersionedRequest(t *testing.T) {

--- a/privilegedhelper/server.go
+++ b/privilegedhelper/server.go
@@ -85,6 +85,7 @@ func (s *Server) handle(ctx context.Context, conn net.Conn) {
 			"requestVersion":               request.Version,
 			"signatureKeys":                signatureKeyMetadata(request.Envelope.Signatures),
 			"directorProofs":               credentialKeyMetadata(request.VerificationKeys),
+			"requestedAgentPolicy":         agentAuthorizationPolicy(request.AgentPolicy),
 			"configuredOrgId":              requestCredential.OrgID,
 			"configuredRunnerId":           requestCredential.RunnerID,
 			"configuredAllowedCommands":    requestCredential.AllowedCommands,

--- a/privilegedhelper/verify.go
+++ b/privilegedhelper/verify.go
@@ -75,6 +75,7 @@ type authorizationContext struct {
 	ExpirationTime       time.Time            `json:"expirationTime"`
 	TrustedKeyCount      int                  `json:"trustedKeyCount"`
 	Signed               authorizationPolicy  `json:"signed"`
+	Agent                authorizationPolicy  `json:"agent"`
 	Local                authorizationPolicy  `json:"local"`
 	Effective            authorizationPolicy  `json:"effective"`
 }
@@ -132,11 +133,31 @@ func (c *Credential) Verify(req ExecuteRequest, now time.Time) (*VerifiedCommand
 	signedAllowedSystemServices := signedSystemServices(remote.GetSystemServices())
 	effectiveAllowedSystemServices := signedAllowedSystemServices
 	effectiveElevatableCommands := slices.Clone(inputs.ElevatableCommands)
+	// Every AgentPolicy field is applied independently: a nil field leaves
+	// that axis unrestricted by this layer (defer to signed ∩ policy.json),
+	// while a non-nil (even empty) field narrows it. This lets an operator
+	// configure only some axes (e.g. AllowedCommands) in datadog.yaml
+	// without denying every grant on the axes they left unset.
+	agentPolicy := req.AgentPolicy
+	if agentPolicy != nil {
+		if agentPolicy.AllowedCommands != nil {
+			effectiveAllowedCommands = intersectCommands(effectiveAllowedCommands, agentPolicy.AllowedCommands)
+		}
+		if agentPolicy.AllowedPaths != nil {
+			effectiveAllowedPaths = intersectPaths(effectiveAllowedPaths, agentPolicy.AllowedPaths)
+		}
+		if agentPolicy.AllowedSystemServices != nil {
+			effectiveAllowedSystemServices = intersectSystemServices(effectiveAllowedSystemServices, agentPolicy.AllowedSystemServices)
+		}
+		if agentPolicy.ElevatableCommands != nil {
+			effectiveElevatableCommands = intersectExact(effectiveElevatableCommands, agentPolicy.ElevatableCommands)
+		}
+	}
 	if !c.trustBackendPolicy {
-		effectiveAllowedCommands = intersectCommands(remote.GetAllowedCommands(), c.AllowedCommands)
-		effectiveAllowedPaths = intersectPaths(remote.GetAllowedPaths(), c.AllowedPaths)
-		effectiveAllowedSystemServices = intersectSystemServices(signedAllowedSystemServices, c.AllowedSystemServices)
-		effectiveElevatableCommands = intersectExact(inputs.ElevatableCommands, c.ElevatableCommands)
+		effectiveAllowedCommands = intersectCommands(effectiveAllowedCommands, c.AllowedCommands)
+		effectiveAllowedPaths = intersectPaths(effectiveAllowedPaths, c.AllowedPaths)
+		effectiveAllowedSystemServices = intersectSystemServices(effectiveAllowedSystemServices, c.AllowedSystemServices)
+		effectiveElevatableCommands = intersectExact(effectiveElevatableCommands, c.ElevatableCommands)
 	}
 	return &VerifiedCommand{
 		TaskID: task.GetTaskId(), Command: inputs.Command, Mode: mode,
@@ -159,6 +180,7 @@ func (c *Credential) Verify(req ExecuteRequest, now time.Time) (*VerifiedCommand
 				AllowedSystemServices: cloneSystemServices(signedAllowedSystemServices),
 				ElevatableCommands:    slices.Clone(inputs.ElevatableCommands),
 			},
+			Agent: agentAuthorizationPolicy(agentPolicy),
 			Local: authorizationPolicy{
 				AllowedCommands:       slices.Clone(c.AllowedCommands),
 				AllowedPaths:          slices.Clone(c.AllowedPaths),
@@ -362,6 +384,22 @@ func intersectSystemServiceActions(requested, configured []string) []string {
 		return slices.Clone(configured)
 	}
 	return intersectExact(requested, configured)
+}
+
+// agentAuthorizationPolicy converts an optional request-supplied AgentPolicy
+// into the authorizationPolicy shape used for diagnostics. A nil agentPolicy
+// (the Agent imposed no narrowing at this layer) logs as an all-zero-value
+// policy, matching how an absent local policy.json logs today.
+func agentAuthorizationPolicy(agentPolicy *AgentPolicy) authorizationPolicy {
+	if agentPolicy == nil {
+		return authorizationPolicy{}
+	}
+	return authorizationPolicy{
+		AllowedCommands:       slices.Clone(agentPolicy.AllowedCommands),
+		AllowedPaths:          slices.Clone(agentPolicy.AllowedPaths),
+		AllowedSystemServices: cloneSystemServices(agentPolicy.AllowedSystemServices),
+		ElevatableCommands:    slices.Clone(agentPolicy.ElevatableCommands),
+	}
 }
 
 func cloneSystemServices(services map[string][]string) map[string][]string {

--- a/privilegedhelper/verify_test.go
+++ b/privilegedhelper/verify_test.go
@@ -327,6 +327,158 @@ func TestVerifySignedInputTypesFailClosed(t *testing.T) {
 	}
 }
 
+// agentOnlyCredential returns a credential that trusts the bare request key
+// and imposes no local policy.json, isolating the AgentPolicy layer.
+func agentOnlyCredential(t *testing.T) (*Credential, ed25519.PrivateKey) {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	credential, err := NewRequestCredential([]CredentialKey{socketCredentialKey(t, private)})
+	require.NoError(t, err)
+	return credential, private
+}
+
+func TestVerifyWithoutAgentPolicyMatchesPreExistingBehavior(t *testing.T) {
+	credential, private := testCredential(t)
+	verified, err := credential.Verify(signedRequest(t, private, nil), time.Now())
+	require.NoError(t, err)
+	require.Equal(t, []string{"rshell:truncate"}, verified.AllowedCommands)
+	require.Equal(t, []string{"/var/log"}, verified.AllowedPaths)
+	require.Empty(t, verified.AllowedSystemServices)
+	require.Equal(t, []string{"rshell:truncate"}, verified.ElevatableCommands)
+}
+
+// TestAgentPolicyPartialFieldsOnlyNarrowsConfiguredAxes is the regression test
+// for the reported bug: an AgentPolicy that only sets AllowedCommands must not
+// deny system services, paths, or elevatable commands. Those axes are left
+// nil and therefore deferred entirely to signed ∩ policy.json.
+func TestAgentPolicyPartialFieldsOnlyNarrowsConfiguredAxes(t *testing.T) {
+	credential, private := agentOnlyCredential(t)
+	req := signedRequest(t, private, func(task *PrivateActionTask) {
+		task.GetSystemInputs().GetRemoteAction().SystemServices = map[string]*structpb.ListValue{
+			"mysql.service": systemServiceActions(t, "read", "restart"),
+		}
+	})
+	req.AgentPolicy = &AgentPolicy{AllowedCommands: []string{"rshell:truncate"}}
+
+	verified, err := credential.Verify(req, time.Now())
+	require.NoError(t, err)
+	// Commands are narrowed by the configured axis.
+	require.Equal(t, []string{"rshell:truncate"}, verified.AllowedCommands)
+	// Paths, system services, and elevatable commands are untouched by the
+	// agent layer because those AgentPolicy fields are nil, not empty.
+	require.Equal(t, []string{"/var/log"}, verified.AllowedPaths)
+	require.Equal(t, map[string][]string{"mysql.service": {"read", "restart"}}, verified.AllowedSystemServices)
+	require.Equal(t, []string{"rshell:truncate"}, verified.ElevatableCommands)
+}
+
+// TestAgentPolicyExplicitEmptyFieldDeniesOnlyThatAxis mirrors the existing
+// policy.json convention ("omitting allowedSystemServices denies every
+// systemd action") at the per-field level: a non-nil-but-empty AgentPolicy
+// field is a kill switch for that axis only, leaving nil sibling fields
+// unrestricted.
+func TestAgentPolicyExplicitEmptyFieldDeniesOnlyThatAxis(t *testing.T) {
+	credential, private := agentOnlyCredential(t)
+	req := signedRequest(t, private, func(task *PrivateActionTask) {
+		task.GetSystemInputs().GetRemoteAction().SystemServices = map[string]*structpb.ListValue{
+			"mysql.service": systemServiceActions(t, "read", "restart"),
+		}
+	})
+	req.AgentPolicy = &AgentPolicy{AllowedSystemServices: map[string][]string{}}
+
+	verified, err := credential.Verify(req, time.Now())
+	require.NoError(t, err)
+	// The explicit empty map denies every system service.
+	require.Empty(t, verified.AllowedSystemServices)
+	// Every other axis is nil on the AgentPolicy and therefore unrestricted
+	// by this layer, deferring to the signed task alone.
+	require.Equal(t, []string{"rshell:truncate", "rshell:echo"}, verified.AllowedCommands)
+	require.Equal(t, []string{"/var/log"}, verified.AllowedPaths)
+	require.Equal(t, []string{"rshell:truncate"}, verified.ElevatableCommands)
+}
+
+// TestZeroValueAgentPolicyMatchesNilAgentPolicy confirms the equivalence that
+// falls out of pure per-field nil checks: a &AgentPolicy{} literal with every
+// field left at its Go zero value (nil) imposes no narrowing at all, exactly
+// like a nil ExecuteRequest.AgentPolicy.
+func TestZeroValueAgentPolicyMatchesNilAgentPolicy(t *testing.T) {
+	credential, private := testCredential(t)
+
+	nilReq := signedRequest(t, private, nil)
+	nilReq.AgentPolicy = nil
+	nilVerified, err := credential.Verify(nilReq, time.Now())
+	require.NoError(t, err)
+
+	zeroReq := signedRequest(t, private, nil)
+	zeroReq.AgentPolicy = &AgentPolicy{}
+	zeroVerified, err := credential.Verify(zeroReq, time.Now())
+	require.NoError(t, err)
+
+	require.Equal(t, nilVerified.AllowedCommands, zeroVerified.AllowedCommands)
+	require.Equal(t, nilVerified.AllowedPaths, zeroVerified.AllowedPaths)
+	require.Equal(t, nilVerified.AllowedSystemServices, zeroVerified.AllowedSystemServices)
+	require.Equal(t, nilVerified.ElevatableCommands, zeroVerified.ElevatableCommands)
+}
+
+// TestAgentPolicyThreeWayIntersectionEachLayerNarrowestForDifferentField
+// exercises a true three-way intersection: signed, agent, and local
+// policy.json are each the narrowest constraint for a different field, and
+// the effective result must reflect the narrowest across all three per field.
+func TestAgentPolicyThreeWayIntersectionEachLayerNarrowestForDifferentField(t *testing.T) {
+	credential, private := testCredential(t)
+	// Local policy.json (narrowest for system services).
+	credential.AllowedCommands = []string{"rshell:*"}
+	credential.AllowedPaths = []string{"/var/log"}
+	credential.AllowedSystemServices = map[string][]string{"mysql.service": {"read"}}
+	credential.ElevatableCommands = []string{"rshell:truncate", "rshell:systemctl"}
+
+	req := signedRequest(t, private, func(task *PrivateActionTask) {
+		// Signed task (narrowest for commands).
+		task.GetSystemInputs().GetRemoteAction().AllowedCommands = []string{"rshell:truncate"}
+		task.GetSystemInputs().GetRemoteAction().AllowedPaths = []string{"/var/log"}
+		task.GetSystemInputs().GetRemoteAction().SystemServices = map[string]*structpb.ListValue{
+			"mysql.service": systemServiceActions(t, "read", "restart", "stop"),
+		}
+		task.Inputs.Fields["elevatableCommands"] = structpb.NewListValue(&structpb.ListValue{
+			Values: []*structpb.Value{structpb.NewStringValue("rshell:truncate"), structpb.NewStringValue("rshell:systemctl")},
+		})
+	})
+	// Agent policy (narrowest for paths).
+	req.AgentPolicy = &AgentPolicy{
+		AllowedCommands:       []string{"rshell:*"},
+		AllowedPaths:          []string{"/var/log/app"},
+		AllowedSystemServices: map[string][]string{"mysql.service": {"read", "restart", "stop"}},
+		ElevatableCommands:    []string{"rshell:truncate", "rshell:systemctl"},
+	}
+
+	verified, err := credential.Verify(req, time.Now())
+	require.NoError(t, err)
+	// Signed narrowest.
+	require.Equal(t, []string{"rshell:truncate"}, verified.AllowedCommands)
+	// Agent narrowest.
+	require.Equal(t, []string{"/var/log/app"}, verified.AllowedPaths)
+	// Local narrowest.
+	require.Equal(t, map[string][]string{"mysql.service": {"read"}}, verified.AllowedSystemServices)
+	require.ElementsMatch(t, []string{"rshell:truncate", "rshell:systemctl"}, verified.ElevatableCommands)
+}
+
+// TestAgentPolicyCannotWidenBeyondSignedTask proves an over-permissive
+// AgentPolicy (e.g. the "rshell:*"/"/" wildcards) cannot expand the effective
+// policy beyond what the signed task already allows.
+func TestAgentPolicyCannotWidenBeyondSignedTask(t *testing.T) {
+	credential, private := agentOnlyCredential(t)
+	req := signedRequest(t, private, nil)
+	req.AgentPolicy = &AgentPolicy{
+		AllowedCommands: []string{"rshell:*"},
+		AllowedPaths:    []string{"/"},
+	}
+
+	verified, err := credential.Verify(req, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, []string{"rshell:truncate", "rshell:echo"}, verified.AllowedCommands)
+	require.Equal(t, []string{"/var/log"}, verified.AllowedPaths)
+}
+
 func TestVerifyFailsClosed(t *testing.T) {
 	credential, private := testCredential(t)
 	tests := []struct {


### PR DESCRIPTION
### What does this PR do?

Adds a third, middle intersection layer to the privileged helper's authorization model: an unsigned, Agent-supplied `AgentPolicy` carried on `ExecuteRequest`, representing the Private Action Runner's `datadog.yaml`-configured `restricted_shell.allowed_*` operator settings. Today those settings only narrow the non-privileged rshell path; the privileged path only had backend allowlists intersected with an optional root-owned `policy.json`.

New model:
```
backend (signed task) allowlists ∩ AgentPolicy (optional, from datadog.yaml via the Agent) ∩ optional local policy.json
```

- `privilegedhelper/protocol.go`: new `AgentPolicy` type (`AllowedCommands`, `AllowedPaths`, `AllowedSystemServices`, `ElevatableCommands`) attached to `ExecuteRequest.AgentPolicy *AgentPolicy`. Fields deliberately have no `omitempty` tag so nil (JSON `null`) and non-nil-empty (JSON `[]`/`{}`) survive the wire round-trip distinctly.
- `privilegedhelper/verify.go`: `Verify()` now checks each of the four `AgentPolicy` fields for nil **independently** before intersecting that axis. A nil field defers entirely to signed ∩ policy.json (no narrowing); a non-nil field (even empty) narrows/denies via the existing `intersectCommands`/`intersectPaths`/`intersectSystemServices`/`intersectExact` helpers. `authorizationContext` diagnostics gained an `Agent` field alongside `Signed`/`Local`/`Effective`.
- `docs/PRIVILEGED_HELPER.md`: documents the new layer and its per-field nil-vs-empty convention.

### Motivation

`policy.json` is root-owned and optional, so most deployments never author one — meaning privileged execution today is effectively bounded only by the signed backend task. Operators who already restrict the non-privileged path via `datadog.yaml` had no way to apply the same restriction to privileged/elevated commands. This closes that gap without weakening the trust boundary: `AgentPolicy` is unsigned and Agent-supplied, so it can only **narrow**, never grant — even a compromised/buggy Agent process can at most fail to narrow something, never expand beyond what the signed task + policy.json already allow.

### Security note

Per-field nil-vs-empty semantics matter here: if a whole-struct nil/non-nil check were used instead, configuring just one operator setting (e.g. `allowed_commands`) would have silently denied every other axis (e.g. system services) on the privileged path only, diverging from non-privileged behavior in a way that would be easy to miss and hard to debug. This PR checks each field independently and includes a wire round-trip test guarding the `omitempty` pitfall (Go's `encoding/json` serializes nil and empty slices/maps identically when `omitempty` is set, which would have destroyed the distinction over the actual Unix socket even though in-process tests wouldn't catch it).

### Testing

- Unit tests in `verify_test.go`: no-AgentPolicy regression parity, partial-field AgentPolicy only narrows configured axes, explicit-empty-field deny-all, true 3-way intersection across all three layers, and an over-permissive AgentPolicy cannot widen beyond the signed task.
- Wire round-trip test in `protocol_test.go` (`TestAgentPolicyWireRoundTripPreservesNilVsEmpty`) guarding the `omitempty` pitfall.
- Full repository test suite green, including `-race`.

### Companion PR

DataDog/datadog-agent#(pending) wires the Private Action Runner's existing `restricted_shell.allowed_*` config plus a new `restricted_shell.privileged.elevatable_commands` setting into this new `AgentPolicy` field. That PR currently depends on this one merging and a new rshell version being published before it builds against a real (non-replace-directive) dependency.

### Checklist

- [x] Tests added/updated
- [x] Documentation updated

> **AI assistance disclosure:** This PR was developed with assistance from AI coding agents (Pi subagents). The author reviewed and validated the resulting code and documentation.
